### PR TITLE
feat(#106): add turn sanitizer to drafter pipeline

### DIFF
--- a/cli/internal/drafter/drafter.go
+++ b/cli/internal/drafter/drafter.go
@@ -58,6 +58,9 @@ func (d *Drafter) Process(since time.Time) ([]Draft, error) {
 		allTurns = append(allTurns, turns...)
 	}
 
+	// Sanitize turns: extract conversational text, drop tool_use/metadata.
+	allTurns = sanitizeTurns(allTurns)
+
 	if len(allTurns) == 0 {
 		return nil, nil
 	}

--- a/cli/internal/drafter/sanitizer.go
+++ b/cli/internal/drafter/sanitizer.go
@@ -1,0 +1,127 @@
+package drafter
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// sanitizeTurns filters raw turn text to keep only conversational content.
+// Each raw turn's Text field may contain full Claude Code transcript JSONL
+// (one JSON object per line). The sanitizer:
+//  1. Parses each line as JSON
+//  2. Keeps only lines where type is "assistant" or "user"
+//  3. Extracts text content from message.content[] items where type=="text"
+//  4. Drops tool_use, tool_result, progress, system lines
+//  5. Falls back to keeping raw text if no structured content is found
+func sanitizeTurns(turns []rawTurn) []rawTurn {
+	var result []rawTurn
+	for _, t := range turns {
+		cleaned := sanitizeText(t.Text)
+		if cleaned == "" {
+			continue // drop turns with no extractable text
+		}
+		t.Text = cleaned
+		result = append(result, t)
+	}
+	return result
+}
+
+// sanitizeText processes a single turn's text content.
+// If the text contains JSONL transcript lines, it extracts only text content.
+// If it's plain text (not JSONL), it returns it as-is.
+func sanitizeText(text string) string {
+	lines := strings.Split(text, "\n")
+
+	var extracted []string
+	hasStructured := false
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Try to parse as JSON
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			// Not JSON — could be plain text. Keep it.
+			extracted = append(extracted, line)
+			continue
+		}
+
+		hasStructured = true
+
+		// Check top-level type
+		msgType, _ := obj["type"].(string)
+		if msgType != "assistant" && msgType != "user" {
+			// Drop progress, result, system, etc.
+			continue
+		}
+
+		// Extract text from message.content[]
+		texts := extractTextContent(obj)
+		if len(texts) > 0 {
+			extracted = append(extracted, texts...)
+		}
+	}
+
+	// If we found structured JSON but extracted nothing, the turn was all tool_use/metadata
+	if hasStructured && len(extracted) == 0 {
+		return ""
+	}
+
+	return strings.Join(extracted, "\n")
+}
+
+// extractTextContent pulls text strings from a transcript message object.
+// Handles the nested structure: obj.message.content[].text where content[].type=="text"
+// Also handles flat text fields directly on the object.
+func extractTextContent(obj map[string]any) []string {
+	var texts []string
+
+	// Try obj.message.content[] (Claude Code format)
+	if msg, ok := obj["message"].(map[string]any); ok {
+		if content, ok := msg["content"].([]any); ok {
+			for _, item := range content {
+				if m, ok := item.(map[string]any); ok {
+					if t, _ := m["type"].(string); t == "text" {
+						if text, _ := m["text"].(string); text != "" {
+							texts = append(texts, text)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Try obj.content[] directly (alternative format)
+	if len(texts) == 0 {
+		if content, ok := obj["content"].([]any); ok {
+			for _, item := range content {
+				if m, ok := item.(map[string]any); ok {
+					if t, _ := m["type"].(string); t == "text" {
+						if text, _ := m["text"].(string); text != "" {
+							texts = append(texts, text)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Try obj.content as string directly (simple format)
+	if len(texts) == 0 {
+		if content, ok := obj["content"].(string); ok && content != "" {
+			texts = append(texts, content)
+		}
+	}
+
+	// Try obj.text directly (simplest format)
+	if len(texts) == 0 {
+		if text, ok := obj["text"].(string); ok && text != "" {
+			texts = append(texts, text)
+		}
+	}
+
+	return texts
+}

--- a/cli/internal/drafter/sanitizer_test.go
+++ b/cli/internal/drafter/sanitizer_test.go
@@ -1,0 +1,118 @@
+package drafter
+
+import (
+	"testing"
+)
+
+func TestSanitizeTurns_StripsToolUse(t *testing.T) {
+	// Turn with mixed text + tool_use content
+	turn := rawTurn{
+		Text: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Here is the fix"},{"type":"tool_use","id":"tu1","name":"Read","input":{"path":"/foo"}}]}}`,
+	}
+	result := sanitizeTurns([]rawTurn{turn})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(result))
+	}
+	if result[0].Text != "Here is the fix" {
+		t.Errorf("expected cleaned text, got: %s", result[0].Text)
+	}
+}
+
+func TestSanitizeTurns_StripsProgress(t *testing.T) {
+	// Progress and system lines should be dropped
+	turn := rawTurn{
+		Text: `{"type":"progress","data":{"status":"running"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done"}]}}`,
+	}
+	result := sanitizeTurns([]rawTurn{turn})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(result))
+	}
+	if result[0].Text != "Done" {
+		t.Errorf("expected 'Done', got: %s", result[0].Text)
+	}
+}
+
+func TestSanitizeTurns_PreservesUserText(t *testing.T) {
+	turn := rawTurn{
+		Text: `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Please fix the bug"}]}}`,
+	}
+	result := sanitizeTurns([]rawTurn{turn})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(result))
+	}
+	if result[0].Text != "Please fix the bug" {
+		t.Errorf("expected user text, got: %s", result[0].Text)
+	}
+}
+
+func TestSanitizeTurns_EmptyAfterSanitize(t *testing.T) {
+	// Turn with only tool_use — should be dropped
+	turn := rawTurn{
+		Text: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"Write","input":{}}]}}`,
+	}
+	result := sanitizeTurns([]rawTurn{turn})
+	if len(result) != 0 {
+		t.Errorf("expected 0 turns, got %d", len(result))
+	}
+}
+
+func TestSanitizeTurns_MalformedJSON(t *testing.T) {
+	// Garbage lines should be kept as-is (fallback)
+	turn := rawTurn{
+		Text: "this is just plain text, not JSON",
+	}
+	result := sanitizeTurns([]rawTurn{turn})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(result))
+	}
+	if result[0].Text != "this is just plain text, not JSON" {
+		t.Errorf("expected raw text preserved, got: %s", result[0].Text)
+	}
+}
+
+func TestSanitizeTurns_FallbackKeepsRaw(t *testing.T) {
+	// Unrecognized JSON format — keep raw
+	turn := rawTurn{
+		Text: `{"custom_field": "some value", "data": 123}`,
+	}
+	result := sanitizeTurns([]rawTurn{turn})
+	// Unrecognized format with no type field should be dropped (no type == not assistant/user)
+	// hasStructured=true, type is empty string != "assistant"/"user", so extracted is empty -> dropped
+	if len(result) != 0 {
+		t.Errorf("expected 0 turns (unknown structured JSON with no text), got %d", len(result))
+	}
+}
+
+func TestSanitizeTurns_MultipleContentItems(t *testing.T) {
+	turn := rawTurn{
+		Text: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"First part"},{"type":"text","text":"Second part"},{"type":"tool_use","id":"x","name":"Bash","input":{}}]}}`,
+	}
+	result := sanitizeTurns([]rawTurn{turn})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(result))
+	}
+	if result[0].Text != "First part\nSecond part" {
+		t.Errorf("expected joined text, got: %s", result[0].Text)
+	}
+}
+
+func TestSanitizeTurns_PreservesMetadata(t *testing.T) {
+	// Verify that non-Text fields (Timestamp, SessionID, etc.) are preserved
+	turn := rawTurn{
+		Timestamp: "2026-04-22T12:00:00Z",
+		Event:     "stop",
+		SessionID: "session-123",
+		Text:      `{"type":"user","content":[{"type":"text","text":"hello"}]}`,
+	}
+	result := sanitizeTurns([]rawTurn{turn})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(result))
+	}
+	if result[0].Timestamp != "2026-04-22T12:00:00Z" {
+		t.Error("timestamp not preserved")
+	}
+	if result[0].SessionID != "session-123" {
+		t.Error("session ID not preserved")
+	}
+}


### PR DESCRIPTION
## Summary
- New `sanitizer.go` with `sanitizeTurns()` pipeline step
- Parses JSONL transcript lines, extracts only text content from assistant/user messages
- Drops tool_use, tool_result, progress, system lines
- Falls back to raw text for non-JSON input (plain text preserved)
- Handles 4 content formats: nested message.content[], flat content[], string content, string text
- Integrated into `Process()` between raw file reading and session grouping

## Test plan
- [x] TestSanitizeTurns_StripsToolUse — mixed text+tool_use → only text
- [x] TestSanitizeTurns_StripsProgress — progress/system lines dropped
- [x] TestSanitizeTurns_PreservesUserText — user messages unchanged
- [x] TestSanitizeTurns_EmptyAfterSanitize — tool_use-only turns dropped
- [x] TestSanitizeTurns_MalformedJSON — plain text kept as-is
- [x] TestSanitizeTurns_FallbackKeepsRaw — unknown JSON dropped
- [x] TestSanitizeTurns_MultipleContentItems — multiple text items joined
- [x] TestSanitizeTurns_PreservesMetadata — timestamp/session preserved
- [x] All 24 drafter tests pass

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)