### PR TITLE
feat(harness,watcher): adopt optional interfaces, drop legacy hook API (#179, #180)

### DIFF
--- a/cli/internal/adapters/harness/claude.go
+++ b/cli/internal/adapters/harness/claude.go
@@ -55,11 +55,16 @@ func (a *ClaudeAdapter) GenerateContextFile(config Config, constraints []Constra
 	return nil
 }
 
-func (a *ClaudeAdapter) SupportsHooks() bool {
-	return true
+// DefaultTranscriptDir returns Claude Code's transcript directory.
+func (a *ClaudeAdapter) DefaultTranscriptDir() string {
+	return "~/.claude/projects/"
 }
 
-func (a *ClaudeAdapter) RegisterHooks(hooks []HookDef) error {
+func (a *ClaudeAdapter) RegisterHooks() error {
+	hooks := []HookDef{
+		{Event: "Stop", Command: "mom draft"},
+		{Event: "SessionEnd", Command: "mom draft"},
+	}
 	claudeDir := filepath.Join(a.projectRoot, ".claude")
 	settingsPath := filepath.Join(claudeDir, "settings.json")
 
@@ -118,24 +123,6 @@ func (a *ClaudeAdapter) RegisterHooks(hooks []HookDef) error {
 	}
 
 	return nil
-}
-
-// DefaultHooks returns the standard MOM hooks for Claude Code.
-// Recording is handled by `mom watch` (filesystem watcher) — no record hook needed.
-// Stop → mom draft: processes drafts after each response (continuous mode, 1-response lag).
-// SessionEnd → mom draft: fallback to draft the last response when the
-// session closes — covers abrupt exits and final decisions.
-func DefaultHooks() []HookDef {
-	return []HookDef{
-		{
-			Event:   "Stop",
-			Command: "mom draft",
-		},
-		{
-			Event:   "SessionEnd",
-			Command: "mom draft",
-		},
-	}
 }
 
 func (a *ClaudeAdapter) DetectHarness() bool {
@@ -207,6 +194,11 @@ func (a *ClaudeAdapter) Capabilities() AdapterCapability {
 	}
 	return cap
 }
+
+var (
+	_ HookInstaller    = (*ClaudeAdapter)(nil)
+	_ TranscriptSource = (*ClaudeAdapter)(nil)
+)
 
 // HasWatermark checks if a file contains the MOM watermark (or the legacy L.E.O. watermark).
 func HasWatermark(path string) bool {

--- a/cli/internal/adapters/harness/claude_test.go
+++ b/cli/internal/adapters/harness/claude_test.go
@@ -15,13 +15,6 @@ func TestClaudeAdapter_Name(t *testing.T) {
 	}
 }
 
-func TestClaudeAdapter_SupportsHooks(t *testing.T) {
-	a := NewClaudeAdapter("/tmp/test")
-	if !a.SupportsHooks() {
-		t.Error("expected SupportsHooks to be true")
-	}
-}
-
 func TestClaudeAdapter_DetectHarness(t *testing.T) {
 	dir := t.TempDir()
 
@@ -206,71 +199,10 @@ func TestClaudeAdapter_GenerateContextFile_CommunicationModes(t *testing.T) {
 
 func TestClaudeAdapter_RegisterHooks(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, ".claude"), 0755)
 	a := NewClaudeAdapter(dir)
 
-	hooks := []HookDef{
-		{Event: "PostToolUse", Matcher: "Write", Command: "validate.sh"},
-	}
-
-	if err := a.RegisterHooks(hooks); err != nil {
+	if err := a.RegisterHooks(); err != nil {
 		t.Fatalf("RegisterHooks failed: %v", err)
-	}
-
-	content, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
-	if err != nil {
-		t.Fatalf("reading settings.json: %v", err)
-	}
-
-	// Verify Claude Code hooks format: { "hooks": { "Event": [ { "matcher": "...", "hooks": [...] } ] } }
-	var settings map[string]any
-	if err := json.Unmarshal(content, &settings); err != nil {
-		t.Fatalf("parsing settings.json: %v", err)
-	}
-
-	hooksMap, ok := settings["hooks"].(map[string]any)
-	if !ok {
-		t.Fatal("hooks should be a map keyed by event name")
-	}
-
-	postToolUse, ok := hooksMap["PostToolUse"].([]any)
-	if !ok {
-		t.Fatal("hooks.PostToolUse should be an array")
-	}
-	if len(postToolUse) != 1 {
-		t.Fatalf("expected 1 matcher group, got %d", len(postToolUse))
-	}
-
-	group, ok := postToolUse[0].(map[string]any)
-	if !ok {
-		t.Fatal("matcher group should be a map")
-	}
-	if group["matcher"] != "Write" {
-		t.Errorf("expected matcher 'Write', got %v", group["matcher"])
-	}
-
-	innerHooks, ok := group["hooks"].([]any)
-	if !ok || len(innerHooks) == 0 {
-		t.Fatal("matcher group should have a hooks array")
-	}
-	hookEntry, ok := innerHooks[0].(map[string]any)
-	if !ok {
-		t.Fatal("hook entry should be a map")
-	}
-	if hookEntry["type"] != "command" {
-		t.Errorf("expected type 'command', got %v", hookEntry["type"])
-	}
-	if hookEntry["command"] != "validate.sh" {
-		t.Errorf("expected command 'validate.sh', got %v", hookEntry["command"])
-	}
-}
-
-func TestClaudeAdapter_RegisterHooks_DefaultHooks(t *testing.T) {
-	dir := t.TempDir()
-	a := NewClaudeAdapter(dir)
-
-	if err := a.RegisterHooks(DefaultHooks()); err != nil {
-		t.Fatalf("RegisterHooks with defaults failed: %v", err)
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))

--- a/cli/internal/adapters/harness/codex.go
+++ b/cli/internal/adapters/harness/codex.go
@@ -50,11 +50,11 @@ func (a *CodexAdapter) GenerateContextFile(config Config, constraints []Constrai
 	return nil
 }
 
-func (a *CodexAdapter) SupportsHooks() bool {
-	return true
-}
-
-func (a *CodexAdapter) RegisterHooks(hooks []HookDef) error {
+func (a *CodexAdapter) RegisterHooks() error {
+	hooks := []HookDef{
+		{Event: "Stop", Command: "mom record"},
+		{Event: "Stop", Command: "mom draft"},
+	}
 	codexDir := filepath.Join(a.projectRoot, ".codex")
 	hooksPath := filepath.Join(codexDir, "hooks.json")
 
@@ -95,15 +95,6 @@ func (a *CodexAdapter) RegisterHooks(hooks []HookDef) error {
 	}
 
 	return nil
-}
-
-// CodexHooks returns the standard MOM hooks for Codex.
-// Stop → mom record + mom draft: continuous mode (1-response lag).
-func CodexHooks() []HookDef {
-	return []HookDef{
-		{Event: "Stop", Command: "mom record"},
-		{Event: "Stop", Command: "mom draft"},
-	}
 }
 
 // RegisterMCP writes MOM's MCP server entry to both the project-level .mcp.json
@@ -210,3 +201,5 @@ func (a *CodexAdapter) Capabilities() AdapterCapability {
 	}
 	return cap
 }
+
+var _ HookInstaller = (*CodexAdapter)(nil)

--- a/cli/internal/adapters/harness/codex_test.go
+++ b/cli/internal/adapters/harness/codex_test.go
@@ -82,18 +82,11 @@ func TestCodexAdapter_GenerateContextFileWatermark(t *testing.T) {
 	}
 }
 
-func TestCodexAdapter_SupportsHooks(t *testing.T) {
-	a := NewCodexAdapter("/tmp/test")
-	if !a.SupportsHooks() {
-		t.Error("expected SupportsHooks to be true")
-	}
-}
-
 func TestCodexAdapter_RegisterHooks(t *testing.T) {
 	dir := t.TempDir()
 	a := NewCodexAdapter(dir)
 
-	if err := a.RegisterHooks(CodexHooks()); err != nil {
+	if err := a.RegisterHooks(); err != nil {
 		t.Fatalf("RegisterHooks failed: %v", err)
 	}
 

--- a/cli/internal/adapters/harness/harness.go
+++ b/cli/internal/adapters/harness/harness.go
@@ -116,12 +116,6 @@ type Adapter interface {
 	// constraints, skills, and identity.
 	GenerateContextFile(config Config, constraints []Constraint, skills []Skill, identity *Identity) error
 
-	// SupportsHooks returns whether this Harness supports hooks.
-	SupportsHooks() bool
-
-	// RegisterHooks registers hooks with the Harness if supported.
-	RegisterHooks(hooks []HookDef) error
-
 	// DetectHarness checks whether this Harness is present in the project.
 	DetectHarness() bool
 
@@ -170,18 +164,4 @@ type TranscriptSource interface {
 	DefaultTranscriptDir() string
 }
 
-// HooksForHarness returns the standard MOM hooks for the given Harness name.
-func HooksForHarness(name string) []HookDef {
-	switch name {
-	case "claude":
-		return DefaultHooks()
-	case "codex":
-		return CodexHooks()
-	case "windsurf":
-		return WindsurfHooks()
-	case "pi":
-		return PiHooks()
-	default:
-		return DefaultHooks()
-	}
-}
+

--- a/cli/internal/adapters/harness/pi.go
+++ b/cli/internal/adapters/harness/pi.go
@@ -57,21 +57,13 @@ func (a *PiAdapter) GenerateContextFile(config Config, constraints []Constraint,
 	return nil
 }
 
-func (a *PiAdapter) SupportsHooks() bool {
-	// Pi has no native hook system, but RegisterHooks installs an extension
-	// that fulfills the same architectural role (wiring Harness → MOM).
-	return true
+// DefaultTranscriptDir returns pi's session transcript directory.
+func (a *PiAdapter) DefaultTranscriptDir() string {
+	return "~/.pi/agent/sessions/"
 }
 
-// RegisterHooks lays down pi extensions that integrate MOM. Pi has no
-// equivalent of Claude/Codex/Windsurf hook config; the extension model is
-// how pi gets extended at runtime, so MOM's "hook" for pi is an embedded
-// TypeScript extension dropped into .pi/extensions/.
-//
-// The hooks []HookDef parameter is accepted for interface compatibility
-// but is not used — pi does not run shell commands per event. Use
-// PiHooks() (returns nil) when invoking from init.go.
-func (a *PiAdapter) RegisterHooks(_ []HookDef) error {
+// RegisterExtension lays down the MOM TypeScript extension in .pi/extensions/.
+func (a *PiAdapter) RegisterExtension() error {
 	extDir := filepath.Join(a.projectRoot, ".pi", "extensions")
 	if err := os.MkdirAll(extDir, 0755); err != nil {
 		return fmt.Errorf("creating .pi/extensions dir: %w", err)
@@ -81,13 +73,6 @@ func (a *PiAdapter) RegisterHooks(_ []HookDef) error {
 	if err := os.WriteFile(target, piMomToolsExtension, 0644); err != nil {
 		return fmt.Errorf("writing %s: %w", target, err)
 	}
-	return nil
-}
-
-// PiHooks returns the standard MOM hooks for pi. Pi has no hook system,
-// so this returns nil; RegisterHooks ignores its argument and lays down
-// the embedded extension instead.
-func PiHooks() []HookDef {
 	return nil
 }
 
@@ -137,3 +122,8 @@ func (a *PiAdapter) Capabilities() AdapterCapability {
 	}
 	return cap
 }
+
+var (
+	_ ExtensionInstaller = (*PiAdapter)(nil)
+	_ TranscriptSource   = (*PiAdapter)(nil)
+)

--- a/cli/internal/adapters/harness/pi_test.go
+++ b/cli/internal/adapters/harness/pi_test.go
@@ -70,14 +70,12 @@ func TestPiAdapter_GenerateContextFile_MinimalDelivery(t *testing.T) {
 	}
 }
 
-func TestPiAdapter_RegisterHooks_LaysDownExtension(t *testing.T) {
+func TestPiAdapter_RegisterExtension_LaysDownExtension(t *testing.T) {
 	dir := t.TempDir()
 	a := NewPiAdapter(dir)
 
-	// Hooks parameter is ignored — pi has no hook system. Pass PiHooks()
-	// to mirror how init.go invokes the adapter.
-	if err := a.RegisterHooks(PiHooks()); err != nil {
-		t.Fatalf("RegisterHooks: %v", err)
+	if err := a.RegisterExtension(); err != nil {
+		t.Fatalf("RegisterExtension: %v", err)
 	}
 
 	target := filepath.Join(dir, ".pi", "extensions", "mom-tools.ts")
@@ -104,15 +102,15 @@ func TestPiAdapter_RegisterHooks_LaysDownExtension(t *testing.T) {
 	}
 }
 
-func TestPiAdapter_RegisterHooks_Idempotent(t *testing.T) {
+func TestPiAdapter_RegisterExtension_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 	a := NewPiAdapter(dir)
 
-	if err := a.RegisterHooks(nil); err != nil {
-		t.Fatalf("first RegisterHooks: %v", err)
+	if err := a.RegisterExtension(); err != nil {
+		t.Fatalf("first RegisterExtension: %v", err)
 	}
-	if err := a.RegisterHooks(nil); err != nil {
-		t.Fatalf("second RegisterHooks: %v", err)
+	if err := a.RegisterExtension(); err != nil {
+		t.Fatalf("second RegisterExtension: %v", err)
 	}
 
 	// Second call should overwrite cleanly with identical content.
@@ -276,15 +274,3 @@ func TestPiAdapter_Watermark(t *testing.T) {
 // other adapters' capability tests — keeping the cross-Harness contract
 // (Supports vs Experimental, no overlap) in one place.
 
-func TestPiAdapter_SupportsHooks(t *testing.T) {
-	a := NewPiAdapter("/tmp/x")
-	if !a.SupportsHooks() {
-		t.Error("pi adapter should report SupportsHooks=true (extension lay-down)")
-	}
-}
-
-func TestPiHooks_IsNil(t *testing.T) {
-	if h := PiHooks(); h != nil {
-		t.Errorf("PiHooks() should return nil (pi has no hook system); got %v", h)
-	}
-}

--- a/cli/internal/adapters/harness/windsurf.go
+++ b/cli/internal/adapters/harness/windsurf.go
@@ -56,11 +56,15 @@ func (a *WindsurfAdapter) GenerateContextFile(config Config, constraints []Const
 	return nil
 }
 
-func (a *WindsurfAdapter) SupportsHooks() bool {
-	return true
+// DefaultTranscriptDir returns Windsurf's transcript directory.
+func (a *WindsurfAdapter) DefaultTranscriptDir() string {
+	return "~/.windsurf/transcripts/"
 }
 
-func (a *WindsurfAdapter) RegisterHooks(hooks []HookDef) error {
+func (a *WindsurfAdapter) RegisterHooks() error {
+	hooks := []HookDef{
+		{Event: "post_cascade_response_with_transcript", Command: "mom draft"},
+	}
 	windsurfDir := filepath.Join(a.projectRoot, ".windsurf")
 	if err := os.MkdirAll(windsurfDir, 0755); err != nil {
 		return fmt.Errorf("creating .windsurf dir: %w", err)
@@ -92,19 +96,6 @@ func (a *WindsurfAdapter) RegisterHooks(hooks []HookDef) error {
 		return fmt.Errorf("writing hooks.json: %w", err)
 	}
 	return nil
-}
-
-// WindsurfHooks returns the standard MOM hooks for Windsurf.
-//
-// Recording is handled by the filesystem watcher (mom watch --runtime windsurf),
-// which reads ~/.windsurf/transcripts/ directly. The mom record hook is intentionally
-// omitted to avoid the 25-fires-per-turn problem and explosive raw data growth (#145).
-//
-// Only mom draft is retained so the drafter pipeline runs after each turn.
-func WindsurfHooks() []HookDef {
-	return []HookDef{
-		{Event: "post_cascade_response_with_transcript", Command: "mom draft"},
-	}
 }
 
 func (a *WindsurfAdapter) DetectHarness() bool {
@@ -203,3 +194,8 @@ func (a *WindsurfAdapter) Capabilities() AdapterCapability {
 	}
 	return cap
 }
+
+var (
+	_ HookInstaller    = (*WindsurfAdapter)(nil)
+	_ TranscriptSource = (*WindsurfAdapter)(nil)
+)

--- a/cli/internal/adapters/harness/windsurf_test.go
+++ b/cli/internal/adapters/harness/windsurf_test.go
@@ -84,7 +84,7 @@ func TestWindsurfAdapter_RegisterHooks(t *testing.T) {
 	dir := t.TempDir()
 	a := NewWindsurfAdapter(dir)
 
-	if err := a.RegisterHooks(WindsurfHooks()); err != nil {
+	if err := a.RegisterHooks(); err != nil {
 		t.Fatalf("RegisterHooks failed: %v", err)
 	}
 

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -311,15 +311,20 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 				return
 			}
 
-			// Register MCP server config and hooks. The Adapter interface
-			// covers all Harnesses uniformly; each adapter knows its own hook
-			// set via HooksForHarness(name).
+			// Register MCP, then any optional integration mechanisms the
+			// Harness exposes (hooks, extensions).
 			if err := adapter.RegisterMCP(); err != nil {
 				genErr = err
 				return
 			}
-			if adapter.SupportsHooks() {
-				if err := adapter.RegisterHooks(harness.HooksForHarness(rt)); err != nil {
+			if h, ok := adapter.(harness.HookInstaller); ok {
+				if err := h.RegisterHooks(); err != nil {
+					genErr = err
+					return
+				}
+			}
+			if e, ok := adapter.(harness.ExtensionInstaller); ok {
+				if err := e.RegisterExtension(); err != nil {
 					genErr = err
 					return
 				}
@@ -450,12 +455,12 @@ func runReinit(cmd *cobra.Command, cwd, leoDir string, result OnboardingResult, 
 			continue
 		}
 
-		// Register MCP + hooks generically. Same pattern as upgrade.go and
-		// the fresh-init path above; covers any adapter implementing the
-		// harness.Adapter interface, including pi.
 		_ = adapter.RegisterMCP()
-		if adapter.SupportsHooks() {
-			_ = adapter.RegisterHooks(harness.HooksForHarness(rt))
+		if h, ok := adapter.(harness.HookInstaller); ok {
+			_ = h.RegisterHooks()
+		}
+		if e, ok := adapter.(harness.ExtensionInstaller); ok {
+			_ = e.RegisterExtension()
 		}
 	}
 

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -779,13 +779,17 @@ func regenerateRuntimeFiles(projectRoot, leoDir string, cfg *config.Config) erro
 			return fmt.Errorf("generating %s context: %w", rt, err)
 		}
 
-		// Register MCP server config and hooks for all adapters.
 		if err := adapter.RegisterMCP(); err != nil {
 			return fmt.Errorf("registering %s MCP config: %w", rt, err)
 		}
-		if adapter.SupportsHooks() {
-			if err := adapter.RegisterHooks(harness.HooksForHarness(rt)); err != nil {
+		if h, ok := adapter.(harness.HookInstaller); ok {
+			if err := h.RegisterHooks(); err != nil {
 				return fmt.Errorf("registering %s hooks: %w", rt, err)
+			}
+		}
+		if e, ok := adapter.(harness.ExtensionInstaller); ok {
+			if err := e.RegisterExtension(); err != nil {
+				return fmt.Errorf("registering %s extension: %w", rt, err)
 			}
 		}
 	}

--- a/cli/internal/cmd/watch.go
+++ b/cli/internal/cmd/watch.go
@@ -28,19 +28,12 @@ var (
 	watchTranscriptDir string
 	watchDebounceMs    int
 	watchStatus        bool
-	watchRuntime       string
+	watchHarness       string
 	watchSweep         bool
 	watchInstall       bool
 	watchUninstall     bool
 	watchGlobal        bool
 )
-
-// defaultTranscriptDirs maps runtime name to its default transcript directory.
-var defaultTranscriptDirs = map[string]string{
-	"claude":   "~/.claude/projects/",
-	"windsurf": "~/.windsurf/transcripts/",
-	"pi":       "~/.pi/agent/sessions/",
-}
 
 var watchCmd = &cobra.Command{
 	Use:   "watch",
@@ -64,7 +57,7 @@ The watcher runs in the foreground. Use Ctrl-C to stop.`,
 }
 
 func init() {
-	watchCmd.Flags().StringVar(&watchRuntime, "runtime", "claude",
+	watchCmd.Flags().StringVar(&watchHarness, "runtime", "claude",
 		`Runtime to watch: "claude" (default), "windsurf", or "pi"`)
 	watchCmd.Flags().StringVar(&watchTranscriptDir, "dir", "",
 		"Transcript directory to watch (overrides the runtime default)")
@@ -116,40 +109,34 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	// Build watcher sources: if --runtime is explicitly set, use single source;
 	// otherwise read config and watch all enabled runtimes.
 	var sources []watcher.Source
-	runtimeExplicit := cmd.Flags().Changed("runtime")
+	harnessExplicit := cmd.Flags().Changed("runtime")
 
-	if runtimeExplicit {
-		// Manual single-runtime mode.
+	if harnessExplicit {
+		// Manual single-Harness mode.
 		transcriptDir := watchTranscriptDir
 		var adapter watcher.Adapter
 
-		switch watchRuntime {
+		switch watchHarness {
 		case "windsurf":
 			adapter = &watcher.WindsurfAdapter{ProjectDir: projectDir}
-			if transcriptDir == "" {
-				transcriptDir = defaultTranscriptDirs["windsurf"]
-			}
 		case "pi":
 			adapter = watcher.NewPiAdapter()
-			if transcriptDir == "" {
-				transcriptDir = defaultTranscriptDirs["pi"]
-			}
 		case "claude", "":
 			adapter = watcher.NewClaudeAdapter()
-			if transcriptDir == "" {
-				transcriptDir = defaultTranscriptDirs["claude"]
-			}
 		default:
-			return fmt.Errorf("unknown runtime %q — supported: claude, windsurf, pi", watchRuntime)
+			return fmt.Errorf("unknown runtime %q — supported: claude, windsurf, pi", watchHarness)
+		}
+		if transcriptDir == "" {
+			transcriptDir = harnessTranscriptDir(watchHarness)
 		}
 
 		sources = []watcher.Source{{
-			Runtime:       watchRuntime,
+			Runtime:       watchHarness,
 			TranscriptDir: transcriptDir,
 			Adapter:       adapter,
 		}}
 	} else {
-		// Config-driven multi-runtime mode (daemon default).
+		// Config-driven multi-Harness mode (daemon default).
 		momCfg, err := config.Load(momDir)
 		if err != nil {
 			return fmt.Errorf("loading config: %w", err)
@@ -208,11 +195,11 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Print startup info.
-	runtimeNames := make([]string, len(sources))
+	harnessNames := make([]string, len(sources))
 	for i, src := range sources {
-		runtimeNames[i] = src.Runtime
+		harnessNames[i] = src.Runtime
 	}
-	p.Diamond(fmt.Sprintf("watch [%s]", strings.Join(runtimeNames, ", ")))
+	p.Diamond(fmt.Sprintf("watch [%s]", strings.Join(harnessNames, ", ")))
 	for rt, dir := range w.TranscriptDirs() {
 		p.Chevron(fmt.Sprintf("%s: %s", rt, dir))
 	}
@@ -228,7 +215,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 
 // newProjectBus creates a Herald event bus with Logbook and Drafter subscribers
 // wired for a given momDir. Used by both single-project and global watch modes.
-// adapters maps runtime name → Adapter for runtime-specific logbook parsing.
+// adapters maps Harness name → Adapter for Harness-specific logbook parsing.
 func newProjectBus(momDir string, adapters map[string]watcher.Adapter) *herald.Bus {
 	bus := herald.NewBus()
 
@@ -243,7 +230,7 @@ func newProjectBus(momDir string, adapters map[string]watcher.Adapter) *herald.B
 		logsDir := filepath.Join(md, "logs")
 		_ = os.MkdirAll(logsDir, 0755)
 
-		// Use runtime-specific parser when available, fall back to Claude format.
+		// Use Harness-specific parser when available, fall back to Claude format.
 		var sessionLog *logbook.SessionLog
 		var err error
 		if rt, ok := e.Payload["runtime"].(string); ok {

--- a/cli/internal/cmd/watch_helpers.go
+++ b/cli/internal/cmd/watch_helpers.go
@@ -6,11 +6,28 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/momhq/mom/cli/internal/adapters/harness"
 	"github.com/momhq/mom/cli/internal/config"
 	"github.com/momhq/mom/cli/internal/daemon"
 	"github.com/momhq/mom/cli/internal/ux"
 	"github.com/momhq/mom/cli/internal/watcher"
 )
+
+// harnessTranscriptDir resolves a Harness's default transcript directory via
+// its TranscriptSource implementation. Returns "" if the Harness is unknown
+// or has no transcript source.
+func harnessTranscriptDir(name string) string {
+	reg := harness.NewRegistry("")
+	h, ok := reg.Get(name)
+	if !ok {
+		return ""
+	}
+	if ts, ok := h.(harness.TranscriptSource); ok {
+		return ts.DefaultTranscriptDir()
+	}
+	return ""
+}
+
 
 
 // ensureGlobalDaemon registers the project in the global watch registry and
@@ -154,42 +171,39 @@ func sweepTranscripts(momDir string) {
 }
 
 // buildWatcherSources builds watcher.Source entries from config for all
-// watcher-capable runtimes.
+// watcher-capable Harnesses.
 func buildWatcherSources(cfg *config.Config, projectDir string) []watcher.Source {
 	var sources []watcher.Source
 	for _, rt := range cfg.EnabledRuntimes() {
+		var (
+			override string
+			adapter  watcher.Adapter
+		)
 		switch rt {
 		case "claude":
-			dir := cfg.Watcher.TranscriptDir
-			if dir == "" {
-				dir = "~/.claude/projects/"
-			}
-			sources = append(sources, watcher.Source{
-				Runtime:       "claude",
-				TranscriptDir: dir,
-				Adapter:       watcher.NewClaudeAdapter(),
-			})
+			override = cfg.Watcher.TranscriptDir
+			adapter = watcher.NewClaudeAdapter()
 		case "windsurf":
-			dir := cfg.Watcher.WindsurfTranscriptDir
-			if dir == "" {
-				dir = "~/.windsurf/transcripts/"
-			}
-			sources = append(sources, watcher.Source{
-				Runtime:       "windsurf",
-				TranscriptDir: dir,
-				Adapter:       &watcher.WindsurfAdapter{ProjectDir: projectDir},
-			})
+			override = cfg.Watcher.WindsurfTranscriptDir
+			adapter = &watcher.WindsurfAdapter{ProjectDir: projectDir}
 		case "pi":
-			dir := cfg.Watcher.PiTranscriptDir
-			if dir == "" {
-				dir = "~/.pi/agent/sessions/"
-			}
-			sources = append(sources, watcher.Source{
-				Runtime:       "pi",
-				TranscriptDir: dir,
-				Adapter:       watcher.NewPiAdapter(),
-			})
+			override = cfg.Watcher.PiTranscriptDir
+			adapter = watcher.NewPiAdapter()
+		default:
+			continue
 		}
+		dir := override
+		if dir == "" {
+			dir = harnessTranscriptDir(rt)
+		}
+		if dir == "" {
+			continue
+		}
+		sources = append(sources, watcher.Source{
+			Runtime:       rt,
+			TranscriptDir: dir,
+			Adapter:       adapter,
+		})
 	}
 	return sources
 }

--- a/cli/internal/watcher/adapter_windsurf.go
+++ b/cli/internal/watcher/adapter_windsurf.go
@@ -227,7 +227,7 @@ func (a *WindsurfAdapter) ParseSession(transcriptPath, sessionID string) (*logbo
 			log.Interactions++
 
 		case "code_action":
-			windCountTool(log, "code_action")
+			a.windCountTool(log, "code_action")
 			if ca, ok := entry["code_action"].(map[string]any); ok {
 				if p, ok := ca["path"].(string); ok && p != "" {
 					filesChanged[p] = true
@@ -235,7 +235,7 @@ func (a *WindsurfAdapter) ParseSession(transcriptPath, sessionID string) (*logbo
 			}
 
 		case "command_action":
-			windCountTool(log, "command_action")
+			a.windCountTool(log, "command_action")
 
 		case "mcp_tool":
 			toolName := ""
@@ -243,7 +243,7 @@ func (a *WindsurfAdapter) ParseSession(transcriptPath, sessionID string) (*logbo
 				toolName, _ = mcp["tool_name"].(string)
 			}
 			if toolName != "" {
-				windCountTool(log, toolName)
+				a.windCountTool(log, toolName)
 				if toolName == "create_memory_draft" {
 					log.MemoriesCreated++
 				}
@@ -264,18 +264,23 @@ func (a *WindsurfAdapter) ParseSession(transcriptPath, sessionID string) (*logbo
 	return log, nil
 }
 
-// windCountTool increments tool counts in a SessionLog, routing to the correct category.
-func windCountTool(log *logbook.SessionLog, toolName string) {
-	var category string
+// CategorizeTool returns Windsurf-specific synonyms for tool names; falls back
+// to logbook.CategorizeToolCall for everything else.
+func (a *WindsurfAdapter) CategorizeTool(toolName string) string {
 	switch toolName {
 	case "code_action":
-		category = "codebase_write"
+		return "codebase_write"
 	case "command_action":
-		category = "system"
+		return "system"
 	default:
-		category = logbook.CategorizeToolCall(toolName)
+		return logbook.CategorizeToolCall(toolName)
 	}
+}
 
+// windCountTool increments tool counts in a SessionLog, routing via the
+// adapter's CategorizeTool override.
+func (a *WindsurfAdapter) windCountTool(log *logbook.SessionLog, toolName string) {
+	category := a.CategorizeTool(toolName)
 	group := log.ToolCalls[category]
 	group.Total++
 	if group.Detail == nil {
@@ -284,3 +289,5 @@ func windCountTool(log *logbook.SessionLog, toolName string) {
 	group.Detail[toolName]++
 	log.ToolCalls[category] = group
 }
+
+var _ ToolCategorizer = (*WindsurfAdapter)(nil)


### PR DESCRIPTION
Closes #179. (#180 was merged into #179 — see issue thread.)

## Summary

Adapters implement the optional interfaces from #178; call sites dispatch via type assertion; legacy `SupportsHooks()` and parameterized `RegisterHooks([]HookDef)` are removed from base `Adapter` and every adapter \u2014 all atomic with the migration, because Go's lack of method overloading prevented splitting it into two PRs.

End state matches [ADR 0002](https://github.com/momhq/mom/blob/main/adr/0002-adapter-integration-as-optional-interfaces.md), [ADR 0004](https://github.com/momhq/mom/blob/main/adr/0004-transcript-source-as-optional-interface.md), [ADR 0005](https://github.com/momhq/mom/blob/main/adr/0005-tool-categorization-as-optional-interface.md).

## Diff shape

```
14 files changed, 137 insertions(+), 258 deletions(-)
```

Net **\u2212121 lines** \u2014 the migration is a simplification, not a complication.

## Adapter changes

| Adapter | Implements (new) | Removed |
|---|---|---|
| `ClaudeAdapter` | `HookInstaller`, `TranscriptSource` | `SupportsHooks`, parameterized `RegisterHooks`, `DefaultHooks` free fn |
| `CodexAdapter` | `HookInstaller` | `SupportsHooks`, parameterized `RegisterHooks`, `CodexHooks` free fn |
| `WindsurfAdapter` (harness) | `HookInstaller`, `TranscriptSource` | `SupportsHooks`, parameterized `RegisterHooks`, `WindsurfHooks` free fn |
| `PiAdapter` | `ExtensionInstaller`, `TranscriptSource` | `SupportsHooks`, the awkward parameterized-but-ignored `RegisterHooks(_ []HookDef)`, `PiHooks` free fn |
| `watcher.WindsurfAdapter` | `ToolCategorizer` | (none \u2014 the package-level `windCountTool` became a method that uses `CategorizeTool`) |

Each adapter file ends with a compile-time interface check:
```go
var _ HookInstaller    = (*ClaudeAdapter)(nil)
var _ TranscriptSource = (*ClaudeAdapter)(nil)
```

## Call site changes

- `cmd/init.go`, `cmd/upgrade.go`: `if h, ok := adapter.(harness.HookInstaller); ok { h.RegisterHooks() }` (and the same for `ExtensionInstaller`)
- `cmd/watch.go`, `cmd/watch_helpers.go`: `harnessTranscriptDir(name)` helper resolves defaults via `TranscriptSource`; `defaultTranscriptDirs` map deleted
- `watcher/adapter_windsurf.go`: `windCountTool` became a method on the adapter that uses `CategorizeTool`; `logbook.CategorizeToolCall` remains the fallback

## Removals from base Adapter

```go
type Adapter interface {
    Name() string
    Tier() Tier
    GenerateContextFile(...) error
-   SupportsHooks() bool
-   RegisterHooks(hooks []HookDef) error
    DetectHarness() bool
    GeneratedFiles() []string
    GeneratedDirs() []string
    Watermark() string
    Capabilities() AdapterCapability
    GitIgnorePaths() []string
    RegisterMCP() error
}
```

`HooksForHarness(name)` lookup function also deleted.

## Verification

- `go build ./...` passes
- `go test ./...` passes (except pre-existing `TestLiveMemoryFiles`)
- All affected packages: `harness`, `watcher`, `cmd` \u2014 green

## Refs

- Closes #179
- Subsumes #180 (per issue-thread comment)
- Implements [ADR 0002](https://github.com/momhq/mom/blob/main/adr/0002-adapter-integration-as-optional-interfaces.md), [ADR 0004](https://github.com/momhq/mom/blob/main/adr/0004-transcript-source-as-optional-interface.md), [ADR 0005](https://github.com/momhq/mom/blob/main/adr/0005-tool-categorization-as-optional-interface.md)
- Part of [PRD 0001](https://github.com/momhq/mom/blob/main/prd/0001-deepen-mom-architecture.md)