### PR TITLE
feat(search): FTS5 AND/OR query split + content-first column weights (#198)

### DIFF
--- a/cli/internal/adapters/storage/sqlite.go
+++ b/cli/internal/adapters/storage/sqlite.go
@@ -18,7 +18,7 @@ import (
 const (
 	// dbSchemaVersion is bumped whenever the schema changes.
 	// A version mismatch triggers a full reindex.
-	dbSchemaVersion = "2"
+	dbSchemaVersion = "3"
 
 	// dbFileName is the SQLite database file inside .mom/cache/.
 	dbFileName = "index.db"
@@ -255,10 +255,23 @@ type SearchResult struct {
 	SessionID      string
 }
 
+// QueryType controls FTS5 token matching behaviour.
+type QueryType int
+
+const (
+	// QueryOR uses implicit OR — any token match scores (default, broader).
+	QueryOR QueryType = iota
+	// QueryAND requires all tokens to match (stricter, higher precision).
+	QueryAND
+)
+
 // SearchOptions controls a Search call.
 type SearchOptions struct {
 	// Query is a free-text search string. Empty = return all (no FTS filter).
 	Query string
+	// QueryType selects AND (all tokens required) or OR (any token scores).
+	// Defaults to QueryOR when zero.
+	QueryType QueryType
 	// ScopePaths restricts results to specific .mom/ directories.
 	// Empty = all scopes.
 	ScopePaths []string
@@ -334,15 +347,21 @@ func (idx *sqliteIndex) Search(opts SearchOptions) ([]SearchResult, error) {
 		args = append(args, opts.Limit)
 	} else {
 		// FTS5 MATCH query — bm25() returns negative values (more negative = better).
+		// Column weights: id=0, summary=2, tags=1, content_text=10 (ADR 0007).
 		ftsConds := "memories_fts MATCH ?"
-		ftsArg := buildFTSQuery(opts.Query)
+		var ftsArg string
+		if opts.QueryType == QueryAND {
+			ftsArg = buildFTSQueryAND(opts.Query)
+		} else {
+			ftsArg = buildFTSQueryOR(opts.Query)
+		}
 
 		// Build the WHERE clause combining FTS join and other filters.
 		allConds := append([]string{ftsConds}, conds...)
 		wherePart := "WHERE " + strings.Join(allConds, " AND ")
 
 		query = `
-			SELECT m.id, m.summary, m.tags_json, -bm25(memories_fts) AS raw_score,
+			SELECT m.id, m.summary, m.tags_json, -bm25(memories_fts, 0, 2, 1, 10) AS raw_score,
 			       m.scope_path, m.promotion_state, m.landmark,
 			       m.centrality_score, m.created, m.session_id
 			FROM memories_fts
@@ -408,20 +427,32 @@ func (idx *sqliteIndex) Search(opts SearchOptions) ([]SearchResult, error) {
 	return results, nil
 }
 
-// buildFTSQuery converts a natural-language query into an FTS5 MATCH expression.
-// Simple approach: tokenize and join with NEAR or just space (implicit OR in FTS5).
-// For better precision we prefix each token with + to require it (AND logic).
-func buildFTSQuery(query string) string {
+// buildFTSQueryOR builds an FTS5 MATCH expression with implicit OR —
+// any token match scores (broader, higher recall).
+func buildFTSQueryOR(query string) string {
 	tokens := strings.Fields(strings.ToLower(query))
 	if len(tokens) == 0 {
 		return ""
 	}
-	// Quote each token to avoid FTS5 special-character issues.
 	quoted := make([]string, 0, len(tokens))
 	for _, t := range tokens {
-		// Escape double-quotes inside the token.
 		t = strings.ReplaceAll(t, `"`, `""`)
 		quoted = append(quoted, `"`+t+`"`)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// buildFTSQueryAND builds an FTS5 MATCH expression requiring all tokens —
+// every token must appear in the document (stricter, higher precision).
+func buildFTSQueryAND(query string) string {
+	tokens := strings.Fields(strings.ToLower(query))
+	if len(tokens) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		t = strings.ReplaceAll(t, `"`, `""`)
+		quoted = append(quoted, `+"`+t+`"`)
 	}
 	return strings.Join(quoted, " ")
 }

--- a/cli/internal/adapters/storage/sqlite_test.go
+++ b/cli/internal/adapters/storage/sqlite_test.go
@@ -362,7 +362,7 @@ func TestSQLiteIndex_Upsert_Overwrite(t *testing.T) {
 	}
 }
 
-func TestBuildFTSQuery(t *testing.T) {
+func TestBuildFTSQueryOR(t *testing.T) {
 	cases := []struct {
 		input string
 		want  string
@@ -373,9 +373,70 @@ func TestBuildFTSQuery(t *testing.T) {
 		{"single", `"single"`},
 	}
 	for _, tc := range cases {
-		got := buildFTSQuery(tc.input)
+		got := buildFTSQueryOR(tc.input)
 		if got != tc.want {
-			t.Errorf("buildFTSQuery(%q) = %q, want %q", tc.input, got, tc.want)
+			t.Errorf("buildFTSQueryOR(%q) = %q, want %q", tc.input, got, tc.want)
 		}
+	}
+}
+
+func TestBuildFTSQueryAND(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"hello world", `+"hello" +"world"`},
+		{"JWT authentication", `+"jwt" +"authentication"`},
+		{"", ""},
+		{"single", `+"single"`},
+	}
+	for _, tc := range cases {
+		got := buildFTSQueryAND(tc.input)
+		if got != tc.want {
+			t.Errorf("buildFTSQueryAND(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestSearchColumnWeights(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := openSQLiteIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idx.Close()
+
+	// contentMatch has the query term only in content_text (high weight).
+	contentMatch := &Doc{
+		ID: "content-match", Scope: "project", Tags: []string{"unrelated"},
+		Created: time.Now(), CreatedBy: "test", PromotionState: "curated",
+		Classification: "INTERNAL", Compartments: map[string][]string{},
+		Content: map[string]any{"detail": "harness integration architecture decision"},
+	}
+	// tagMatch has the query term only in tags (low weight).
+	tagMatch := &Doc{
+		ID: "tag-match", Scope: "project", Tags: []string{"harness"},
+		Created: time.Now(), CreatedBy: "test", PromotionState: "curated",
+		Classification: "INTERNAL", Compartments: map[string][]string{},
+		Content: map[string]any{"detail": "unrelated information about something else"},
+	}
+
+	if err := idx.Upsert(contentMatch, dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Upsert(tagMatch, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := idx.Search(SearchOptions{Query: "harness", Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	// content-match should rank first — content_text weight (10) > tags weight (1).
+	if results[0].ID != "content-match" {
+		t.Errorf("expected content-match to rank first (content weight > tag weight), got %q", results[0].ID)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #198.

Three changes to the FTS5 search layer, all prerequisites for the recall engine (#199):

**1. Query split**
`buildFTSQuery` replaced by two explicit functions:
- `buildFTSQueryOR` — implicit OR, any token scores (current behaviour, broader)
- `buildFTSQueryAND` — all tokens required via `+` prefix (stricter, higher precision)

`SearchOptions` gains a `QueryType` field (`QueryOR` default, `QueryAND` opt-in) so the recall engine can call each variant without duplicating query-building logic.

**2. Column weights**
`bm25()` updated to `bm25(memories_fts, 0, 2, 1, 10)`:
- `id` — 0 (slug, not a search signal)
- `summary` — 2 (one-line intent)
- `tags` — 1 (discovery labels, not relevance)
- `content_text` — 10 (the knowledge body, highest signal)

**3. Schema version bump**
`dbSchemaVersion` `"2"` → `"3"`. A version mismatch triggers automatic full reindex on first open — no user action required.

## Scope

[PRD 0002 — Recall v2](https://github.com/momhq/mom/blob/main/prd/0002-recall-v2.md)
[ADR 0007 — FTS5 content-first column weights](https://github.com/momhq/mom/blob/main/adr/0007-fts5-content-first-column-weights.md)
[ADR 0008 — Query relaxation: AND before OR](https://github.com/momhq/mom/blob/main/adr/0008-query-relaxation-and-before-or.md)

## Test plan

- [x] `TestBuildFTSQueryOR` — OR expression format
- [x] `TestBuildFTSQueryAND` — AND expression format with `+` prefix
- [x] `TestSearchColumnWeights` — content match outscores tag-only match with weighted `bm25()`
- [x] Full suite passes (pre-existing `TestLiveMemoryFiles` failure unrelated)