### PR TITLE
feat(#107): enable hooks + MCP wiring for Codex adapter

### DIFF
--- a/cli/internal/adapters/runtime/capabilities/codex.yaml
+++ b/cli/internal/adapters/runtime/capabilities/codex.yaml
@@ -1,5 +1,5 @@
 adapter: codex
-version: "0.1"
+version: "1.0"
 supports:
   - session.start
   - session.end

--- a/cli/internal/adapters/runtime/codex.go
+++ b/cli/internal/adapters/runtime/codex.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,10 +46,102 @@ func (a *CodexAdapter) GenerateContextFile(config Config, constraints []Constrai
 }
 
 func (a *CodexAdapter) SupportsHooks() bool {
-	return false
+	return true
 }
 
 func (a *CodexAdapter) RegisterHooks(hooks []HookDef) error {
+	codexDir := filepath.Join(a.projectRoot, ".codex")
+	hooksPath := filepath.Join(codexDir, "hooks.json")
+
+	// Ensure .codex/ exists.
+	if err := os.MkdirAll(codexDir, 0755); err != nil {
+		return fmt.Errorf("creating .codex dir: %w", err)
+	}
+
+	// Build Codex hooks structure — the entire file IS the hooks map:
+	//   { "EventName": [ { "matcher": "...", "hooks": [ {...} ] } ] }
+	hooksMap := make(map[string]any)
+
+	// Group HookDefs by event.
+	byEvent := make(map[string][]HookDef)
+	for _, h := range hooks {
+		byEvent[h.Event] = append(byEvent[h.Event], h)
+	}
+
+	for event, defs := range byEvent {
+		var matcherGroups []map[string]any
+		for _, d := range defs {
+			entry := map[string]any{
+				"type":    "command",
+				"command": d.Command,
+				"timeout": 10,
+			}
+			group := map[string]any{
+				"hooks": []map[string]any{entry},
+			}
+			if d.Matcher != "" {
+				group["matcher"] = d.Matcher
+			}
+			matcherGroups = append(matcherGroups, group)
+		}
+		hooksMap[event] = matcherGroups
+	}
+
+	data, err := json.MarshalIndent(hooksMap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling hooks: %w", err)
+	}
+
+	data = append(data, '\n')
+	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
+		return fmt.Errorf("writing hooks.json: %w", err)
+	}
+
+	return nil
+}
+
+// CodexHooks returns the standard MOM hooks for Codex.
+// Stop covers both Claude's Stop and SessionEnd — so both record and draft go on Stop.
+func CodexHooks() []HookDef {
+	return []HookDef{
+		{Event: "Stop", Command: "mom record"},
+		{Event: "Stop", Command: "mom draft"},
+	}
+}
+
+// RegisterMCP writes or updates .mcp.json at the project root, injecting the
+// MOM MCP server entry. Existing entries for other servers are preserved.
+func (a *CodexAdapter) RegisterMCP() error {
+	mcpPath := filepath.Join(a.projectRoot, ".mcp.json")
+
+	// Load existing .mcp.json or start fresh.
+	root := make(map[string]any)
+	if data, err := os.ReadFile(mcpPath); err == nil {
+		if err := json.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("parsing .mcp.json: %w", err)
+		}
+	}
+
+	servers, _ := root["mcpServers"].(map[string]any)
+	if servers == nil {
+		servers = make(map[string]any)
+	}
+
+	servers["mom"] = map[string]any{
+		"command": "mom",
+		"args":    []string{"serve", "mcp"},
+	}
+	root["mcpServers"] = servers
+
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling .mcp.json: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(mcpPath, data, 0644); err != nil {
+		return fmt.Errorf("writing .mcp.json: %w", err)
+	}
+
 	return nil
 }
 
@@ -58,11 +151,15 @@ func (a *CodexAdapter) DetectRuntime() bool {
 }
 
 func (a *CodexAdapter) GeneratedFiles() []string {
-	return []string{"AGENTS.md"}
+	return []string{
+		"AGENTS.md",
+		filepath.Join(".codex", "hooks.json"),
+		".mcp.json",
+	}
 }
 
 func (a *CodexAdapter) GeneratedDirs() []string {
-	return nil
+	return []string{".codex"}
 }
 
 func (a *CodexAdapter) Watermark() string {
@@ -70,7 +167,7 @@ func (a *CodexAdapter) Watermark() string {
 }
 
 func (a *CodexAdapter) GitIgnorePaths() []string {
-	return []string{"AGENTS.md"}
+	return []string{"AGENTS.md", ".codex/"}
 }
 
 func (a *CodexAdapter) Capabilities() AdapterCapability {

--- a/cli/internal/adapters/runtime/codex_test.go
+++ b/cli/internal/adapters/runtime/codex_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,28 +82,139 @@ func TestCodexAdapter_GenerateContextFileWatermark(t *testing.T) {
 	}
 }
 
+func TestCodexAdapter_SupportsHooks(t *testing.T) {
+	a := NewCodexAdapter("/tmp/test")
+	if !a.SupportsHooks() {
+		t.Error("expected SupportsHooks to be true")
+	}
+}
+
+func TestCodexAdapter_RegisterHooks(t *testing.T) {
+	dir := t.TempDir()
+	a := NewCodexAdapter(dir)
+
+	if err := a.RegisterHooks(CodexHooks()); err != nil {
+		t.Fatalf("RegisterHooks failed: %v", err)
+	}
+
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+	content, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("reading hooks.json: %v", err)
+	}
+
+	// The entire file IS the hooks map (no wrapping "hooks" key).
+	var hooksMap map[string]any
+	if err := json.Unmarshal(content, &hooksMap); err != nil {
+		t.Fatalf("parsing hooks.json: %v", err)
+	}
+
+	stop, ok := hooksMap["Stop"].([]any)
+	if !ok {
+		t.Fatal("hooks.json should have a Stop event array")
+	}
+	if len(stop) != 2 {
+		t.Fatalf("expected 2 Stop matcher groups, got %d", len(stop))
+	}
+
+	// Verify both "mom record" and "mom draft" are present.
+	var commands []string
+	for _, entry := range stop {
+		group, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatal("matcher group should be a map")
+		}
+		innerHooks, ok := group["hooks"].([]any)
+		if !ok || len(innerHooks) == 0 {
+			t.Fatal("matcher group should have a hooks array")
+		}
+		hookEntry, ok := innerHooks[0].(map[string]any)
+		if !ok {
+			t.Fatal("hook entry should be a map")
+		}
+		if hookEntry["type"] != "command" {
+			t.Errorf("expected type 'command', got %v", hookEntry["type"])
+		}
+		commands = append(commands, hookEntry["command"].(string))
+	}
+
+	hasRecord := false
+	hasDraft := false
+	for _, cmd := range commands {
+		if cmd == "mom record" {
+			hasRecord = true
+		}
+		if cmd == "mom draft" {
+			hasDraft = true
+		}
+	}
+	if !hasRecord {
+		t.Error("hooks.json missing 'mom record' command")
+	}
+	if !hasDraft {
+		t.Error("hooks.json missing 'mom draft' command")
+	}
+}
+
+func TestCodexAdapter_RegisterMCP(t *testing.T) {
+	dir := t.TempDir()
+	a := NewCodexAdapter(dir)
+
+	if err := a.RegisterMCP(); err != nil {
+		t.Fatalf("RegisterMCP failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("reading .mcp.json: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"mom"`) {
+		t.Error(".mcp.json missing mom server entry")
+	}
+	if !strings.Contains(s, `"command": "mom"`) {
+		t.Error(".mcp.json missing mom command")
+	}
+	if !strings.Contains(s, `"serve"`) {
+		t.Error(".mcp.json missing serve arg")
+	}
+}
+
 func TestCodexAdapter_GeneratedFiles(t *testing.T) {
 	a := NewCodexAdapter("/tmp/test")
 	files := a.GeneratedFiles()
-	if len(files) != 1 || files[0] != "AGENTS.md" {
-		t.Errorf("expected [AGENTS.md], got %v", files)
+	expected := []string{"AGENTS.md", filepath.Join(".codex", "hooks.json"), ".mcp.json"}
+	if len(files) != len(expected) {
+		t.Fatalf("expected %d files, got %d: %v", len(expected), len(files), files)
+	}
+	for i, f := range files {
+		if f != expected[i] {
+			t.Errorf("expected files[%d] = %q, got %q", i, expected[i], f)
+		}
+	}
+}
+
+func TestCodexAdapter_GitIgnorePaths(t *testing.T) {
+	a := NewCodexAdapter("/tmp/test")
+	paths := a.GitIgnorePaths()
+	expected := []string{"AGENTS.md", ".codex/"}
+	if len(paths) != len(expected) {
+		t.Fatalf("expected %d paths, got %d: %v", len(expected), len(paths), paths)
+	}
+	for i, p := range paths {
+		if p != expected[i] {
+			t.Errorf("expected paths[%d] = %q, got %q", i, expected[i], p)
+		}
 	}
 }
 
 func TestCodexAdapter_GeneratedDirs(t *testing.T) {
 	a := NewCodexAdapter("/tmp/test")
-	if dirs := a.GeneratedDirs(); dirs != nil {
-		t.Errorf("expected nil dirs, got %v", dirs)
+	dirs := a.GeneratedDirs()
+	if len(dirs) != 1 || dirs[0] != ".codex" {
+		t.Errorf("expected [.codex], got %v", dirs)
 	}
 }
-
-func TestCodexAdapter_SupportsHooks(t *testing.T) {
-	a := NewCodexAdapter("/tmp/test")
-	if a.SupportsHooks() {
-		t.Error("expected SupportsHooks to be false")
-	}
-}
-
 
 func TestCodexAdapter_NoIdentity(t *testing.T) {
 	dir := t.TempDir()

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -318,6 +318,18 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 					return
 				}
 			}
+
+			// Register MCP server config and hooks for Codex.
+			if ca, ok := adapter.(*runtime.CodexAdapter); ok {
+				if err := ca.RegisterMCP(); err != nil {
+					genErr = err
+					return
+				}
+				if err := ca.RegisterHooks(runtime.CodexHooks()); err != nil {
+					genErr = err
+					return
+				}
+			}
 		}
 
 		if showSpinner {


### PR DESCRIPTION
## Summary
- Enable `SupportsHooks()` for Codex adapter (was false)
- Add `RegisterHooks()` — writes `.codex/hooks.json` with Stop events for `mom record` and `mom draft`
- Add `RegisterMCP()` — writes `.mcp.json` with MOM MCP server entry
- Update `GeneratedFiles()`, `GeneratedDirs()`, `GitIgnorePaths()` to include new artifacts
- Bump codex capability version from 0.1 to 1.0
- Wire Codex hooks+MCP in `init.go` Phase 3

## Test plan
- [x] TestCodexAdapter_RegisterHooks
- [x] TestCodexAdapter_RegisterMCP
- [x] TestCodexAdapter_GeneratedFiles
- [x] TestCodexAdapter_GitIgnorePaths
- [x] TestCodexAdapter_GenerateContextFile
- [x] All existing tests pass

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)