### PR TITLE
fix: upgrade migration bugs — nil profile + owner→user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,16 @@ CLAUDE.md
 # Leo cache (ephemeral)
 .leo/cache/
 
+# Architecture drafts (internal, do not publish)
+.leo/kb/architecture/
+
 # Leo export output
 leo-export/
 
 # CLI build artifacts
 cli/bin/
 .aider*
+
+# Runtime-generated adapter files (like CLAUDE.md)
+AGENTS.md
+.clinerules/

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -243,6 +243,9 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 		}
 
 		defaultProfile := profiles.DefaultProfiles()[cfg.User.DefaultProfile]
+		if defaultProfile == nil {
+			defaultProfile = profiles.DefaultProfiles()["general-manager"]
+		}
 		runtimeProfile := runtime.Profile{
 			Name:             defaultProfile.Name,
 			Description:      defaultProfile.Description,

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -328,6 +328,9 @@ func regenerateRuntimeFiles(projectRoot, leoDir string, cfg *config.Config) erro
 	}
 
 	defaultProfile := profiles.DefaultProfiles()[cfg.User.DefaultProfile]
+	if defaultProfile == nil {
+		defaultProfile = profiles.DefaultProfiles()["general-manager"]
+	}
 	runtimeProfile := runtime.Profile{
 		Name:             defaultProfile.Name,
 		Description:      defaultProfile.Description,

--- a/cli/internal/cmd/upgrade_test.go
+++ b/cli/internal/cmd/upgrade_test.go
@@ -37,10 +37,10 @@ func setupV060Project(t *testing.T) string {
 		os.MkdirAll(d, 0755)
 	}
 
-	// Write v0.6.0-style config (legacy format).
+	// Write v0.6.0-style config (legacy format with "owner:" key).
 	legacyConfig := `version: "1"
 runtime: claude
-user:
+owner:
   language: pt
   mode: caveman
   default_profile: cto
@@ -341,6 +341,51 @@ func TestUpgradeCmd_GeneratesRuntimeFiles(t *testing.T) {
 	claudeMD := filepath.Join(dir, ".claude", "CLAUDE.md")
 	if _, err := os.Stat(claudeMD); err != nil {
 		t.Error("CLAUDE.md not generated during upgrade")
+	}
+}
+
+func TestUpgradeCmd_MigratesGeneralistProfile(t *testing.T) {
+	resetUpgradeFlags(t)
+	dir := setupV060Project(t)
+	leoDir := filepath.Join(dir, ".leo")
+
+	// Override config with old "generalist" profile name.
+	legacyConfig := `version: "1"
+runtime: claude
+owner:
+  language: pt
+  mode: concise
+  default_profile: generalist
+  autonomy: balanced
+kb:
+  auto_propagate: true
+  wrap_up: prompt
+  stale_threshold: 30d
+`
+	os.WriteFile(filepath.Join(leoDir, "config.yaml"), []byte(legacyConfig), 0644)
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"upgrade"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("upgrade failed: %v\noutput:\n%s", err, buf.String())
+	}
+
+	cfg, err := config.Load(leoDir)
+	if err != nil {
+		t.Fatalf("loading config after upgrade: %v", err)
+	}
+	if cfg.User.DefaultProfile != "general-manager" {
+		t.Errorf("expected generalist→general-manager migration, got %q", cfg.User.DefaultProfile)
+	}
+	if cfg.User.Language != "pt" {
+		t.Errorf("expected language=pt preserved from owner field, got %q", cfg.User.Language)
 	}
 }
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -94,6 +94,7 @@ type legacyConfig struct {
 	Version     string            `yaml:"version"`
 	Runtime     string            `yaml:"runtime"`
 	CoreSource  string            `yaml:"core_source"`
+	Owner       UserConfig        `yaml:"owner"`
 	User        UserConfig        `yaml:"user"`
 	KB          KBConfig          `yaml:"kb"`
 	Specialists legacySpecialists `yaml:"specialists"`
@@ -166,6 +167,17 @@ func migrateFromLegacy(legacy *legacyConfig) *Config {
 		rt = "claude"
 	}
 
+	// v0.6.0 used "owner:" key, v0.6.x transitional used "user:".
+	user := legacy.User
+	if user.Language == "" && user.Mode == "" && legacy.Owner.Language != "" {
+		user = legacy.Owner
+	}
+
+	// Map old profile name "generalist" → "general-manager".
+	if user.DefaultProfile == "generalist" {
+		user.DefaultProfile = "general-manager"
+	}
+
 	return &Config{
 		Version:    legacy.Version,
 		CoreSource: legacy.CoreSource,
@@ -175,7 +187,7 @@ func migrateFromLegacy(legacy *legacyConfig) *Config {
 				Tiers:   tiers,
 			},
 		},
-		User: legacy.User,
+		User: user,
 		KB:   legacy.KB,
 	}
 }


### PR DESCRIPTION
## Summary

- **#57**: Fix nil pointer dereference when `default_profile` doesn't exist in `DefaultProfiles()` — adds fallback to `general-manager` in `init.go` and `upgrade.go`
- **#58**: Fix `owner:` → `user:` migration losing settings — adds `Owner` field to `legacyConfig`, copies to `User` when empty. Maps `generalist` → `general-manager`

## Test plan

- [x] `TestUpgradeCmd_MigratesConfig` — validates owner→user migration preserves language, mode, autonomy
- [x] `TestUpgradeCmd_MigratesGeneralistProfile` — validates generalist→general-manager + owner field migration
- [x] Full test suite passes (`go test ./...`)
- [x] Verified in production: upgraded 5 repos (saintfy, logbook-legal, leo-core, logbook, discovery)

Closes #57
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)