### PR TITLE
feat(harness): add Tier enum and method on Adapter interface (#177)

### DIFF
--- a/cli/internal/adapters/harness/claude.go
+++ b/cli/internal/adapters/harness/claude.go
@@ -29,6 +29,10 @@ func (a *ClaudeAdapter) Name() string {
 	return "claude"
 }
 
+func (a *ClaudeAdapter) Tier() Tier {
+	return Fluent
+}
+
 func (a *ClaudeAdapter) GenerateContextFile(config Config, constraints []Constraint, skills []Skill, identity *Identity) error {
 	claudeDir := filepath.Join(a.projectRoot, ".claude")
 	if err := os.MkdirAll(claudeDir, 0755); err != nil {

--- a/cli/internal/adapters/harness/codex.go
+++ b/cli/internal/adapters/harness/codex.go
@@ -29,6 +29,10 @@ func (a *CodexAdapter) Name() string {
 	return "codex"
 }
 
+func (a *CodexAdapter) Tier() Tier {
+	return Fluent
+}
+
 func (a *CodexAdapter) GenerateContextFile(config Config, constraints []Constraint, skills []Skill, identity *Identity) error {
 	var body string
 	if config.Delivery == "context-file" {

--- a/cli/internal/adapters/harness/harness.go
+++ b/cli/internal/adapters/harness/harness.go
@@ -68,6 +68,32 @@ type AdapterCapability struct {
 	Experimental []string `yaml:"experimental"`
 }
 
+// Tier classifies a Harness's integration quality with MOM.
+type Tier int
+
+const (
+	// Functional integration: minimal surface, automation may be unreliable.
+	Functional Tier = iota
+	// Fluent integration: standard idioms (hooks, settings files), good fidelity.
+	Fluent
+	// Native integration: programmable extensibility, full feature exposure.
+	Native
+)
+
+// String returns the lowercase tier name.
+func (t Tier) String() string {
+	switch t {
+	case Native:
+		return "native"
+	case Fluent:
+		return "fluent"
+	case Functional:
+		return "functional"
+	default:
+		return "unknown"
+	}
+}
+
 // HookDef defines a hook to register with the Harness.
 type HookDef struct {
 	Event   string // e.g. "PostToolUse"
@@ -81,6 +107,9 @@ type HookDef struct {
 type Adapter interface {
 	// Name returns the Harness identifier (e.g. "claude", "codex", "windsurf").
 	Name() string
+
+	// Tier returns the Harness's integration quality classification.
+	Tier() Tier
 
 	// GenerateContextFile generates the Harness's boot file
 	// (e.g. CLAUDE.md, AGENTS.md) from MOM's config,

--- a/cli/internal/adapters/harness/pi.go
+++ b/cli/internal/adapters/harness/pi.go
@@ -37,6 +37,8 @@ func NewPiAdapter(projectRoot string) *PiAdapter {
 
 func (a *PiAdapter) Name() string { return "pi" }
 
+func (a *PiAdapter) Tier() Tier { return Native }
+
 func (a *PiAdapter) GenerateContextFile(config Config, constraints []Constraint, skills []Skill, identity *Identity) error {
 	var body string
 	if config.Delivery == "context-file" {

--- a/cli/internal/adapters/harness/tier_test.go
+++ b/cli/internal/adapters/harness/tier_test.go
@@ -1,0 +1,40 @@
+package harness
+
+import "testing"
+
+func TestAdapterTiers(t *testing.T) {
+	cases := []struct {
+		name    string
+		adapter Adapter
+		want    Tier
+	}{
+		{"pi", NewPiAdapter(""), Native},
+		{"claude", NewClaudeAdapter(""), Fluent},
+		{"codex", NewCodexAdapter(""), Fluent},
+		{"windsurf", NewWindsurfAdapter(""), Functional},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.adapter.Tier(); got != c.want {
+				t.Errorf("%s.Tier() = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTierString(t *testing.T) {
+	cases := []struct {
+		tier Tier
+		want string
+	}{
+		{Native, "native"},
+		{Fluent, "fluent"},
+		{Functional, "functional"},
+		{Tier(99), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.tier.String(); got != c.want {
+			t.Errorf("Tier(%d).String() = %q, want %q", c.tier, got, c.want)
+		}
+	}
+}

--- a/cli/internal/adapters/harness/windsurf.go
+++ b/cli/internal/adapters/harness/windsurf.go
@@ -28,6 +28,10 @@ func (a *WindsurfAdapter) Name() string {
 	return "windsurf"
 }
 
+func (a *WindsurfAdapter) Tier() Tier {
+	return Functional
+}
+
 func (a *WindsurfAdapter) GenerateContextFile(config Config, constraints []Constraint, skills []Skill, identity *Identity) error {
 	rulesDir := filepath.Join(a.projectRoot, ".windsurf", "rules")
 	if err := os.MkdirAll(rulesDir, 0755); err != nil {


### PR DESCRIPTION
Closes #177.

## Summary

Adds the **Tier** classification primitive to the Harness Adapter interface, per [ADR 0002](https://github.com/momhq/mom/blob/main/adr/0002-adapter-integration-as-optional-interfaces.md) and the Tier vocabulary in CONTEXT.md.

## Changes

- New `Tier` enum in the `harness` package: `Functional`, `Fluent`, `Native` (declared in iota order from least to most extensible).
- New `Tier() Tier` method on the base `Adapter` interface.
- `String()` method returns lowercase tier name (`"native"`, `"fluent"`, `"functional"`, `"unknown"`).
- All 4 existing adapters implement `Tier()`:
  - `PiAdapter` → `Native`
  - `ClaudeAdapter` → `Fluent`
  - `CodexAdapter` → `Fluent`
  - `WindsurfAdapter` → `Functional`
- Added `tier_test.go` with `TestAdapterTiers` (table-driven, 4 adapters) and `TestTierString` (4 cases including unknown).

## Verification

- `go build ./...` passes
- `go test ./...` passes (except pre-existing unrelated `TestLiveMemoryFiles`)
- New tests pass (5/5 subcases)

## Refs

- Closes #177
- Implements Tier as defined in [ADR 0002](https://github.com/momhq/mom/blob/main/adr/0002-adapter-integration-as-optional-interfaces.md)
- Part of [PRD 0001](https://github.com/momhq/mom/blob/main/prd/0001-deepen-mom-architecture.md)