### PR TITLE
feat(doctor): surface harness tier and integration capabilities (#184)

### DIFF
--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -94,6 +94,33 @@ func runDoctorBase(cmd *cobra.Command, verbose bool) error {
 		p.Checkf("config.yaml: valid (runtimes: %s)", strings.Join(cfg.EnabledRuntimes(), ", "))
 	}
 
+	// Harness status: tier + integration capabilities.
+	if cfg != nil && len(cfg.EnabledRuntimes()) > 0 {
+		cwd, _ := os.Getwd()
+		reg := harness.NewRegistry(cwd)
+		for _, name := range cfg.EnabledRuntimes() {
+			a, ok := reg.Get(name)
+			if !ok {
+				continue
+			}
+			var parts []string
+			if _, ok := a.(harness.HookInstaller); ok {
+				parts = append(parts, "hooks")
+			}
+			if _, ok := a.(harness.ExtensionInstaller); ok {
+				parts = append(parts, "extension")
+			}
+			if ts, ok := a.(harness.TranscriptSource); ok {
+				parts = append(parts, "transcript:"+ts.DefaultTranscriptDir())
+			}
+			detail := a.Tier().String()
+			if len(parts) > 0 {
+				detail += "  " + strings.Join(parts, "  ")
+			}
+			p.Checkf("%s: %s", name, detail)
+		}
+	}
+
 	// Check 3: memory and core dirs exist.
 	docsDir := filepath.Join(leoDir, "memory")
 	if _, statErr := os.Stat(docsDir); statErr != nil {
@@ -682,13 +709,32 @@ func printBundleAdapterStatus(cmd *cobra.Command, cwd string, cfg *config.Config
 	}
 	registry := harness.NewRegistry(cwd)
 	for _, name := range enabled {
-		adapter, ok := registry.Get(name)
+		a, ok := registry.Get(name)
 		if !ok {
 			cmd.Printf("  %s: unknown adapter\n", name)
 			continue
 		}
-		cap := adapter.Capabilities()
-		cmd.Printf("  %s v%s\n", cap.Name, cap.Version)
+		cap := a.Capabilities()
+		cmd.Printf("  %s v%s  [%s]\n", cap.Name, cap.Version, a.Tier())
+
+		// Integration mechanisms.
+		var mechanisms []string
+		if _, ok := a.(harness.HookInstaller); ok {
+			mechanisms = append(mechanisms, "hooks")
+		}
+		if _, ok := a.(harness.ExtensionInstaller); ok {
+			mechanisms = append(mechanisms, "extension")
+		}
+		if len(mechanisms) > 0 {
+			cmd.Printf("    integration:  %s\n", strings.Join(mechanisms, ", "))
+		}
+
+		// Transcript source.
+		if ts, ok := a.(harness.TranscriptSource); ok {
+			cmd.Printf("    transcript:   %s\n", ts.DefaultTranscriptDir())
+		}
+
+		// MRP event coverage.
 		if len(cap.Supports) > 0 {
 			cmd.Printf("    supported:    %s\n", strings.Join(cap.Supports, ", "))
 		}


### PR DESCRIPTION
Closes #184.

## Summary

`mom doctor` now reports each enabled Harness's tier and integration capabilities inline. No new flags — surfaces in the standard `mom doctor` output and in `mom doctor --bundle`.

## Output example

```
✔ config.yaml: valid (runtimes: pi, claude, windsurf)
✔ pi:       native  extension  transcript:~/.pi/agent/sessions/
✔ claude:   fluent  hooks  transcript:~/.claude/projects/
✔ windsurf: functional  hooks  transcript:~/.windsurf/transcripts/
```

For `--bundle`, each adapter entry now also shows `[tier]`, integration, and transcript:

```
  claude-code v1.0  [fluent]
    integration:  hooks
    transcript:   ~/.claude/projects/
    supported:    session.start, ...
```

## Changes

Single file: `cli/internal/cmd/doctor.go`

- `runDoctorBase`: new harness-status block after the config check — iterates enabled Harnesses via registry, surfaces `Tier()`, `HookInstaller`, `ExtensionInstaller`, `TranscriptSource`
- `printBundleAdapterStatus` (`--bundle`): adds `[tier]`, integration mechanisms, and transcript dir to the existing per-adapter display

## Verification

- `go build ./...` ✅
- `go test ./...` ✅
- Live output verified against the mom project (claude adapter)