### PR TITLE
refactor(watcher): rename runtime → harness in watcher package internals (#192)

### DIFF
--- a/cli/internal/cmd/watch.go
+++ b/cli/internal/cmd/watch.go
@@ -131,7 +131,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		}
 
 		sources = []watcher.Source{{
-			Runtime:       watchHarness,
+			Harness:       watchHarness,
 			TranscriptDir: transcriptDir,
 			Adapter:       adapter,
 		}}
@@ -151,7 +151,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	if watchSweep {
 		adapterMap := make(map[string]watcher.Adapter, len(sources))
 		for _, src := range sources {
-			adapterMap[src.Runtime] = src.Adapter
+			adapterMap[src.Harness] = src.Adapter
 		}
 		bus := newProjectBus(momDir, adapterMap)
 		w, err := watcher.New(watcher.Config{
@@ -179,7 +179,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	// Logbook and Drafter subscribe as downstream processors.
 	adapterMap := make(map[string]watcher.Adapter, len(sources))
 	for _, src := range sources {
-		adapterMap[src.Runtime] = src.Adapter
+		adapterMap[src.Harness] = src.Adapter
 	}
 	bus := newProjectBus(momDir, adapterMap)
 
@@ -197,7 +197,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	// Print startup info.
 	harnessNames := make([]string, len(sources))
 	for i, src := range sources {
-		harnessNames[i] = src.Runtime
+		harnessNames[i] = src.Harness
 	}
 	p.Diamond(fmt.Sprintf("watch [%s]", strings.Join(harnessNames, ", ")))
 	for rt, dir := range w.TranscriptDirs() {
@@ -305,7 +305,7 @@ func runWatchGlobal(sweepOnly bool) error {
 			}
 			adapterMap := make(map[string]watcher.Adapter, len(sources))
 			for _, src := range sources {
-				adapterMap[src.Runtime] = src.Adapter
+				adapterMap[src.Harness] = src.Adapter
 			}
 			bus := newProjectBus(entry.MomDir, adapterMap)
 			w, err := watcher.New(watcher.Config{
@@ -357,7 +357,7 @@ func runWatchGlobal(sweepOnly bool) error {
 		}
 		adapterMap := make(map[string]watcher.Adapter, len(sources))
 		for _, src := range sources {
-			adapterMap[src.Runtime] = src.Adapter
+			adapterMap[src.Harness] = src.Adapter
 		}
 		bus := newProjectBus(entry.MomDir, adapterMap)
 		w, err := watcher.New(watcher.Config{

--- a/cli/internal/cmd/watch_helpers.go
+++ b/cli/internal/cmd/watch_helpers.go
@@ -153,7 +153,7 @@ func sweepTranscripts(momDir string) {
 
 	adapterMap := make(map[string]watcher.Adapter, len(sources))
 	for _, src := range sources {
-		adapterMap[src.Runtime] = src.Adapter
+		adapterMap[src.Harness] = src.Adapter
 	}
 	bus := newProjectBus(momDir, adapterMap)
 	w, err := watcher.New(watcher.Config{
@@ -200,7 +200,7 @@ func buildWatcherSources(cfg *config.Config, projectDir string) []watcher.Source
 			continue
 		}
 		sources = append(sources, watcher.Source{
-			Runtime:       rt,
+			Harness:       rt,
 			TranscriptDir: dir,
 			Adapter:       adapter,
 		})

--- a/cli/internal/watcher/adapter.go
+++ b/cli/internal/watcher/adapter.go
@@ -8,10 +8,10 @@ import (
 	"github.com/momhq/mom/cli/internal/recorder"
 )
 
-// Adapter parses runtime-specific transcript lines into RawEntry values.
-// Each runtime (Claude Code, Windsurf, Codex) has its own adapter.
+// Adapter parses Harness-specific transcript lines into RawEntry values.
+// Each Harness (Claude Code, Windsurf, Pi) has its own adapter.
 type Adapter interface {
-	// Name returns the adapter's runtime identifier.
+	// Name returns the adapter's Harness identifier.
 	Name() string
 
 	// ParseLine parses a single JSONL line from a transcript file.
@@ -21,7 +21,7 @@ type Adapter interface {
 }
 
 // SessionParser is optionally implemented by adapters that provide
-// runtime-specific logbook parsing. Falls back to logbook.ParseTranscript
+// Harness-specific logbook parsing. Falls back to logbook.ParseTranscript
 // (Claude Code format) when not implemented.
 type SessionParser interface {
 	ParseSession(transcriptPath, sessionID string) (*logbook.SessionLog, error)
@@ -44,7 +44,7 @@ type ToolCategorizer interface {
 	CategorizeTool(toolName string) string
 }
 
-// ProjectScoper is optionally implemented by adapters whose runtime uses a
+// ProjectScoper is optionally implemented by adapters whose Harness uses a
 // non-default project-slug convention for its per-project transcript
 // subdirectory. The default convention (claude/codex) is
 // strings.ReplaceAll(path, "/", "-"); pi (for example) uses
@@ -54,7 +54,7 @@ type ToolCategorizer interface {
 // projectSlug() to locate the scoped transcript subdirectory.
 type ProjectScoper interface {
 	// ProjectSlug returns the per-project subdirectory name this adapter's
-	// runtime would create under its base transcript directory for the given
+	// Harness would create under its base transcript directory for the given
 	// absolute project path.
 	ProjectSlug(projectDir string) string
 }

--- a/cli/internal/watcher/watcher.go
+++ b/cli/internal/watcher/watcher.go
@@ -17,14 +17,14 @@ import (
 	"github.com/momhq/mom/cli/internal/ux"
 )
 
-// Source describes one runtime's transcript directory and parser.
+// Source describes one Harness's transcript directory and parser.
 type Source struct {
-	// Runtime is the name of the runtime (e.g. "claude", "windsurf").
-	Runtime string
+	// Harness is the name of the Harness (e.g. "claude", "windsurf").
+	Harness string
 	// TranscriptDir is the directory to watch (e.g. ~/.claude/projects/).
 	// Tilde expansion is performed automatically.
 	TranscriptDir string
-	// Adapter parses runtime-specific JSONL lines.
+	// Adapter parses Harness-specific JSONL lines.
 	Adapter Adapter
 }
 
@@ -32,7 +32,7 @@ type Source struct {
 type Config struct {
 	// TranscriptDir is the directory to watch (e.g. ~/.claude/projects/).
 	// Tilde expansion is performed automatically.
-	// DEPRECATED: use Sources instead. Kept for single-runtime compat.
+	// DEPRECATED: use Sources instead. Kept for single-Harness compat.
 	TranscriptDir string
 	// ProjectDir is the absolute path of the project being watched.
 	// Used to scope ingestion to the matching transcript subdirectory.
@@ -40,10 +40,10 @@ type Config struct {
 	ProjectDir string
 	// MomDir is the path to .mom/ where raw/ and cursor files are written.
 	MomDir string
-	// Adapter parses runtime-specific JSONL lines.
-	// DEPRECATED: use Sources instead. Kept for single-runtime compat.
+	// Adapter parses Harness-specific JSONL lines.
+	// DEPRECATED: use Sources instead. Kept for single-Harness compat.
 	Adapter Adapter
-	// Sources lists all runtime transcript directories to watch.
+	// Sources lists all Harness transcript directories to watch.
 	// When set, TranscriptDir and Adapter are ignored.
 	Sources []Source
 	// DebounceMs is how long to wait after a Write event before reading.
@@ -60,12 +60,12 @@ type Config struct {
 
 // resolvedSource is a Source after tilde expansion and project scoping.
 type resolvedSource struct {
-	runtime string
+	harness string
 	dir     string // resolved absolute path
 	adapter Adapter
 }
 
-// Watcher watches runtime transcript directories and ingests new entries
+// Watcher watches Harness transcript directories and ingests new entries
 // into .mom/raw/ using cursor-based incremental reads.
 type Watcher struct {
 	cfg        Config
@@ -89,7 +89,7 @@ func New(cfg Config) (*Watcher, error) {
 	sources := cfg.Sources
 	if len(sources) == 0 && cfg.TranscriptDir != "" {
 		sources = []Source{{
-			Runtime:       "default",
+			Harness:       "default",
 			TranscriptDir: cfg.TranscriptDir,
 			Adapter:       cfg.Adapter,
 		}}
@@ -100,7 +100,7 @@ func New(cfg Config) (*Watcher, error) {
 	for _, src := range sources {
 		dir, err := expandTilde(src.TranscriptDir)
 		if err != nil {
-			return nil, fmt.Errorf("expanding transcript dir for %s: %w", src.Runtime, err)
+			return nil, fmt.Errorf("expanding transcript dir for %s: %w", src.Harness, err)
 		}
 
 		// Scope to project-specific subdirectory when ProjectDir is set.
@@ -122,7 +122,7 @@ func New(cfg Config) (*Watcher, error) {
 		}
 
 		resolved = append(resolved, resolvedSource{
-			runtime: src.Runtime,
+			harness: src.Harness,
 			dir:     dir,
 			adapter: src.Adapter,
 		})
@@ -168,7 +168,7 @@ func (w *Watcher) Run() error {
 	// Watch all transcript directories recursively.
 	for _, src := range w.sources {
 		if err := w.addDir(src.dir); err != nil {
-			w.logf("watching %s (%s): %v — skipping", src.dir, src.runtime, err)
+			w.logf("watching %s (%s): %v — skipping", src.dir, src.harness, err)
 		}
 	}
 
@@ -185,7 +185,7 @@ func (w *Watcher) Run() error {
 	}
 
 	for _, src := range w.sources {
-		w.logf("watcher started on %s (%s)", src.dir, src.runtime)
+		w.logf("watcher started on %s (%s)", src.dir, src.harness)
 	}
 
 	for {
@@ -236,7 +236,7 @@ func (w *Watcher) TranscriptDir() string {
 func (w *Watcher) TranscriptDirs() map[string]string {
 	dirs := make(map[string]string, len(w.sources))
 	for _, src := range w.sources {
-		dirs[src.runtime] = src.dir
+		dirs[src.harness] = src.dir
 	}
 	return dirs
 }

--- a/cli/internal/watcher/watcher_test.go
+++ b/cli/internal/watcher/watcher_test.go
@@ -375,7 +375,7 @@ func TestNew_ProjectScoping_PiUsesCustomSlug(t *testing.T) {
 		ProjectDir: projectDir,
 		MomDir:     momDir,
 		Sources: []Source{{
-			Runtime:       "pi",
+			Harness:       "pi",
 			TranscriptDir: base,
 			Adapter:       NewPiAdapter(),
 		}},
@@ -412,7 +412,7 @@ func TestNew_ProjectScoping_ClaudeUsesDefaultSlug(t *testing.T) {
 		ProjectDir: projectDir,
 		MomDir:     momDir,
 		Sources: []Source{{
-			Runtime:       "claude",
+			Harness:       "claude",
 			TranscriptDir: base,
 			Adapter:       NewClaudeAdapter(),
 		}},


### PR DESCRIPTION
Closes #192.

## Summary

Mechanical Zone A rename in `cli/internal/watcher/` per [ADR 0001](https://github.com/momhq/mom/blob/main/adr/0001-adopt-harness-as-canonical-term.md). No user-visible changes.

## Changes

- `Source.Runtime` → `Source.Harness` (public struct field)
- `resolvedSource.runtime` → `resolvedSource.harness` (private field)
- All `src.Runtime` / `src.runtime` accesses updated across `watcher.go`, `cmd/watch.go`, `cmd/watch_helpers.go`, `watcher_test.go`
- Comments in `adapter.go` and `watcher.go` use "Harness" terminology

## Out of scope

- `e.Runtime` JSON payload field in herald events → #186
- `legacyConfig.Runtime` YAML field → #186
- CLI flags / user-facing strings → #187

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (pre-existing `TestLiveMemoryFiles` aside)