### PR TITLE
fix(cartographer): set promotion_state to draft (#195)

### DIFF
--- a/cli/internal/cmd/map.go
+++ b/cli/internal/cmd/map.go
@@ -430,7 +430,7 @@ func writeDrafts(drafts []cartographer.Draft, momDir string) (int, error) {
 			Tags:           d.Tags,
 			Created:        now,
 			CreatedBy:      "cartographer",
-			PromotionState: "curated",
+			PromotionState: "draft",
 			Classification: "INTERNAL",
 			Content:        content,
 		})


### PR DESCRIPTION
## Summary

Fixes #195.

Cartographer output was being written with `promotion_state: "curated"`, bypassing the quality gate. Automated scanning is unreviewed by definition — its memories should start as `draft` and become `curated` only when explicitly promoted.

One-line change in `cmd/map.go`: `"curated"` → `"draft"`.

## Scope

[PRD 0002 — Recall v2](https://github.com/momhq/mom/blob/main/prd/0002-recall-v2.md)

## Notes

`TestLiveMemoryFiles` has a pre-existing failure (a live memory file with empty tags, unrelated to this change). All other tests pass.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes
- [x] Pre-existing `TestLiveMemoryFiles` failure confirmed unrelated to this change