### PR TITLE
feat(harness,watcher): define optional integration interfaces (#178)

### DIFF
--- a/cli/internal/adapters/harness/harness.go
+++ b/cli/internal/adapters/harness/harness.go
@@ -150,6 +150,26 @@ type Adapter interface {
 	RegisterMCP() error
 }
 
+// HookInstaller is optionally implemented by adapters whose Harness has a
+// hook system. The adapter owns its hook list internally.
+type HookInstaller interface {
+	RegisterHooks() error
+}
+
+// ExtensionInstaller is optionally implemented by adapters whose Harness
+// supports loadable extensions.
+type ExtensionInstaller interface {
+	RegisterExtension() error
+}
+
+// TranscriptSource is optionally implemented by adapters whose Harness
+// emits a transcript file or directory the watcher should tail.
+type TranscriptSource interface {
+	// DefaultTranscriptDir returns the path (tilde-expanded if needed) where
+	// the Harness writes transcripts. Empty string means none.
+	DefaultTranscriptDir() string
+}
+
 // HooksForHarness returns the standard MOM hooks for the given Harness name.
 func HooksForHarness(name string) []HookDef {
 	switch name {

--- a/cli/internal/watcher/adapter.go
+++ b/cli/internal/watcher/adapter.go
@@ -36,6 +36,14 @@ type ProjectFilter interface {
 	BelongsToProject(path string) bool
 }
 
+// ToolCategorizer is optionally implemented by adapters that know how to
+// bucket their Harness's tool names into logbook categories. Falls back to
+// logbook.categorizeTool when not implemented or when an empty string is
+// returned for an unknown tool.
+type ToolCategorizer interface {
+	CategorizeTool(toolName string) string
+}
+
 // ProjectScoper is optionally implemented by adapters whose runtime uses a
 // non-default project-slug convention for its per-project transcript
 // subdirectory. The default convention (claude/codex) is


### PR DESCRIPTION
Closes #178.

## Summary

Adds the four optional interfaces from [ADR 0002](https://github.com/momhq/mom/blob/main/adr/0002-adapter-integration-as-optional-interfaces.md), [ADR 0004](https://github.com/momhq/mom/blob/main/adr/0004-transcript-source-as-optional-interface.md), and [ADR 0005](https://github.com/momhq/mom/blob/main/adr/0005-tool-categorization-as-optional-interface.md). **Additive only** — no removals from base `Adapter`. Adapter implementations come in #179, call-site migration and base cleanup in #180.

## Changes

In `cli/internal/adapters/harness/harness.go`:
- `HookInstaller` — `RegisterHooks() error` (parameterless; adapter owns its hook list)
- `ExtensionInstaller` — `RegisterExtension() error`
- `TranscriptSource` — `DefaultTranscriptDir() string`

In `cli/internal/watcher/adapter.go`:
- `ToolCategorizer` — `CategorizeTool(toolName string) string`

## Verification

- `go build ./...` passes
- `go test ./...` passes (except pre-existing `TestLiveMemoryFiles`)
- Diff: +28 lines / 2 files

## Refs

- Closes #178
- Defines interfaces from [ADR 0002](https://github.com/momhq/mom/blob/main/adr/0002-adapter-integration-as-optional-interfaces.md), [ADR 0004](https://github.com/momhq/mom/blob/main/adr/0004-transcript-source-as-optional-interface.md), [ADR 0005](https://github.com/momhq/mom/blob/main/adr/0005-tool-categorization-as-optional-interface.md)
- Part of [PRD 0001](https://github.com/momhq/mom/blob/main/prd/0001-deepen-mom-architecture.md)