### PR TITLE
feat(#114): inherit constraints/skills from parent scope on init

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -235,23 +235,27 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 			return
 		}
 
-		// Write core constraints.
-		constraintsDir := filepath.Join(leoDir, "constraints")
-		for name, content := range coreConstraints() {
-			path := filepath.Join(constraintsDir, name+".json")
-			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-				kbErr = fmt.Errorf("writing constraint %s: %w", name, err)
-				return
+		// Write core constraints — skip if a parent scope already provides them.
+		if !parentScopeHasDir(cwd, "constraints") {
+			constraintsDir := filepath.Join(leoDir, "constraints")
+			for name, content := range coreConstraints() {
+				path := filepath.Join(constraintsDir, name+".json")
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					kbErr = fmt.Errorf("writing constraint %s: %w", name, err)
+					return
+				}
 			}
 		}
 
-		// Write core skills.
-		skillsDir := filepath.Join(leoDir, "skills")
-		for name, content := range coreSkills() {
-			path := filepath.Join(skillsDir, name+".json")
-			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-				kbErr = fmt.Errorf("writing skill %s: %w", name, err)
-				return
+		// Write core skills — skip if a parent scope already provides them.
+		if !parentScopeHasDir(cwd, "skills") {
+			skillsDir := filepath.Join(leoDir, "skills")
+			for name, content := range coreSkills() {
+				path := filepath.Join(skillsDir, name+".json")
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					kbErr = fmt.Errorf("writing skill %s: %w", name, err)
+					return
+				}
 			}
 		}
 
@@ -569,4 +573,51 @@ func buildRuntimeIdentity() *runtime.Identity {
 		Philosophy:  identityData.Philosophy,
 		Constraints: identityData.Constraints,
 	}
+}
+
+// parentScopeHasDir walks up from dir looking for a parent .mom/ directory that
+// contains the given subdirectory (e.g. "constraints" or "skills") with at least
+// one .json file. This allows child scopes to inherit from a parent scope
+// instead of duplicating files. Only real parent directories are checked — dir
+// itself is skipped.
+func parentScopeHasDir(dir, subdir string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = string(filepath.Separator)
+	}
+
+	current := dir
+	for {
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached filesystem root.
+			break
+		}
+		current = parent
+
+		candidate := filepath.Join(current, ".mom", subdir)
+		if hasJSONFiles(candidate) {
+			return true
+		}
+
+		// Stop after processing $HOME (same boundary as scope.Walk).
+		if current == home {
+			break
+		}
+	}
+	return false
+}
+
+// hasJSONFiles returns true if dir exists and contains at least one .json file.
+func hasJSONFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".json" {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -267,3 +267,131 @@ func TestInitCmd_BackupExistingFile(t *testing.T) {
 		t.Error("backup content doesn't match original")
 	}
 }
+
+// TestInitCmd_InheritsConstraintsFromParent verifies that when a parent scope
+// already has constraints/ and skills/, child init skips creating local copies.
+func TestInitCmd_InheritsConstraintsFromParent(t *testing.T) {
+	// Create org/repo directory structure.
+	orgDir := t.TempDir()
+	repoDir := filepath.Join(orgDir, "repo-a")
+	os.MkdirAll(repoDir, 0755)
+
+	// Initialize the org scope using runInitWithConfig directly to avoid
+	// cobra global state issues when tests run in parallel/sequence.
+	cmd := &cobra.Command{}
+	cmd.SetOut(new(bytes.Buffer))
+
+	orgResult := OnboardingResult{
+		Runtimes:   []string{"claude"},
+		Language:   "en",
+		Mode:       "concise",
+		InstallDir: orgDir,
+		ScopeLabel: "org",
+	}
+	if err := runInitWithConfig(cmd, orgDir, false, orgResult); err != nil {
+		t.Fatalf("org init failed: %v", err)
+	}
+
+	// Verify org has constraints.
+	orgConstraints := filepath.Join(orgDir, ".mom", "constraints")
+	entries, err := os.ReadDir(orgConstraints)
+	if err != nil || len(entries) == 0 {
+		t.Fatal("org scope should have constraint files")
+	}
+
+	// Now init the child repo — should inherit constraints from org.
+	repoResult := OnboardingResult{
+		Runtimes:   []string{"claude"},
+		Language:   "en",
+		Mode:       "concise",
+		InstallDir: repoDir,
+		ScopeLabel: "repo",
+	}
+	if err := runInitWithConfig(cmd, repoDir, false, repoResult); err != nil {
+		t.Fatalf("repo init failed: %v", err)
+	}
+
+	// Child constraints dir should exist but be empty (no duplicated files).
+	repoConstraints := filepath.Join(repoDir, ".mom", "constraints")
+	repoEntries, err := os.ReadDir(repoConstraints)
+	if err != nil {
+		t.Fatalf("repo constraints dir should exist: %v", err)
+	}
+	if len(repoEntries) > 0 {
+		t.Errorf("repo constraints should be empty (inherited from org), got %d files", len(repoEntries))
+	}
+
+	// Child skills dir should also be empty.
+	repoSkills := filepath.Join(repoDir, ".mom", "skills")
+	repoSkillEntries, err := os.ReadDir(repoSkills)
+	if err != nil {
+		t.Fatalf("repo skills dir should exist: %v", err)
+	}
+	if len(repoSkillEntries) > 0 {
+		t.Errorf("repo skills should be empty (inherited from org), got %d files", len(repoSkillEntries))
+	}
+}
+
+// TestInitCmd_CreatesConstraintsWhenNoParent verifies that a standalone repo
+// (no parent scope) still gets local constraints and skills.
+func TestInitCmd_CreatesConstraintsWhenNoParent(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"init", "--runtimes", "claude"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Standalone repo should have constraints written locally.
+	constraintsDir := filepath.Join(dir, ".mom", "constraints")
+	entries, err := os.ReadDir(constraintsDir)
+	if err != nil {
+		t.Fatalf("constraints dir should exist: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("standalone repo should have local constraint files")
+	}
+
+	// And skills too.
+	skillsDir := filepath.Join(dir, ".mom", "skills")
+	skillEntries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		t.Fatalf("skills dir should exist: %v", err)
+	}
+	if len(skillEntries) == 0 {
+		t.Error("standalone repo should have local skill files")
+	}
+}
+
+// TestParentScopeHasDir_Unit tests the parentScopeHasDir helper directly.
+func TestParentScopeHasDir_Unit(t *testing.T) {
+	// Setup: org/.mom/constraints/ with a file, repo under org.
+	orgDir := t.TempDir()
+	constraintsDir := filepath.Join(orgDir, ".mom", "constraints")
+	os.MkdirAll(constraintsDir, 0755)
+	os.WriteFile(filepath.Join(constraintsDir, "test.json"), []byte(`{}`), 0644)
+
+	repoDir := filepath.Join(orgDir, "repo-a")
+	os.MkdirAll(repoDir, 0755)
+
+	// From repo dir, parent should have constraints.
+	if !parentScopeHasDir(repoDir, "constraints") {
+		t.Error("expected parentScopeHasDir to find constraints in parent")
+	}
+
+	// From repo dir, parent should NOT have skills (none created).
+	if parentScopeHasDir(repoDir, "skills") {
+		t.Error("expected parentScopeHasDir to not find skills in parent")
+	}
+
+	// From org dir itself, no parent has constraints.
+	if parentScopeHasDir(orgDir, "constraints") {
+		t.Error("expected parentScopeHasDir to not find constraints above org")
+	}
+}


### PR DESCRIPTION
## Summary
- `mom init` now walks up the directory tree looking for existing `.mom/constraints/` and `.mom/skills/` in a parent scope
- If found, skips creating local copies — scope hierarchy resolves them via `Walk()`
- Standalone repos (no parent) still get local copies as before

## Test plan
- [x] `TestInitCmd_InheritsConstraintsFromParent` — org→repo inheritance works
- [x] `TestInitCmd_CreatesConstraintsWhenNoParent` — standalone repo still gets local files
- [x] `TestParentScopeHasDir_Unit` — unit test for helper (positive, negative, boundary)
- [x] `go test ./internal/cmd/` passes

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)