### PR TITLE
Add ADRs 0001-0005 and PRD 0001 for architecture deepening

### DIFF
--- a/adr/0001-adopt-harness-as-canonical-term.md
+++ b/adr/0001-adopt-harness-as-canonical-term.md
@@ -1,0 +1,12 @@
+# 0001 — Adopt "Harness" as the canonical term for AI agent frameworks
+
+MOM integrates with AI agent frameworks (Pi, Claude Code, Codex, Windsurf, Cursor, Cline, ...). The codebase and architecture docs originally called these **Runtimes** — a term overloaded in computer science (language runtime, container runtime, Go's `runtime` package) and giving no signal that the integration target is specifically an AI agent framework.
+
+We adopt **Harness** as the canonical term going forward. It is the AI-domain term of art (Pi describes itself as a "coding agent harness"; the broader ecosystem uses it for the framework around an LLM that adds tools, hooks, MCP, and prompt scaffolding). It is unambiguous in this domain and carries product-narrative leverage.
+
+## Consequences
+
+- All new code, docs, and PRs use **Harness** / `HarnessAdapter` / `harness` naming.
+- The legacy term **runtime** remains in the existing codebase and is migrated incrementally (`cli/internal/adapters/runtime/` → `cli/internal/adapters/harness/`, `RuntimeAdapter` → `HarnessAdapter`, etc.) as a separate mechanical PR.
+- Existing architecture docs (`mom-engineer/architecture/v1/glossary.md`, `11-full-architecture.md`, top-level `README.md`) are updated in the same migration PR.
+- `CONTEXT.md` flags "runtime" as the alias to avoid.

--- a/adr/0002-adapter-integration-as-optional-interfaces.md
+++ b/adr/0002-adapter-integration-as-optional-interfaces.md
@@ -1,0 +1,19 @@
+# 0002 — Adapter integration mechanisms as non-exclusive optional interfaces
+
+MOM Adapters integrate with different Harnesses (Pi, Claude Code, Codex, Windsurf, ...) using fundamentally different mechanisms: Native-tier harnesses (Pi) accept programmable extensions; Fluent and Functional-tier harnesses accept hook configuration files. A single base `Adapter` interface that required `RegisterHooks([]HookDef)` from every adapter resulted in `pi.go::RegisterHooks` ignoring its `[]HookDef` argument and writing a TypeScript extension instead — the type signature lied for one of four implementations, and adding a runtime forced edits in three places (the adapter, a free `XxxHooks()` function, and a name-keyed `HooksForRuntime(name)` switch).
+
+The base `Adapter` interface now declares only what every Harness must support: `Name()`, `Tier()`, `DetectHarness()`, `GenerateContextFile()`, `RegisterMCP()`, `GeneratedFiles()`, `GeneratedDirs()`, `GitIgnorePaths()`, `Watermark()`, and `Capabilities()`. Integration mechanisms move to optional, **non-exclusive** interfaces — `HookInstaller` for harnesses with hook systems, `ExtensionInstaller` for harnesses with extension systems. A future Harness that supports both may implement both. Callers dispatch via Go type assertion, matching the existing `ProjectScoper` precedent.
+
+## Consequences
+
+- The legacy `HooksForRuntime(name string)` lookup table and the per-adapter `DefaultHooks()`/`CodexHooks()`/`WindsurfHooks()`/`PiHooks()` free functions are deleted. Each adapter owns its hooks internally via parameterless `RegisterHooks()`.
+- The legacy `SupportsHooks() bool` method is deleted. The type assertion `_, ok := adapter.(HookInstaller)` is the support check.
+- Adding a future integration mechanism (supervisor process, native tool injection, etc.) is additive: a new optional interface, no breaking change to the base `Adapter`.
+- **Tier and interface implementation are independent.** Tier (Native / Fluent / Functional) is editorial integration-quality judgment; the optional interfaces describe install mechanics. A Functional-tier Adapter may implement `HookInstaller` (Windsurf does today). A Native-tier Adapter may implement both interfaces if its Harness gains a hook system later.
+- **Silent contract drift risk.** If `RegisterHooks` or `RegisterExtension` is renamed, the type assertion `a.(HookInstaller)` compiles successfully but stops matching at runtime, silently disabling the install. **Mitigation:** every adapter file ends with a compile-time interface check, e.g. `var _ HookInstaller = (*ClaudeAdapter)(nil)`. Same pattern adopted for `ProjectScoper` in `cli/internal/watcher/adapter_pi.go`.
+
+## Considered alternatives
+
+- **Two new methods on base `Adapter` (Flavor 1).** Each adapter would implement both, returning nil from the unused one. Rejected: forces no-op stubs and doesn't shrink the base interface.
+- **Tier-gated dispatch by caller (Flavor 3).** Caller switches on `adapter.Tier()`. Rejected: leaks tier dispatch to every call site, defeating the depth of the `Adapter` abstraction.
+- **Keep "hooks" as the umbrella concept, just consolidate the lookup (Option A from grilling).** Rejected: the type signature continues to lie for pi (`[]HookDef` is ignored). The split is editorial but worth encoding — see `CONTEXT.md` for the **Tier** rationale.

--- a/adr/0003-design-for-breakability.md
+++ b/adr/0003-design-for-breakability.md
@@ -1,0 +1,22 @@
+# 0003 — Design for breakability: modular monolith with extractable seams
+
+MOM is built as a modular monolith: single-process simplicity by default, but with seams designed so that any module can be extracted into its own service if growth demands it. The discipline is:
+
+1. **Default to single-process simplicity.** Don't introduce a service boundary unless the cost of *not* having it exceeds the cost of having it.
+2. **Treat module boundaries as if they could become service boundaries.** Even when extraction isn't planned, design so that future extraction is mechanical — not a rewrite.
+3. **Favor event-driven seams** when they fit the domain. Input → process → output, with the process being replaceable.
+4. **Coupling is paid daily; modularity is paid at extraction.** Choose the cheaper bill given expected lifetime.
+
+This is a *decision-making framework*, not a one-off architectural choice. It will recur every time we resolve a "should this be one thing or two?" question.
+
+## Examples
+
+- **ADR 0002** (adapter interfaces): Flavor 2 over Flavor 1 — optional interfaces instead of base methods — because the base stays small and focused, allowing future extraction of "integration mechanisms" as a separate service without breaking existing adapters.
+- **ADR 0004** (watcher sources): Optional `TranscriptSource` interface over base method, with joining logic at call site only — because the two registries (runtime adapters, watcher adapters) can be extracted into a unified `HarnessRegistry` service without touching either adapter type.
+
+## Consequences
+
+- Interfaces stay small and focused. New capabilities add optional interfaces rather than bloating the base.
+- Call sites handle joining logic explicitly (e.g., type assertions, name-keyed lookups). This keeps coupling explicit and extractable.
+- If a module grows large enough to warrant its own service, the extraction is mechanical: lift the joining logic into a new struct/package, add HTTP/gRPC serialization, and wire the event-driven seam.
+- The monolith stays simple until complexity demands otherwise.

--- a/adr/0004-transcript-source-as-optional-interface.md
+++ b/adr/0004-transcript-source-as-optional-interface.md
@@ -1,0 +1,23 @@
+# 0003 — Design for breakability: modular monolith with extractable seams
+
+MOM is built as a modular monolith: single-process simplicity by default, but with seams designed so that any module can be extracted into its own service if growth demands it. The discipline is:
+
+1. **Default to single-process simplicity.** Don't introduce a service boundary unless the cost of *not* having it exceeds the cost of having it.
+2. **Treat module boundaries as if they could become service boundaries.** Even when extraction isn't planned, design so that future extraction is mechanical — not a rewrite.
+3. **Favor event-driven seams** when they fit the domain. Input → process → output, with the process being replaceable.
+4. **Coupling is paid daily; modularity is paid at extraction.** Choose the cheaper bill given expected lifetime.
+
+This is a *decision-making framework*, not a one-off architectural choice. It will recur every time we resolve a "should this be one thing or two?" question.
+
+## Examples
+
+- **ADR 0002** (adapter interfaces): Flavor 2 over Flavor 1 — optional interfaces instead of base methods — because the base stays small and focused, allowing future extraction of "integration mechanisms" as a separate service without breaking existing adapters.
+- **ADR 0004** (watcher sources): Optional `TranscriptSource` interface over base method, with joining logic at call site only — because the two registries (runtime adapters, watcher adapters) can be extracted into a unified `HarnessRegistry` service without touching either adapter type.
+
+## Consequences
+
+- Interfaces stay small and focused. New capabilities add optional interfaces rather than bloating the base.
+- Call sites handle joining logic explicitly (e.g., type assertions, name-keyed lookups). This keeps coupling explicit and extractable.
+- If a module grows large enough to warrant its own service, the extraction is mechanical: lift the joining logic into a new struct/package, add HTTP/gRPC serialization, and wire the event-driven seam.
+- The monolith stays simple until complexity demands otherwise.</content>
+<parameter name="path">/Users/vmarino/Github/mom/mom/adr/0003-design-for-breakability.md

--- a/adr/0005-tool-categorization-as-optional-interface.md
+++ b/adr/0005-tool-categorization-as-optional-interface.md
@@ -1,0 +1,18 @@
+# 0005 — Tool categorization as optional interface on watcher.Adapter
+
+Tool names (e.g., "git", "run_terminal_cmd") come from harness transcripts; categorization buckets them into logbook categories ("git", "search", "mcp", "agentic", "other"). The categorization logic is harness-specific ("what tools does my harness expose") but lived separately: a switch in `cli/internal/logbook/logbook.go::categorizeTool`, a near-duplicate in `cli/internal/adapters/runtime/adapter_pi.go::toolCategory`, and tests in `cli/internal/adapters/runtime/capabilities_test.go::TestCategorizeTool`. Adding a tool in pi required edits in three places.
+
+Tool categorization moves to an optional interface on `watcher.Adapter` (the runtime-time parser that already handles harness-specific transcript parsing). Adapters that expose tools implement `ToolCategorizer`; adapters that don't (transcript-only) simply don't satisfy the interface. The logbook's switch becomes a fallback for unknown tools.
+
+## Consequences
+
+- The duplicate switches in `adapter_pi.go` and `capabilities_test.go` are deleted. Tool additions in pi now require only one edit: implement `CategorizeTool` on the pi watcher adapter.
+- The logbook's `categorizeTool` becomes a fallback: if the watcher adapter implements `ToolCategorizer` and returns a non-empty category, use it; else fall back to the existing switch.
+- **Fits the breakability principle (ADR 0003).** If watcher logic extracts to its own service, tool categorization goes with it.
+- **Symmetric with existing watcher adapter capabilities.** Watcher adapters already have harness-specific parsing logic (`ParseLine`, `ProjectScoper`, `SessionParser`). Categorization joins them.
+- Adding a new tool category is harness-local: the watcher adapter defines it.
+
+## Considered alternatives
+
+- **Method on base `watcher.Adapter` (D1).** Rejected: forces every watcher adapter (even transcript-only ones) to implement it, returning empty or "other".
+- **ToolCategorizer on `runtime.Adapter` (D2).** Rejected: violates breakability (runtime adapters are install-time; tool knowledge belongs with runtime-time watcher logic).

--- a/prd/0001-deepen-mom-architecture.md
+++ b/prd/0001-deepen-mom-architecture.md
@@ -1,0 +1,73 @@
+## Problem Statement
+
+As MOM's codebase grows with support for more AI harnesses (Pi, Claude Code, Codex, Windsurf, etc.), adding new harnesses or features (hooks, extensions, tools) requires repetitive, error-prone edits across multiple files (e.g., switches, lookups, tests). This friction slows development, introduces bugs, and violates the principle of harness-agnostic design — MOM should be extensible without touching core logic for each new harness.
+
+From the user's perspective: "We need to make MOM more harness-agnostic and reduce the coupling so adding a new harness doesn't require touching N files."
+
+## Solution
+
+Refactor MOM's harness integration architecture to use optional, non-exclusive interfaces and centralized knowledge ownership. This makes harness-specific logic opt-in and breakable into separate services if needed, while keeping the monolith simple today. The solution addresses four architectural friction points identified via the `improve-codebase-architecture` skill, documented in ADRs 0001-0005.
+
+From the user's perspective: MOM becomes a flexible, harness-agnostic memory layer where new harnesses "just work" with minimal code changes, and the architecture supports future extraction (e.g., watcher as a microservice) without rewrites.
+
+## User Stories
+
+1. As a MOM developer, I want to add a new harness (e.g., Cursor or Cline) without editing switches in `logbook.go`, `watch.go`, or adapter files, so that I can ship faster and reduce bugs.
+2. As a MOM developer, I want harness-specific integration mechanisms (hooks, extensions, transcripts) to be opt-in and non-exclusive, so that a harness can use multiple methods (e.g., hooks + extensions) without interface conflicts.
+3. As a MOM developer, I want tool categorization to live with the harness's watcher adapter, so that adding a new tool in Pi only requires editing one file, and the logbook provides a fallback for unknown tools.
+4. As a MOM developer, I want the codebase to use "Harness" as the canonical term instead of "Runtime", so that the vocabulary aligns with the AI domain and reduces confusion.
+5. As a MOM developer, I want the architecture designed for breakability (modular monolith with extractable seams), so that if a module (e.g., watcher) grows large, it can be extracted into its own service without rewriting adapters.
+6. As a MOM user (developer using MOM), I want better harness support (e.g., Native-tier extensibility in Pi, Fluent-tier hooks in Claude), so that MOM integrates more deeply with my preferred AI harness and captures more knowledge automatically.
+7. As a MOM maintainer, I want ADRs documenting architectural decisions in `/adr/`, so that future contributors understand the why behind interfaces and tiering without guessing.
+8. As a MOM contributor, I want CONTEXT.md to define domain terms (Harness, Adapter, Tier), so that PRs use consistent vocabulary and discussions stay aligned.
+9. As a MOM developer, I want compile-time checks for optional interfaces, so that silent contract drift (e.g., renaming `RegisterHooks`) is caught at build time.
+10. As a MOM user, I want `mom doctor` to surface harness tiers and capabilities clearly, so that I can understand why certain features work in Pi but not in Windsurf.
+11. As a MOM developer, I want the watcher source assembly (harness name, transcript dir, adapter) to be owned by the runtime adapter but joinable at call sites, so that adding a harness requires only one edit, and the logic is extractable to a registry service later.
+12. As a MOM user, I want fallback mechanisms (e.g., MCP when transcripts change to SQLite), so that MOM remains robust as harness architectures evolve.
+13. As a MOM developer, I want optional interfaces for capabilities like `HookInstaller`, `ExtensionInstaller`, `TranscriptSource`, `ToolCategorizer`, so that the base `Adapter` stays small and focused on universal harness facts.
+14. As a MOM maintainer, I want the codebase to migrate from "runtime" to "harness" terminology incrementally, so that docs, types, and directories align with the new canonical term.
+15. As a MOM contributor, I want the tier system (Native / Fluent / Functional) to be editorial and independent of interface implementation, so that a Functional harness can still support hooks without becoming Fluent.
+16. As a MOM user, I want MOM to be harness-agnostic, meaning it adapts to how each harness works (hooks, extensions, MCP, transcripts), so that I can switch harnesses without losing memory functionality.
+17. As a MOM developer, I want the logbook's tool categorization to fall back to a default switch, so that unknown tools are categorized as "other" without breaking.
+18. As a MOM contributor, I want ADRs to include consequences and alternatives, so that decisions are reversible and context is preserved.
+19. As a MOM developer, I want the architecture to favor event-driven seams (input → process → output), so that modules can be replaced or extracted easily.
+20. As a MOM maintainer, I want all ADRs numbered sequentially in `/adr/`, so that the decision history is linear and searchable.
+
+## Implementation Decisions
+
+- Adopt "Harness" as canonical term (ADR 0001); migrate codebase incrementally (e.g., `cli/internal/adapters/runtime/` → `harness/`, types renamed).
+- Base `Adapter` interface shrinks to universal harness facts (Name, Tier, DetectHarness, GenerateContextFile, RegisterMCP, GeneratedFiles/Dirs, GitIgnorePaths, Watermark, Capabilities); integration mechanisms become optional interfaces (HookInstaller, ExtensionInstaller, TranscriptSource, ToolCategorizer).
+- Tier (Native / Fluent / Functional) declared via `Tier() Tier` method; editorial judgment independent of interface implementation.
+- Watcher source assembly owned by runtime adapter via optional `TranscriptSource` interface; joining logic at call sites (name-keyed lookups) for breakability.
+- Tool categorization owned by watcher adapter via optional `ToolCategorizer`; logbook provides fallback.
+- Design for breakability (ADR 0003): optional interfaces over base methods, explicit joining at call sites, no hard dependencies that block future extraction.
+- Compile-time interface checks (e.g., `var _ HookInstaller = (*PiAdapter)(nil)`) to prevent silent contract drift.
+- ADRs in `/adr/` at repo root, minimal template (title + 1-3 sentences + consequences + alternatives).
+- CONTEXT.md created lazily with domain terms; updated as terms resolve.
+
+## Testing Decisions
+
+A good test focuses on external behavior, not implementation details — e.g., "does the adapter register hooks when implemented?" not "does this internal method return true?"
+
+Modules to test:
+- New optional interfaces: Test that adapters implementing them (e.g., Pi for ExtensionInstaller) behave correctly, and adapters not implementing them don't break (type assertions return false).
+- Tier declaration: Test `adapter.Tier()` returns expected values (Pi = Native, Claude = Fluent, Windsurf = Functional).
+- Watcher source assembly: Test that call sites (watch.go, watch_helpers.go) correctly assemble sources from adapters with/without TranscriptSource.
+- Tool categorization: Test watcher adapters with ToolCategorizer override logbook fallback; test unknown tools fall back to "other".
+- Breakability: No specific tests, but ensure no hard imports that would block extraction (e.g., runtime package doesn't import watcher types directly).
+- Harness rename: Tests updated to use new terminology, but behavior unchanged.
+
+Prior art: Existing tests like `capabilities_test.go::TestCategorizeTool` (update to new interface); `adapter_pi_test.go` for extension registration.
+
+## Out of Scope
+
+- Implementation of fallback mechanisms (e.g., MCP when transcripts change to SQLite) — acknowledged as future need but not built now.
+- Full codebase migration to "Harness" (mechanical PR separate from this).
+- New harness additions (e.g., Cursor) — this is the enabling architecture.
+- User-facing features beyond better integration (e.g., new memory types).
+- Extraction of modules into services (design for it, but don't do it).
+- Changes to MRP events or memory schemas.
+
+## Further Notes
+
+This PRD synthesizes the conversation's ADRs into an implementable plan. The goal is harness-agnostic extensibility without over-engineering. If modules don't match expectations, adjust before slicing into issues. For testing, focus on adapters with optional interfaces; no need for full integration tests yet. Reference ADRs 0001-0005 for detailed rationale.


### PR DESCRIPTION
Documents the architectural decisions for deepening MOM's codebase via optional interfaces, harness terminology, and breakability principles. See individual files for details.