### PR TITLE
feat(#108): enable hooks + MCP wiring for Cline adapter

### DIFF
--- a/cli/internal/adapters/runtime/cline.go
+++ b/cli/internal/adapters/runtime/cline.go
@@ -2,9 +2,11 @@ package runtime
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -50,11 +52,60 @@ func (a *ClineAdapter) GenerateContextFile(config Config, constraints []Constrai
 }
 
 func (a *ClineAdapter) SupportsHooks() bool {
-	return false
+	return true
 }
 
 func (a *ClineAdapter) RegisterHooks(hooks []HookDef) error {
+	hooksDir := filepath.Join(a.projectRoot, ".clinerules", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		return fmt.Errorf("creating hooks dir: %w", err)
+	}
+
+	// Group commands by event so multiple commands go into one script.
+	byEvent := make(map[string][]string)
+	for _, h := range hooks {
+		byEvent[h.Event] = append(byEvent[h.Event], h.Command)
+	}
+
+	for event, commands := range byEvent {
+		scriptName := clineEventToFilename(event)
+		scriptPath := filepath.Join(hooksDir, scriptName)
+
+		var sb strings.Builder
+		sb.WriteString("#!/bin/sh\n")
+		for _, cmd := range commands {
+			sb.WriteString(cmd + " < /dev/null\n")
+		}
+		sb.WriteString("echo '{\"cancel\": false}'\n")
+
+		if err := os.WriteFile(scriptPath, []byte(sb.String()), 0755); err != nil {
+			return fmt.Errorf("writing hook script %s: %w", scriptName, err)
+		}
+	}
 	return nil
+}
+
+// clineEventToFilename converts "TaskComplete" to "task-complete.sh".
+func clineEventToFilename(event string) string {
+	var result []byte
+	for i, r := range event {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			result = append(result, '-')
+		}
+		result = append(result, byte(r|0x20)) // toLower
+	}
+	return string(result) + ".sh"
+}
+
+// ClineHooks returns the standard MOM hooks for Cline.
+// TaskComplete → mom record + mom draft: captures and processes transcript.
+// TaskCancel → mom record: captures raw transcript on cancellation.
+func ClineHooks() []HookDef {
+	return []HookDef{
+		{Event: "TaskComplete", Command: "mom record"},
+		{Event: "TaskComplete", Command: "mom draft"},
+		{Event: "TaskCancel", Command: "mom record"},
+	}
 }
 
 func (a *ClineAdapter) DetectRuntime() bool {
@@ -62,8 +113,49 @@ func (a *ClineAdapter) DetectRuntime() bool {
 	return err == nil && info.IsDir()
 }
 
+// RegisterMCP writes or updates .mcp.json at the project root, injecting the
+// MOM MCP server entry. Existing entries for other servers are preserved.
+func (a *ClineAdapter) RegisterMCP() error {
+	mcpPath := filepath.Join(a.projectRoot, ".mcp.json")
+
+	// Load existing .mcp.json or start fresh.
+	root := make(map[string]any)
+	if data, err := os.ReadFile(mcpPath); err == nil {
+		if err := json.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("parsing .mcp.json: %w", err)
+		}
+	}
+
+	servers, _ := root["mcpServers"].(map[string]any)
+	if servers == nil {
+		servers = make(map[string]any)
+	}
+
+	servers["mom"] = map[string]any{
+		"command": "mom",
+		"args":    []string{"serve", "mcp"},
+	}
+	root["mcpServers"] = servers
+
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling .mcp.json: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(mcpPath, data, 0644); err != nil {
+		return fmt.Errorf("writing .mcp.json: %w", err)
+	}
+
+	return nil
+}
+
 func (a *ClineAdapter) GeneratedFiles() []string {
-	return []string{filepath.Join(".clinerules", "mom-context.md")}
+	return []string{
+		filepath.Join(".clinerules", "mom-context.md"),
+		filepath.Join(".clinerules", "hooks", "task-complete.sh"),
+		filepath.Join(".clinerules", "hooks", "task-cancel.sh"),
+		".mcp.json",
+	}
 }
 
 // GeneratedDirs returns nil — .clinerules/ may contain user's workflows, hooks,

--- a/cli/internal/adapters/runtime/cline_test.go
+++ b/cli/internal/adapters/runtime/cline_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,8 +113,22 @@ func TestClineAdapter_GenerateContextFilePreservesDir(t *testing.T) {
 func TestClineAdapter_GeneratedFiles(t *testing.T) {
 	a := NewClineAdapter("/tmp/test")
 	files := a.GeneratedFiles()
-	if len(files) != 1 || files[0] != filepath.Join(".clinerules", "mom-context.md") {
-		t.Errorf("expected [.clinerules/mom-context.md], got %v", files)
+
+	want := []string{
+		filepath.Join(".clinerules", "mom-context.md"),
+		filepath.Join(".clinerules", "hooks", "task-complete.sh"),
+		filepath.Join(".clinerules", "hooks", "task-cancel.sh"),
+		".mcp.json",
+	}
+
+	if len(files) != len(want) {
+		t.Fatalf("GeneratedFiles() returned %d files, want %d", len(files), len(want))
+	}
+
+	for i, f := range files {
+		if f != want[i] {
+			t.Errorf("GeneratedFiles()[%d] = %q, want %q", i, f, want[i])
+		}
 	}
 }
 
@@ -126,8 +141,8 @@ func TestClineAdapter_GeneratedDirs(t *testing.T) {
 
 func TestClineAdapter_SupportsHooks(t *testing.T) {
 	a := NewClineAdapter("/tmp/test")
-	if a.SupportsHooks() {
-		t.Error("expected SupportsHooks to be false")
+	if !a.SupportsHooks() {
+		t.Error("expected SupportsHooks to be true")
 	}
 }
 
@@ -144,6 +159,120 @@ func TestClineAdapter_NoIdentity(t *testing.T) {
 	content, _ := os.ReadFile(filepath.Join(dir, ".clinerules", "mom-context.md"))
 	if !strings.Contains(string(content), "She remembers, so you don't have to") {
 		t.Error("should have fallback identity")
+	}
+}
+
+func TestClineAdapter_RegisterHooks(t *testing.T) {
+	dir := t.TempDir()
+	adapter := NewClineAdapter(dir)
+
+	if err := adapter.RegisterHooks(ClineHooks()); err != nil {
+		t.Fatalf("RegisterHooks() error: %v", err)
+	}
+
+	for _, name := range []string{"task-complete.sh", "task-cancel.sh"} {
+		path := filepath.Join(dir, ".clinerules", "hooks", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected hook script %s to exist, got: %v", name, err)
+		}
+	}
+}
+
+func TestClineAdapter_HookScriptContent(t *testing.T) {
+	dir := t.TempDir()
+	adapter := NewClineAdapter(dir)
+
+	if err := adapter.RegisterHooks(ClineHooks()); err != nil {
+		t.Fatalf("RegisterHooks() error: %v", err)
+	}
+
+	scriptPath := filepath.Join(dir, ".clinerules", "hooks", "task-complete.sh")
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("reading task-complete.sh: %v", err)
+	}
+	content := string(data)
+
+	for _, want := range []string{"mom record", "mom draft", `{"cancel": false}`} {
+		if !strings.Contains(content, want) {
+			t.Errorf("task-complete.sh should contain %q, got:\n%s", want, content)
+		}
+	}
+
+	if !strings.HasPrefix(content, "#!/bin/sh\n") {
+		t.Errorf("task-complete.sh should start with shebang, got:\n%s", content)
+	}
+}
+
+func TestClineAdapter_HookScriptPermissions(t *testing.T) {
+	dir := t.TempDir()
+	adapter := NewClineAdapter(dir)
+
+	if err := adapter.RegisterHooks(ClineHooks()); err != nil {
+		t.Fatalf("RegisterHooks() error: %v", err)
+	}
+
+	for _, name := range []string{"task-complete.sh", "task-cancel.sh"} {
+		path := filepath.Join(dir, ".clinerules", "hooks", name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		perm := info.Mode().Perm()
+		if perm&0111 == 0 {
+			t.Errorf("%s should be executable, got permissions %o", name, perm)
+		}
+	}
+}
+
+func TestClineAdapter_RegisterMCP(t *testing.T) {
+	dir := t.TempDir()
+	adapter := NewClineAdapter(dir)
+
+	if err := adapter.RegisterMCP(); err != nil {
+		t.Fatalf("RegisterMCP() error: %v", err)
+	}
+
+	mcpPath := filepath.Join(dir, ".mcp.json")
+	data, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatalf("reading .mcp.json: %v", err)
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parsing .mcp.json: %v", err)
+	}
+
+	servers, ok := root["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mcpServers key in .mcp.json")
+	}
+
+	mom, ok := servers["mom"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mom entry in mcpServers")
+	}
+
+	if mom["command"] != "mom" {
+		t.Errorf("expected command=mom, got %v", mom["command"])
+	}
+}
+
+func TestClineEventToFilename(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"TaskComplete", "task-complete.sh"},
+		{"TaskCancel", "task-cancel.sh"},
+	}
+
+	for _, tt := range tests {
+		got := clineEventToFilename(tt.input)
+		if got != tt.want {
+			t.Errorf("clineEventToFilename(%q) = %q, want %q", tt.input, got, tt.want)
+		}
 	}
 }
 

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -342,6 +342,18 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 					return
 				}
 			}
+
+			// Register MCP server config and hooks for Cline.
+			if ca, ok := adapter.(*runtime.ClineAdapter); ok {
+				if err := ca.RegisterMCP(); err != nil {
+					genErr = err
+					return
+				}
+				if err := ca.RegisterHooks(runtime.ClineHooks()); err != nil {
+					genErr = err
+					return
+				}
+			}
 		}
 
 		if showSpinner {


### PR DESCRIPTION
## Summary
- Enable `SupportsHooks()` for Cline adapter
- Add `RegisterHooks()` — creates executable shell scripts in `.clinerules/hooks/` (Cline uses scripts, not JSON config)
- Add `RegisterMCP()` — writes `.mcp.json` with MOM MCP server entry
- Add `ClineHooks()` — TaskComplete (record+draft) and TaskCancel (record)
- Add `clineEventToFilename()` helper (CamelCase to kebab-case)
- Update `GeneratedFiles()` to include hook scripts and `.mcp.json`
- Wire Cline hooks+MCP in `init.go` Phase 3

## Test plan
- [x] TestClineAdapter_RegisterHooks
- [x] TestClineAdapter_HookScriptContent
- [x] TestClineAdapter_HookScriptPermissions
- [x] TestClineAdapter_RegisterMCP
- [x] TestClineAdapter_GeneratedFiles
- [x] TestClineEventToFilename
- [x] All existing tests pass

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)