### PR TITLE
feat: onboarding mode selection + boot sequence fix

### DIFF
--- a/cli/internal/adapters/runtime/claude.go
+++ b/cli/internal/adapters/runtime/claude.go
@@ -46,11 +46,8 @@ func (a *ClaudeAdapter) GenerateContextFile(config Config, profile Profile, rule
 	// Boot sequence
 	b.WriteString("## Boot sequence\n\n")
 	b.WriteString("1. Read `.leo/kb/index.json` — this is your neural map\n")
-	b.WriteString("2. From the index, load all docs where `type: \"rule\"` — these govern your behavior\n")
-	b.WriteString("3. From the index, load all docs where `type: \"identity\"` — this is who the project is\n")
-	b.WriteString("4. From the index, load all docs where `type: \"skill\"` — these are your executable workflows\n")
-	b.WriteString("5. From the index, load all docs where `type: \"feedback\"` — these are owner corrections\n")
-	b.WriteString("6. You are now loaded. Greet the owner and proceed.\n\n")
+	b.WriteString("2. From the index, load all docs where `boot: true` — these govern your behavior, identity, skills, and corrections\n")
+	b.WriteString("3. You are now loaded. Greet the owner and proceed.\n\n")
 
 	// Rules summary
 	if len(rules) > 0 {

--- a/cli/internal/adapters/runtime/claude_test.go
+++ b/cli/internal/adapters/runtime/claude_test.go
@@ -79,10 +79,22 @@ func TestClaudeAdapter_GenerateContextFile(t *testing.T) {
 		"no filler",
 		"Balanced",
 		"Propose before",
+		"boot: true",
+	}
+	notChecks := []string{
+		`load all docs where` + " `" + `type: "rule"` + "`",
+		`load all docs where` + " `" + `type: "identity"` + "`",
+		`load all docs where` + " `" + `type: "skill"` + "`",
+		`load all docs where` + " `" + `type: "feedback"` + "`",
 	}
 	for _, check := range checks {
 		if !strings.Contains(s, check) {
 			t.Errorf("CLAUDE.md missing %q", check)
+		}
+	}
+	for _, notCheck := range notChecks {
+		if strings.Contains(s, notCheck) {
+			t.Errorf("CLAUDE.md should not contain %q", notCheck)
 		}
 	}
 }

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -52,6 +52,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	return runInitWithConfig(cmd, cwd, force, OnboardingResult{
 		Runtime:        rt,
 		Language:       config.Default().Owner.Language,
+		Mode:           config.Default().Owner.Mode,
 		DefaultProfile: config.Default().Owner.DefaultProfile,
 		Autonomy:       config.Default().Owner.Autonomy,
 	})
@@ -87,6 +88,7 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 	cfg.Runtime = result.Runtime
 	cfg.CoreSource = result.CoreSource
 	cfg.Owner.Language = result.Language
+	cfg.Owner.Mode = result.Mode
 	cfg.Owner.DefaultProfile = result.DefaultProfile
 	cfg.Owner.Autonomy = result.Autonomy
 

--- a/cli/internal/cmd/onboarding.go
+++ b/cli/internal/cmd/onboarding.go
@@ -18,6 +18,7 @@ import (
 type OnboardingResult struct {
 	Runtime        string // "claude", "cursor", "windsurf", "other"
 	Language       string // "en", "pt", "es"
+	Mode           string // "verbose", "concise", "caveman"
 	DefaultProfile string // "generalist", "backend-engineer"
 	Autonomy       string // "autonomous", "balanced", "supervised"
 	CoreSource     string // path to leo-core clone, or "" if skipped
@@ -78,31 +79,38 @@ func runOnboarding(r io.Reader, w io.Writer, cwd string) (OnboardingResult, erro
 		return OnboardingResult{}, err
 	}
 
-	// ── Step 4: Profile ───────────────────────────────────────────────────────
+	// ── Step 4: Mode ─────────────────────────────────────────────────────────
+	mode, err := askMode(scanner, w)
+	if err != nil {
+		return OnboardingResult{}, err
+	}
+
+	// ── Step 5: Profile ───────────────────────────────────────────────────────
 	profile, err := askProfile(scanner, w)
 	if err != nil {
 		return OnboardingResult{}, err
 	}
 
-	// ── Step 5: Autonomy ──────────────────────────────────────────────────────
+	// ── Step 6: Autonomy ──────────────────────────────────────────────────────
 	autonomy, err := askAutonomy(scanner, w)
 	if err != nil {
 		return OnboardingResult{}, err
 	}
 
-	// ── Step 6: Core Source ───────────────────────────────────────────────────
+	// ── Step 7: Core Source ───────────────────────────────────────────────────
 	coreSource, err := askCoreSource(scanner, w)
 	if err != nil {
 		return OnboardingResult{}, err
 	}
 
-	// ── Step 7: Summary + Confirm ─────────────────────────────────────────────
+	// ── Step 8: Summary + Confirm ─────────────────────────────────────────────
 	fmt.Fprintln(w)
 	separator(w)
 	fmt.Fprintln(w, "  Here's your configuration:")
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "    Runtime:   %s\n", runtimeLabel(rt))
 	fmt.Fprintf(w, "    Language:  %s\n", languageLabel(lang))
+	fmt.Fprintf(w, "    Mode:      %s\n", modeLabel(mode))
 	fmt.Fprintf(w, "    Profile:   %s\n", profileLabel(profile))
 	fmt.Fprintf(w, "    Autonomy:  %s\n", autonomyLabel(autonomy))
 	fmt.Fprintln(w)
@@ -118,6 +126,7 @@ func runOnboarding(r io.Reader, w io.Writer, cwd string) (OnboardingResult, erro
 	return OnboardingResult{
 		Runtime:        rt,
 		Language:       lang,
+		Mode:           mode,
 		DefaultProfile: profile,
 		Autonomy:       autonomy,
 		CoreSource:     coreSource,
@@ -186,6 +195,35 @@ func askLanguage(scanner *scannerWrapper, w io.Writer) (string, error) {
 			return "pt", nil
 		case "3":
 			return "es", nil
+		default:
+			fmt.Fprintln(w, "  Invalid choice. Please enter 1, 2, or 3.")
+		}
+	}
+}
+
+// askMode prompts for the communication mode.
+func askMode(scanner *scannerWrapper, w io.Writer) (string, error) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  How should Leo communicate?")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  [1] Verbose  — detailed explanations and reasoning")
+	fmt.Fprintln(w, "  [2] Concise  — short and direct (recommended)")
+	fmt.Fprintln(w, "  [3] Caveman  — minimal tokens, maximum signal")
+	fmt.Fprintln(w)
+
+	for {
+		fmt.Fprint(w, "  → Choice [2]: ")
+		line := scanner.readLine()
+		if line == "" {
+			return "concise", nil
+		}
+		switch line {
+		case "1":
+			return "verbose", nil
+		case "2":
+			return "concise", nil
+		case "3":
+			return "caveman", nil
 		default:
 			fmt.Fprintln(w, "  Invalid choice. Please enter 1, 2, or 3.")
 		}
@@ -365,6 +403,17 @@ func profileLabel(profile string) string {
 		return p.Name
 	}
 	return profile
+}
+
+func modeLabel(mode string) string {
+	switch mode {
+	case "verbose":
+		return "Verbose"
+	case "caveman":
+		return "Caveman"
+	default:
+		return "Concise"
+	}
 }
 
 func autonomyLabel(autonomy string) string {

--- a/cli/internal/cmd/onboarding_test.go
+++ b/cli/internal/cmd/onboarding_test.go
@@ -15,8 +15,8 @@ import (
 // TestOnboarding_DefaultSelections verifies that pressing Enter for every
 // prompt accepts the default value for each step.
 func TestOnboarding_DefaultSelections(t *testing.T) {
-	// Six newlines: runtime, language, profile, autonomy, core-source, confirm.
-	input := strings.NewReader("\n\n\n\n\n\n")
+	// Seven newlines: runtime, language, mode, profile, autonomy, core-source, confirm.
+	input := strings.NewReader("\n\n\n\n\n\n\n")
 	output := &bytes.Buffer{}
 
 	result, err := runOnboarding(input, output, t.TempDir())
@@ -29,6 +29,9 @@ func TestOnboarding_DefaultSelections(t *testing.T) {
 	}
 	if result.Language != "en" {
 		t.Errorf("expected language=en, got %q", result.Language)
+	}
+	if result.Mode != "concise" {
+		t.Errorf("expected mode=concise, got %q", result.Mode)
 	}
 	if result.DefaultProfile != "generalist" {
 		t.Errorf("expected profile=generalist, got %q", result.DefaultProfile)
@@ -56,9 +59,9 @@ func TestOnboarding_ExplicitSelections(t *testing.T) {
 		}
 	}
 
-	// runtime=2 (cursor), language=2 (pt), profile=backend-engineer index,
+	// runtime=2 (cursor), language=2 (pt), mode=3 (caveman), profile=backend-engineer index,
 	// autonomy=3 (supervised), core-source=skip, confirm=Y
-	input := strings.NewReader(fmt.Sprintf("2\n2\n%d\n3\n\nY\n", beIdx))
+	input := strings.NewReader(fmt.Sprintf("2\n2\n3\n%d\n3\n\nY\n", beIdx))
 	output := &bytes.Buffer{}
 
 	result, err := runOnboarding(input, output, t.TempDir())
@@ -71,6 +74,9 @@ func TestOnboarding_ExplicitSelections(t *testing.T) {
 	}
 	if result.Language != "pt" {
 		t.Errorf("expected language=pt, got %q", result.Language)
+	}
+	if result.Mode != "caveman" {
+		t.Errorf("expected mode=caveman, got %q", result.Mode)
 	}
 	if result.DefaultProfile != "backend-engineer" {
 		t.Errorf("expected profile=backend-engineer, got %q", result.DefaultProfile)
@@ -100,8 +106,9 @@ func TestOnboarding_InvalidThenValid(t *testing.T) {
 
 	// runtime: bad input then valid "3" (windsurf)
 	// language: bad input then default Enter
+	// mode: default Enter
 	// profile: invalid then generalist index, autonomy: "1" (autonomous), core-source: skip, confirm: default Enter
-	input := strings.NewReader(fmt.Sprintf("99\n3\nXXX\n\n999\n%d\n1\n\n\n", genIdx))
+	input := strings.NewReader(fmt.Sprintf("99\n3\nXXX\n\n\n999\n%d\n1\n\n\n", genIdx))
 	output := &bytes.Buffer{}
 
 	result, err := runOnboarding(input, output, t.TempDir())
@@ -131,8 +138,8 @@ func TestOnboarding_RuntimeAutoDetect_Claude(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Accept all defaults (6 newlines: runtime, language, profile, autonomy, core-source, confirm).
-	input := strings.NewReader("\n\n\n\n\n\n")
+	// Accept all defaults (7 newlines: runtime, language, mode, profile, autonomy, core-source, confirm).
+	input := strings.NewReader("\n\n\n\n\n\n\n")
 	output := &bytes.Buffer{}
 
 	result, err := runOnboarding(input, output, dir)
@@ -158,8 +165,8 @@ func TestOnboarding_RuntimeAutoDetect_Cursor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Accept all defaults (6 newlines: runtime, language, profile, autonomy, core-source, confirm).
-	input := strings.NewReader("\n\n\n\n\n\n")
+	// Accept all defaults (7 newlines: runtime, language, mode, profile, autonomy, core-source, confirm).
+	input := strings.NewReader("\n\n\n\n\n\n\n")
 	output := &bytes.Buffer{}
 
 	result, err := runOnboarding(input, output, dir)
@@ -175,8 +182,8 @@ func TestOnboarding_RuntimeAutoDetect_Cursor(t *testing.T) {
 // TestOnboarding_ConfirmNo verifies that answering "n" at the confirm step
 // returns an error signalling the user aborted.
 func TestOnboarding_ConfirmNo(t *testing.T) {
-	// runtime, language, profile, autonomy, core-source (skip), confirm=n
-	input := strings.NewReader("\n\n\n\n\nn\n")
+	// runtime, language, mode, profile, autonomy, core-source (skip), confirm=n
+	input := strings.NewReader("\n\n\n\n\n\nn\n")
 	output := &bytes.Buffer{}
 
 	_, err := runOnboarding(input, output, t.TempDir())
@@ -190,7 +197,7 @@ func TestOnboarding_ConfirmNo(t *testing.T) {
 
 // TestOnboarding_OutputContainsWelcome verifies the welcome banner appears.
 func TestOnboarding_OutputContainsWelcome(t *testing.T) {
-	input := strings.NewReader("\n\n\n\n\n\n")
+	input := strings.NewReader("\n\n\n\n\n\n\n")
 	output := &bytes.Buffer{}
 
 	_, err := runOnboarding(input, output, t.TempDir())
@@ -206,8 +213,8 @@ func TestOnboarding_OutputContainsWelcome(t *testing.T) {
 
 // TestOnboarding_OutputContainsSummary verifies the summary step renders.
 func TestOnboarding_OutputContainsSummary(t *testing.T) {
-	// runtime=1, language=1, profile=1, autonomy=2, core-source=skip, confirm=Y
-	input := strings.NewReader("1\n1\n1\n2\n\nY\n")
+	// runtime=1, language=1, mode=2 (concise), profile=1, autonomy=2, core-source=skip, confirm=Y
+	input := strings.NewReader("1\n1\n2\n1\n2\n\nY\n")
 	output := &bytes.Buffer{}
 
 	_, err := runOnboarding(input, output, t.TempDir())
@@ -216,7 +223,7 @@ func TestOnboarding_OutputContainsSummary(t *testing.T) {
 	}
 
 	out := output.String()
-	for _, keyword := range []string{"Runtime", "Language", "Profile", "Autonomy"} {
+	for _, keyword := range []string{"Runtime", "Language", "Mode", "Profile", "Autonomy"} {
 		if !strings.Contains(out, keyword) {
 			t.Errorf("expected summary to contain %q, got:\n%s", keyword, out)
 		}
@@ -227,10 +234,10 @@ func TestOnboarding_OutputContainsSummary(t *testing.T) {
 
 func TestAskRuntime(t *testing.T) {
 	cases := []struct {
-		name     string
-		input    string
-		cwd      string // "" means no special dir
-		wantRT   string
+		name   string
+		input  string
+		cwd    string // "" means no special dir
+		wantRT string
 	}{
 		{name: "default enter", input: "\n", wantRT: "claude"},
 		{name: "pick 1", input: "1\n", wantRT: "claude"},
@@ -280,6 +287,33 @@ func TestAskLanguage(t *testing.T) {
 			}
 			if got != tc.wantLang {
 				t.Errorf("expected %q, got %q", tc.wantLang, got)
+			}
+		})
+	}
+}
+
+func TestAskMode(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantMode string
+	}{
+		{name: "default enter", input: "\n", wantMode: "concise"},
+		{name: "pick 1", input: "1\n", wantMode: "verbose"},
+		{name: "pick 2", input: "2\n", wantMode: "concise"},
+		{name: "pick 3", input: "3\n", wantMode: "caveman"},
+		{name: "invalid then 3", input: "bad\n3\n", wantMode: "caveman"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scanner, out := makeScanner(tc.input)
+			got, err := askMode(scanner, out)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantMode {
+				t.Errorf("expected %q, got %q", tc.wantMode, got)
 			}
 		})
 	}
@@ -379,9 +413,9 @@ func TestOnboarding_ResultMappedToConfig(t *testing.T) {
 		}
 	}
 
-	// runtime=2 (cursor), language=3 (es), profile=backend-engineer index, autonomy=1 (autonomous),
-	// core-source=skip, confirm=Y
-	input := strings.NewReader(fmt.Sprintf("2\n3\n%d\n1\n\nY\n", beIdx))
+	// runtime=2 (cursor), language=3 (es), mode=1 (verbose), profile=backend-engineer index,
+	// autonomy=1 (autonomous), core-source=skip, confirm=Y
+	input := strings.NewReader(fmt.Sprintf("2\n3\n1\n%d\n1\n\nY\n", beIdx))
 	output := &bytes.Buffer{}
 
 	result, err := runOnboarding(input, output, t.TempDir())
@@ -389,12 +423,15 @@ func TestOnboarding_ResultMappedToConfig(t *testing.T) {
 		t.Fatalf("runOnboarding failed: %v", err)
 	}
 
-	// cursor, es, backend-engineer, autonomous
+	// cursor, es, verbose, backend-engineer, autonomous
 	if result.Runtime != "cursor" {
 		t.Errorf("runtime: want cursor, got %q", result.Runtime)
 	}
 	if result.Language != "es" {
 		t.Errorf("language: want es, got %q", result.Language)
+	}
+	if result.Mode != "verbose" {
+		t.Errorf("mode: want verbose, got %q", result.Mode)
 	}
 	if result.DefaultProfile != "backend-engineer" {
 		t.Errorf("profile: want backend-engineer, got %q", result.DefaultProfile)


### PR DESCRIPTION
## Summary

- Add verbose/concise/caveman mode selection step to the `leo init` onboarding wizard (closes #30)
- Fix generated CLAUDE.md boot sequence to use `boot: true` instead of loading by type (closes #31)

## Changes

### Onboarding mode selection (#30)
- New `askMode()` function between language and profile steps
- `Mode` field added to `OnboardingResult` struct
- `modeLabel()` helper + summary display
- Wired through `init.go` for both interactive and non-interactive paths
- New `TestAskMode` (5 cases) + all existing tests updated for the extra step

### Boot sequence fix (#31)
- Replaced 6-line type-based boot sequence with 3-line `boot: true` version
- Aligns CLI-generated CLAUDE.md with self-hosting CLAUDE.md
- Added positive (`boot: true` present) and negative (old type-based lines absent) test assertions

## Test plan

- [x] All onboarding tests pass (12 tests including new TestAskMode)
- [x] All runtime adapter tests pass (14 tests)
- [x] `go vet ./...` clean
- [x] End-to-end: `leo init --runtime claude -y` in temp dir produces correct CLAUDE.md with `boot: true` boot sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)