### PR TITLE
ci: add race detector, govulncheck, mod tidy check, smoke test, extra linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,17 @@ jobs:
           go-version: "1.26"
           cache-dependency-path: cli/go.sum
 
+      - name: Check go mod tidy
+        run: go mod tidy && git diff --exit-code go.mod go.sum
+
       - name: Build
         run: make build
 
-      - name: Test with coverage
-        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Smoke test
+        run: ./bin/mom version
+
+      - name: Test with coverage and race detector
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Check coverage threshold
         run: |
@@ -39,6 +45,9 @@ jobs:
             echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
             exit 1
           fi
+
+      - name: Vulnerability scan
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...
 
       - name: Check new Go files have tests
         if: github.event_name == 'pull_request'

--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -2,6 +2,10 @@ version: "2"
 
 linters:
   default: standard
+  enable:
+    - gocritic
+    - misspell
+    - unconvert
   exclusions:
     rules:
       # Don't require error checks on fmt print functions (writing to stdout/buffers)

--- a/cli/internal/cartographer/cartographer.go
+++ b/cli/internal/cartographer/cartographer.go
@@ -461,18 +461,19 @@ func segMatch(pattern, segment string) bool {
 	match := 0
 
 	for si < len(segment) {
-		if pi < len(pattern) && (pattern[pi] == '?' || pattern[pi] == segment[si]) {
+		switch {
+		case pi < len(pattern) && (pattern[pi] == '?' || pattern[pi] == segment[si]):
 			pi++
 			si++
-		} else if pi < len(pattern) && pattern[pi] == '*' {
+		case pi < len(pattern) && pattern[pi] == '*':
 			starIdx = pi
 			match = si
 			pi++
-		} else if starIdx >= 0 {
+		case starIdx >= 0:
 			pi = starIdx + 1
 			match++
 			si = match
-		} else {
+		default:
 			return false
 		}
 	}

--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -287,8 +287,7 @@ func printCapturePipelineLatency(p *ux.Printer, telDir string) {
 			continue
 		}
 		if v, ok := raw["latency_ms"]; ok {
-			switch n := v.(type) {
-			case float64:
+			if n, isFloat := v.(float64); isFloat {
 				latencies = append(latencies, int64(n))
 			}
 		}

--- a/cli/internal/cmd/export.go
+++ b/cli/internal/cmd/export.go
@@ -43,12 +43,12 @@ func runExport(cmd *cobra.Command, args []string) error {
 	// Determine output directory.
 	outputFlag, _ := cmd.Flags().GetString("output")
 	var outputDir string
-	if outputFlag != "" {
+	switch {
+	case outputFlag != "":
 		outputDir = outputFlag
-	} else if len(args) > 0 {
+	case len(args) > 0:
 		outputDir = filepath.Join(args[0], "mom-export")
-	} else {
-		// Default: ./mom-export relative to cwd.
+	default:
 		cwd, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("getting cwd: %w", err)

--- a/cli/internal/cmd/sweep.go
+++ b/cli/internal/cmd/sweep.go
@@ -61,13 +61,14 @@ func runSweep(cmd *cobra.Command, _ []string) error {
 		doSweep()
 	}
 
-	if result.Errors > 0 {
+	switch {
+	case result.Errors > 0:
 		p.Warnf("deleted %d files, freed %.1f MB (%d errors)",
 			result.Deleted, float64(result.BytesFreed)/(1024*1024), result.Errors)
-	} else if result.Deleted > 0 {
+	case result.Deleted > 0:
 		p.Checkf("deleted %d files, freed %.1f MB",
 			result.Deleted, float64(result.BytesFreed)/(1024*1024))
-	} else {
+	default:
 		p.Muted("nothing to clean")
 	}
 	p.Blank()

--- a/cli/internal/watcher/watcher.go
+++ b/cli/internal/watcher/watcher.go
@@ -32,7 +32,8 @@ type Source struct {
 type Config struct {
 	// TranscriptDir is the directory to watch (e.g. ~/.claude/projects/).
 	// Tilde expansion is performed automatically.
-	// DEPRECATED: use Sources instead. Kept for single-runtime compat.
+	//
+	// Deprecated: use Sources instead. Kept for single-runtime compat.
 	TranscriptDir string
 	// ProjectDir is the absolute path of the project being watched.
 	// Used to scope ingestion to the matching transcript subdirectory.
@@ -41,7 +42,8 @@ type Config struct {
 	// MomDir is the path to .mom/ where raw/ and cursor files are written.
 	MomDir string
 	// Adapter parses runtime-specific JSONL lines.
-	// DEPRECATED: use Sources instead. Kept for single-runtime compat.
+	//
+	// Deprecated: use Sources instead. Kept for single-runtime compat.
 	Adapter Adapter
 	// Sources lists all runtime transcript directories to watch.
 	// When set, TranscriptDir and Adapter are ignored.


### PR DESCRIPTION
## Summary

- Add 4 new CI checks: `go mod tidy` validation, `go test -race`, `govulncheck` (dependency vulnerability scan), smoke test (`mom version` after build)
- Enable `gocritic`, `misspell`, and `unconvert` linters in golangci config
- Fix 6 existing lint violations surfaced by the new linters

## Test plan

- [ ] CI passes on this PR (validates the new checks work)
- [ ] `golangci-lint run ./...` returns 0 issues locally
- [ ] `go test ./...` passes (no regressions from lint fixes)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>