### PR TITLE
feat(#145): transcript tail ingestion — Windsurf

### DIFF
--- a/cli/internal/adapters/runtime/windsurf.go
+++ b/cli/internal/adapters/runtime/windsurf.go
@@ -91,11 +91,14 @@ func (a *WindsurfAdapter) RegisterHooks(hooks []HookDef) error {
 }
 
 // WindsurfHooks returns the standard MOM hooks for Windsurf.
-// post_cascade_response_with_transcript provides transcript_path in the hook
-// JSON input — same format as Claude Code hooks, so we use plain "mom record".
+//
+// Recording is handled by the filesystem watcher (mom watch --runtime windsurf),
+// which reads ~/.windsurf/transcripts/ directly. The mom record hook is intentionally
+// omitted to avoid the 25-fires-per-turn problem and explosive raw data growth (#145).
+//
+// Only mom draft is retained so the drafter pipeline runs after each turn.
 func WindsurfHooks() []HookDef {
 	return []HookDef{
-		{Event: "post_cascade_response_with_transcript", Command: "mom record"},
 		{Event: "post_cascade_response_with_transcript", Command: "mom draft"},
 	}
 }

--- a/cli/internal/adapters/runtime/windsurf_test.go
+++ b/cli/internal/adapters/runtime/windsurf_test.go
@@ -108,26 +108,19 @@ func TestWindsurfAdapter_RegisterHooks(t *testing.T) {
 	if !ok {
 		t.Fatal("hooks.json missing post_cascade_response_with_transcript event")
 	}
-	if len(event) != 2 {
-		t.Fatalf("expected 2 hook entries, got %d", len(event))
+	// Recording is done by the filesystem watcher (mom watch --runtime windsurf).
+	// Only mom draft should remain — mom record is intentionally absent (#145).
+	if len(event) != 1 {
+		t.Fatalf("expected 1 hook entry (mom draft only), got %d", len(event))
 	}
 
-	// Verify first hook command is "mom record" with working_directory.
+	// Verify the sole hook command is "mom draft" with working_directory.
 	entry0 := event[0].(map[string]any)
-	if entry0["command"] != "mom record" {
-		t.Errorf("expected command 'mom record', got %v", entry0["command"])
+	if entry0["command"] != "mom draft" {
+		t.Errorf("expected command 'mom draft', got %v", entry0["command"])
 	}
 	if entry0["working_directory"] != dir {
 		t.Errorf("expected working_directory %q, got %v", dir, entry0["working_directory"])
-	}
-
-	// Verify second hook command is "mom draft" with working_directory.
-	entry1 := event[1].(map[string]any)
-	if entry1["command"] != "mom draft" {
-		t.Errorf("expected command 'mom draft', got %v", entry1["command"])
-	}
-	if entry1["working_directory"] != dir {
-		t.Errorf("expected working_directory %q, got %v", dir, entry1["working_directory"])
 	}
 }
 

--- a/cli/internal/cmd/watch.go
+++ b/cli/internal/cmd/watch.go
@@ -15,16 +15,26 @@ var (
 	watchTranscriptDir string
 	watchDebounceMs    int
 	watchStatus        bool
+	watchRuntime       string
 )
+
+// defaultTranscriptDirs maps runtime name to its default transcript directory.
+var defaultTranscriptDirs = map[string]string{
+	"claude":   "~/.claude/projects/",
+	"windsurf": "~/.windsurf/transcripts/",
+}
 
 var watchCmd = &cobra.Command{
 	Use:   "watch",
-	Short: "Watch Claude Code transcripts and ingest turns automatically",
-	Long: `Starts a filesystem watcher on the Claude Code transcript directory
-(default: ~/.claude/projects/) and ingests new conversation turns into
-.mom/raw/ without MCP calls or hook overhead.
+	Short: "Watch runtime transcripts and ingest turns automatically",
+	Long: `Starts a filesystem watcher on a runtime transcript directory and
+ingests new conversation turns into .mom/raw/ without MCP calls or hook overhead.
 
-Each Claude Code session's JSONL transcript is tailed incrementally.
+Supported runtimes:
+  claude    — ~/.claude/projects/ (default)
+  windsurf  — ~/.windsurf/transcripts/
+
+Each session's JSONL transcript is tailed incrementally.
 Cursor files in .mom/raw/ track the last ingested byte offset per session,
 so restarts are safe and idempotent.
 
@@ -35,8 +45,10 @@ The watcher runs in the foreground. Use Ctrl-C to stop.`,
 }
 
 func init() {
-	watchCmd.Flags().StringVar(&watchTranscriptDir, "dir", "~/.claude/projects/",
-		"Transcript directory to watch (Claude Code: ~/.claude/projects/)")
+	watchCmd.Flags().StringVar(&watchRuntime, "runtime", "claude",
+		`Runtime to watch: "claude" (default) or "windsurf"`)
+	watchCmd.Flags().StringVar(&watchTranscriptDir, "dir", "",
+		"Transcript directory to watch (overrides the runtime default)")
 	watchCmd.Flags().IntVar(&watchDebounceMs, "debounce", 300,
 		"Milliseconds to wait after a write event before reading (debounce)")
 	watchCmd.Flags().BoolVar(&watchStatus, "status", false,
@@ -58,10 +70,29 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		return runWatchStatus(momDir)
 	}
 
+	// Resolve adapter and transcript directory from --runtime flag.
+	var adapter watcher.Adapter
+	transcriptDir := watchTranscriptDir
+
+	switch watchRuntime {
+	case "windsurf":
+		adapter = watcher.NewWindsurfAdapter()
+		if transcriptDir == "" {
+			transcriptDir = defaultTranscriptDirs["windsurf"]
+		}
+	case "claude", "":
+		adapter = watcher.NewClaudeAdapter()
+		if transcriptDir == "" {
+			transcriptDir = defaultTranscriptDirs["claude"]
+		}
+	default:
+		return fmt.Errorf("unknown runtime %q — supported: claude, windsurf", watchRuntime)
+	}
+
 	cfg := watcher.Config{
-		TranscriptDir: watchTranscriptDir,
+		TranscriptDir: transcriptDir,
 		MomDir:        momDir,
-		Adapter:       watcher.NewClaudeAdapter(),
+		Adapter:       adapter,
 		DebounceMs:    watchDebounceMs,
 	}
 
@@ -70,7 +101,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("creating watcher: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "watching %s → %s/raw/\n", watchTranscriptDir, momDir)
+	fmt.Fprintf(os.Stderr, "watching %s [%s] → %s/raw/\n", transcriptDir, watchRuntime, momDir)
 	fmt.Fprintf(os.Stderr, "press Ctrl-C to stop\n")
 
 	if err := w.Run(); err != nil {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -40,6 +40,9 @@ type WatcherConfig struct {
 	// TranscriptDir overrides the default Claude Code transcript directory.
 	// Defaults to ~/.claude/projects/ when empty.
 	TranscriptDir string `yaml:"transcript_dir,omitempty"`
+	// WindsurfTranscriptDir overrides the default Windsurf transcript directory.
+	// Defaults to ~/.windsurf/transcripts/ when empty.
+	WindsurfTranscriptDir string `yaml:"windsurf_transcript_dir,omitempty"`
 	// DebounceMs is the debounce delay in milliseconds. Default: 300.
 	DebounceMs int `yaml:"debounce_ms,omitempty"`
 }

--- a/cli/internal/watcher/adapter_windsurf.go
+++ b/cli/internal/watcher/adapter_windsurf.go
@@ -1,0 +1,95 @@
+package watcher
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/momhq/mom/cli/internal/recorder"
+)
+
+// WindsurfAdapter parses Windsurf JSONL transcript lines.
+// Windsurf writes one JSON object per line to ~/.windsurf/transcripts/{trajectory_id}.jsonl
+// with the schema:
+//
+//	{ "status": "done", "type": "user_input",       "user_input":       { "user_response": "..." } }
+//	{ "status": "done", "type": "planner_response", "planner_response": { "response": "..." } }
+//	{ "status": "done", "type": "code_action",      "code_action":      { ... } }   ← skipped
+//	{ "status": "done", "type": "command_action",   "command_action":   { ... } }   ← skipped
+//
+// Only user_input and planner_response are ingested; all other types are dropped.
+type WindsurfAdapter struct{}
+
+// NewWindsurfAdapter returns a new WindsurfAdapter.
+func NewWindsurfAdapter() *WindsurfAdapter {
+	return &WindsurfAdapter{}
+}
+
+func (a *WindsurfAdapter) Name() string { return "windsurf" }
+
+// windsurfTranscriptLine is the minimal subset of a Windsurf JSONL line
+// that the adapter needs to inspect.
+type windsurfTranscriptLine struct {
+	Type            string                  `json:"type"`
+	Status          string                  `json:"status"`
+	UserInput       *windsurfUserInput      `json:"user_input,omitempty"`
+	PlannerResponse *windsurfPlannerResponse `json:"planner_response,omitempty"`
+}
+
+type windsurfUserInput struct {
+	UserResponse string `json:"user_response"`
+}
+
+type windsurfPlannerResponse struct {
+	Response string `json:"response"`
+}
+
+// ParseLine implements Adapter. It parses one JSONL line and returns a
+// RawEntry if the line contains user_input or planner_response content.
+func (a *WindsurfAdapter) ParseLine(line []byte, sessionID string) (recorder.RawEntry, bool) {
+	line = trimLine(line)
+	if len(line) == 0 {
+		return recorder.RawEntry{}, false
+	}
+
+	var tl windsurfTranscriptLine
+	if err := json.Unmarshal(line, &tl); err != nil {
+		return recorder.RawEntry{}, false
+	}
+
+	switch tl.Type {
+	case "user_input":
+		if tl.UserInput == nil {
+			return recorder.RawEntry{}, false
+		}
+		text := strings.TrimSpace(tl.UserInput.UserResponse)
+		if text == "" {
+			return recorder.RawEntry{}, false
+		}
+		return recorder.RawEntry{
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Event:     "watch-user",
+			Text:      text,
+			SessionID: sessionID,
+		}, true
+
+	case "planner_response":
+		if tl.PlannerResponse == nil {
+			return recorder.RawEntry{}, false
+		}
+		text := strings.TrimSpace(tl.PlannerResponse.Response)
+		if text == "" {
+			return recorder.RawEntry{}, false
+		}
+		return recorder.RawEntry{
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Event:     "watch-assistant",
+			Text:      text,
+			SessionID: sessionID,
+		}, true
+
+	default:
+		// Drop: code_action, command_action, file-history-snapshot, hook_progress, etc.
+		return recorder.RawEntry{}, false
+	}
+}

--- a/cli/internal/watcher/adapter_windsurf_test.go
+++ b/cli/internal/watcher/adapter_windsurf_test.go
@@ -1,0 +1,221 @@
+package watcher
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWindsurfAdapter_Name(t *testing.T) {
+	a := NewWindsurfAdapter()
+	if a.Name() != "windsurf" {
+		t.Errorf("expected Name()=windsurf, got %q", a.Name())
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_UserInput(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "user_input",
+		"user_input": map[string]any{
+			"user_response": "How do I implement a binary search?",
+			"rules_applied": map[string]any{"always_on": []string{"rule.md"}},
+		},
+	})
+
+	entry, ok := a.ParseLine(line, "traj-abc123")
+	if !ok {
+		t.Fatal("expected ParseLine to return ok=true for user_input")
+	}
+	if entry.SessionID != "traj-abc123" {
+		t.Errorf("expected session_id=traj-abc123, got %q", entry.SessionID)
+	}
+	if entry.Text != "How do I implement a binary search?" {
+		t.Errorf("unexpected text: %q", entry.Text)
+	}
+	if entry.Event != "watch-user" {
+		t.Errorf("expected event=watch-user, got %q", entry.Event)
+	}
+	if entry.Timestamp == "" {
+		t.Error("expected non-empty timestamp")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_PlannerResponse(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "planner_response",
+		"planner_response": map[string]any{
+			"response": "Binary search works by repeatedly halving the search space.",
+		},
+	})
+
+	entry, ok := a.ParseLine(line, "traj-def456")
+	if !ok {
+		t.Fatal("expected ParseLine to return ok=true for planner_response")
+	}
+	if entry.SessionID != "traj-def456" {
+		t.Errorf("expected session_id=traj-def456, got %q", entry.SessionID)
+	}
+	if entry.Text != "Binary search works by repeatedly halving the search space." {
+		t.Errorf("unexpected text: %q", entry.Text)
+	}
+	if entry.Event != "watch-assistant" {
+		t.Errorf("expected event=watch-assistant, got %q", entry.Event)
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_DropCodeAction(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "code_action",
+		"code_action": map[string]any{
+			"new_content": "def hello(): pass",
+			"path":        "/project/hello.py",
+		},
+	})
+
+	_, ok := a.ParseLine(line, "traj-xxx")
+	if ok {
+		t.Error("expected code_action to be dropped (ok=false)")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_DropCommandAction(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "command_action",
+		"command_action": map[string]any{
+			"command": "npm test",
+			"output":  "All tests passed",
+		},
+	})
+
+	_, ok := a.ParseLine(line, "traj-xxx")
+	if ok {
+		t.Error("expected command_action to be dropped (ok=false)")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_DropFileHistorySnapshot(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "file-history-snapshot",
+	})
+
+	_, ok := a.ParseLine(line, "traj-xxx")
+	if ok {
+		t.Error("expected file-history-snapshot to be dropped (ok=false)")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_DropHookProgress(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	line, _ := json.Marshal(map[string]any{
+		"status": "in_progress",
+		"type":   "hook_progress",
+	})
+
+	_, ok := a.ParseLine(line, "traj-xxx")
+	if ok {
+		t.Error("expected hook_progress to be dropped (ok=false)")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_EmptyUserResponse(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "user_input",
+		"user_input": map[string]any{
+			"user_response": "   ",
+		},
+	})
+
+	_, ok := a.ParseLine(line, "traj-xxx")
+	if ok {
+		t.Error("expected whitespace-only user_response to be dropped (ok=false)")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_EmptyPlannerResponse(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "planner_response",
+		"planner_response": map[string]any{
+			"response": "",
+		},
+	})
+
+	_, ok := a.ParseLine(line, "traj-xxx")
+	if ok {
+		t.Error("expected empty planner response to be dropped (ok=false)")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_MissingUserInputField(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	// type=user_input but no user_input payload
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "user_input",
+	})
+
+	_, ok := a.ParseLine(line, "traj-xxx")
+	if ok {
+		t.Error("expected missing user_input field to be dropped (ok=false)")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_MissingPlannerResponseField(t *testing.T) {
+	a := NewWindsurfAdapter()
+
+	// type=planner_response but no planner_response payload
+	line, _ := json.Marshal(map[string]any{
+		"status": "done",
+		"type":   "planner_response",
+	})
+
+	_, ok := a.ParseLine(line, "traj-xxx")
+	if ok {
+		t.Error("expected missing planner_response field to be dropped (ok=false)")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_InvalidJSON(t *testing.T) {
+	a := NewWindsurfAdapter()
+	_, ok := a.ParseLine([]byte("{not json"), "traj-xxx")
+	if ok {
+		t.Error("expected invalid JSON to return ok=false")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_EmptyLine(t *testing.T) {
+	a := NewWindsurfAdapter()
+	_, ok := a.ParseLine([]byte(""), "traj-xxx")
+	if ok {
+		t.Error("expected empty line to return ok=false")
+	}
+}
+
+func TestWindsurfAdapter_ParseLine_WhitespaceOnlyLine(t *testing.T) {
+	a := NewWindsurfAdapter()
+	_, ok := a.ParseLine([]byte("   \t  "), "traj-xxx")
+	if ok {
+		t.Error("expected whitespace-only line to return ok=false")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `WindsurfAdapter` implementing the `watcher.Adapter` interface from #137
- Parses Windsurf JSONL transcript format (`~/.windsurf/transcripts/{trajectory_id}.jsonl`)
- Filters: keeps `user_input` and `planner_response`; drops `code_action`, `command_action`, `file-history-snapshot`, `hook_progress`
- Extends `mom watch` with `--runtime windsurf` flag (default remains `claude`)
- Removes `mom record` from Windsurf hooks — recording is now handled by the watcher
- Adds `WindsurfTranscriptDir` field to `WatcherConfig` for optional config-file override

## What was implemented

### New files

- `cli/internal/watcher/adapter_windsurf.go` — `WindsurfAdapter` struct with `ParseLine` that maps Windsurf's `user_input`→`watch-user` and `planner_response`→`watch-assistant`, drops all other types
- `cli/internal/watcher/adapter_windsurf_test.go` — 12 unit tests covering all kept/dropped types, empty payloads, missing fields, invalid JSON, whitespace-only lines

### Modified files

- `cli/internal/cmd/watch.go` — adds `--runtime` flag; resolves adapter and default transcript directory from the flag; updated help text lists both supported runtimes
- `cli/internal/config/config.go` — adds `WindsurfTranscriptDir` to `WatcherConfig` (YAML: `windsurf_transcript_dir`)
- `cli/internal/adapters/runtime/windsurf.go` — `WindsurfHooks()` now returns only `mom draft`; `mom record` removed (recording via `mom watch --runtime windsurf`)
- `cli/internal/adapters/runtime/windsurf_test.go` — `TestWindsurfAdapter_RegisterHooks` updated to assert 1 hook entry (mom draft only)

## Test plan

- [x] `go test ./internal/watcher/...` — all 25 tests pass (11 existing + 12 new Windsurf tests)
- [x] `go test ./internal/adapters/runtime/...` — all tests pass including updated `RegisterHooks`
- [x] `go test ./...` — all packages pass (pre-existing `reindexCmd` build failure on base branch is unrelated)
- [x] `go vet ./...` — no issues in changed packages

## Usage

```
mom watch --runtime windsurf
mom watch --runtime windsurf --dir ~/.windsurf/transcripts/
mom watch --runtime claude   # unchanged behavior
```

Closes #145