### PR TITLE
feat(#115): add mom_recall to boot file memory tools list

### DIFF
--- a/cli/internal/adapters/runtime/content.go
+++ b/cli/internal/adapters/runtime/content.go
@@ -12,8 +12,8 @@ func BuildMinimalContextContent() string {
 
 You have MOM tools via MCP. Call ` + "`mom_status`" + ` at the start of every session.
 
-For memory operations: search_memories, get_memory, create_memory_draft,
-list_landmarks, list_scopes.
+For memory operations: mom_recall, search_memories, get_memory,
+create_memory_draft, list_landmarks, list_scopes.
 
 Do NOT skip mom_status — it contains your operating instructions.
 `

--- a/cli/internal/adapters/runtime/content_test.go
+++ b/cli/internal/adapters/runtime/content_test.go
@@ -13,6 +13,10 @@ func TestBuildMinimalContextContent(t *testing.T) {
 		t.Error("minimal content must mention mom_status")
 	}
 
+	if !strings.Contains(content, "mom_recall") {
+		t.Error("minimal content must mention mom_recall")
+	}
+
 	// Under 100 words.
 	words := strings.Fields(content)
 	if len(words) >= 100 {


### PR DESCRIPTION
## Summary
- Adds `mom_recall` to the memory tools list in generated boot files (CLAUDE.md, AGENTS.md, etc.)
- Agents reading only the boot file now discover `mom_recall` and can prioritise it over raw `search_memories` calls

## Test plan
- [x] `content_test.go` updated — asserts `mom_recall` is present in minimal content
- [x] `go test ./internal/adapters/runtime/` passes

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)