### PR TITLE
feat(recall): Engine with progressive scope and quality escalation (#199)

### DIFF
--- a/cli/internal/recall/recall.go
+++ b/cli/internal/recall/recall.go
@@ -1,0 +1,114 @@
+// Package recall implements progressive scope and quality escalation for mom_recall.
+// See ADR 0006 for the full design rationale.
+package recall
+
+import (
+	"sort"
+
+	"github.com/momhq/mom/cli/internal/adapters/storage"
+)
+
+// recallEscalationThreshold is the minimum number of results required before
+// the engine stops escalating to a wider scope or lower quality tier.
+// Named for easy promotion to config when the need arises.
+const recallEscalationThreshold = 3
+
+// Searcher searches a single scope with a given query type and quality filter.
+// Implementations include ScopeSearcher (local SQLite) and future vault searchers.
+type Searcher interface {
+	Search(query string, queryType storage.QueryType, includeDrafts bool, limit int) ([]storage.SearchResult, error)
+}
+
+// Options controls an Engine.Search call.
+type Options struct {
+	// Query is the free-text search string.
+	Query string
+	// MaxResults caps the final result count (default 5).
+	MaxResults int
+	// Tags filters results by tags (AND logic).
+	Tags []string
+	// SessionID restricts results to a specific session.
+	SessionID string
+}
+
+// Engine runs two-pass progressive escalation over an ordered Searcher chain.
+//
+// Pass 1 — curated only: for each scope, try AND query then OR query.
+// Stop as soon as results >= recallEscalationThreshold.
+//
+// Pass 2 — draft fallback: repeat the same chain including drafts,
+// only when Pass 1 did not meet the threshold.
+//
+// Results from all queried scopes are merged and re-ranked by score.
+// The highest score for a given document ID wins across all searches.
+type Engine struct {
+	chain []Searcher
+}
+
+// NewEngine creates an Engine with the given ordered Searcher chain.
+// Chain order defines escalation priority: first entry is searched first.
+func NewEngine(chain []Searcher) *Engine {
+	return &Engine{chain: chain}
+}
+
+// Search runs the two-pass escalation and returns top-N results by score.
+func (e *Engine) Search(opts Options) ([]storage.SearchResult, error) {
+	maxResults := opts.MaxResults
+	if maxResults == 0 {
+		maxResults = 5
+	}
+
+	seen := make(map[string]storage.SearchResult)
+
+	// Pass 1: curated memories only.
+	e.runPass(opts.Query, false, maxResults, seen)
+
+	// Pass 2: include drafts if Pass 1 did not reach the threshold.
+	if len(seen) < recallEscalationThreshold {
+		e.runPass(opts.Query, true, maxResults, seen)
+	}
+
+	results := make([]storage.SearchResult, 0, len(seen))
+	for _, r := range seen {
+		results = append(results, r)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+	if len(results) > maxResults {
+		results = results[:maxResults]
+	}
+	return results, nil
+}
+
+// runPass iterates the chain with AND→OR relaxation per scope.
+// Stops as soon as the seen map reaches recallEscalationThreshold.
+func (e *Engine) runPass(query string, includeDrafts bool, limit int, seen map[string]storage.SearchResult) {
+	for _, s := range e.chain {
+		if len(seen) >= recallEscalationThreshold {
+			return
+		}
+
+		// AND first — stricter, higher precision.
+		if results, err := s.Search(query, storage.QueryAND, includeDrafts, limit); err == nil {
+			mergeResults(seen, results)
+		}
+		if len(seen) >= recallEscalationThreshold {
+			return
+		}
+
+		// OR fallback — broader, captures partial matches.
+		if results, err := s.Search(query, storage.QueryOR, includeDrafts, limit); err == nil {
+			mergeResults(seen, results)
+		}
+	}
+}
+
+// mergeResults adds results to seen, keeping the highest score per document ID.
+func mergeResults(seen map[string]storage.SearchResult, results []storage.SearchResult) {
+	for _, r := range results {
+		if existing, ok := seen[r.ID]; !ok || r.Score > existing.Score {
+			seen[r.ID] = r
+		}
+	}
+}

--- a/cli/internal/recall/recall_test.go
+++ b/cli/internal/recall/recall_test.go
@@ -1,0 +1,218 @@
+package recall
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/adapters/storage"
+)
+
+// mockSearcher implements Searcher for testing.
+// Results are keyed by "AND-curated", "OR-curated", "AND-draft", "OR-draft".
+type mockSearcher struct {
+	name    string
+	results map[string][]storage.SearchResult
+	calls   []string // records call signatures for assertion
+}
+
+func (m *mockSearcher) Search(query string, qt storage.QueryType, includeDrafts bool, limit int) ([]storage.SearchResult, error) {
+	qtStr := "OR"
+	if qt == storage.QueryAND {
+		qtStr = "AND"
+	}
+	qualStr := "curated"
+	if includeDrafts {
+		qualStr = "draft"
+	}
+	key := fmt.Sprintf("%s-%s", qtStr, qualStr)
+	m.calls = append(m.calls, fmt.Sprintf("%s:%s", m.name, key))
+	return m.results[key], nil
+}
+
+func makeResult(id string, score float64, promotionState string) storage.SearchResult {
+	return storage.SearchResult{ID: id, Score: score, PromotionState: promotionState}
+}
+
+// TestEngine_ANDSuccess: AND query meets threshold — no OR or scope escalation.
+func TestEngine_ANDSuccess(t *testing.T) {
+	s1 := &mockSearcher{name: "repo", results: map[string][]storage.SearchResult{
+		"AND-curated": {makeResult("a", 1.0, "curated"), makeResult("b", 0.9, "curated"), makeResult("c", 0.8, "curated")},
+	}}
+	e := NewEngine([]Searcher{s1})
+	results, err := e.Search(Options{Query: "test", MaxResults: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	// Only AND-curated should have been called.
+	if len(s1.calls) != 1 || s1.calls[0] != "repo:AND-curated" {
+		t.Errorf("expected only AND-curated call, got %v", s1.calls)
+	}
+}
+
+// TestEngine_ANDORFallback: AND returns < threshold, OR fills the gap.
+func TestEngine_ANDORFallback(t *testing.T) {
+	s1 := &mockSearcher{name: "repo", results: map[string][]storage.SearchResult{
+		"AND-curated": {makeResult("a", 1.0, "curated")},
+		"OR-curated":  {makeResult("a", 1.0, "curated"), makeResult("b", 0.8, "curated"), makeResult("c", 0.7, "curated")},
+	}}
+	e := NewEngine([]Searcher{s1})
+	results, err := e.Search(Options{Query: "test", MaxResults: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	// AND-curated then OR-curated should be called; no draft pass.
+	if len(s1.calls) != 2 {
+		t.Errorf("expected 2 calls, got %v", s1.calls)
+	}
+}
+
+// TestEngine_ScopeEscalation: repo scope insufficient, escalates to org.
+func TestEngine_ScopeEscalation(t *testing.T) {
+	repo := &mockSearcher{name: "repo", results: map[string][]storage.SearchResult{
+		"AND-curated": {makeResult("a", 1.0, "curated")},
+		"OR-curated":  {makeResult("a", 1.0, "curated")},
+	}}
+	org := &mockSearcher{name: "org", results: map[string][]storage.SearchResult{
+		"AND-curated": {makeResult("b", 0.9, "curated"), makeResult("c", 0.8, "curated")},
+	}}
+	e := NewEngine([]Searcher{repo, org})
+	results, err := e.Search(Options{Query: "test", MaxResults: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results from repo+org, got %d", len(results))
+	}
+	// Repo: AND+OR; org: AND.
+	if len(repo.calls) != 2 {
+		t.Errorf("expected 2 repo calls, got %v", repo.calls)
+	}
+	if len(org.calls) != 1 || org.calls[0] != "org:AND-curated" {
+		t.Errorf("expected 1 org AND-curated call, got %v", org.calls)
+	}
+}
+
+// TestEngine_DraftFallback: curated pass empty, draft pass fills results.
+func TestEngine_DraftFallback(t *testing.T) {
+	s1 := &mockSearcher{name: "repo", results: map[string][]storage.SearchResult{
+		"AND-curated": {},
+		"OR-curated":  {},
+		"AND-draft":   {makeResult("d1", 0.9, "draft"), makeResult("d2", 0.8, "draft"), makeResult("d3", 0.7, "draft")},
+	}}
+	e := NewEngine([]Searcher{s1})
+	results, err := e.Search(Options{Query: "test", MaxResults: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 draft results, got %d", len(results))
+	}
+	// Draft pass must have run.
+	hasDraftCall := false
+	for _, c := range s1.calls {
+		if c == "repo:AND-draft" {
+			hasDraftCall = true
+		}
+	}
+	if !hasDraftCall {
+		t.Errorf("expected draft fallback call, got %v", s1.calls)
+	}
+}
+
+// TestEngine_NoDraftFallbackWhenCuratedSufficient: curated threshold met — no draft pass.
+func TestEngine_NoDraftFallbackWhenCuratedSufficient(t *testing.T) {
+	s1 := &mockSearcher{name: "repo", results: map[string][]storage.SearchResult{
+		"AND-curated": {makeResult("a", 1.0, "curated"), makeResult("b", 0.9, "curated"), makeResult("c", 0.8, "curated")},
+		"AND-draft":   {makeResult("d", 0.5, "draft")},
+	}}
+	e := NewEngine([]Searcher{s1})
+	_, err := e.Search(Options{Query: "test", MaxResults: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range s1.calls {
+		if c == "repo:AND-draft" || c == "repo:OR-draft" {
+			t.Errorf("draft pass should not run when curated threshold met, got call %q", c)
+		}
+	}
+}
+
+// TestEngine_MergeRerank: higher score wins when same doc appears in multiple searches.
+func TestEngine_MergeRerank(t *testing.T) {
+	s1 := &mockSearcher{name: "repo", results: map[string][]storage.SearchResult{
+		"AND-curated": {makeResult("a", 0.5, "curated")},
+		"OR-curated":  {makeResult("a", 1.5, "curated"), makeResult("b", 1.0, "curated"), makeResult("c", 0.8, "curated")},
+	}}
+	e := NewEngine([]Searcher{s1})
+	results, err := e.Search(Options{Query: "test", MaxResults: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "a" should have score 1.5 (OR score wins over AND score).
+	if results[0].ID != "a" || results[0].Score != 1.5 {
+		t.Errorf("expected a/1.5 first, got %s/%.1f", results[0].ID, results[0].Score)
+	}
+}
+
+// TestEngine_ThresholdBoundary: exactly threshold results stops escalation.
+func TestEngine_ThresholdBoundary(t *testing.T) {
+	repo := &mockSearcher{name: "repo", results: map[string][]storage.SearchResult{
+		"AND-curated": {
+			makeResult("a", 1.0, "curated"),
+			makeResult("b", 0.9, "curated"),
+			makeResult("c", 0.8, "curated"),
+		},
+	}}
+	org := &mockSearcher{name: "org", results: map[string][]storage.SearchResult{}}
+	e := NewEngine([]Searcher{repo, org})
+	_, err := e.Search(Options{Query: "test", MaxResults: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Org should never be called — threshold reached after repo AND.
+	if len(org.calls) > 0 {
+		t.Errorf("org should not be called when threshold met, got %v", org.calls)
+	}
+}
+
+// TestEngine_EmptyChain: no searchers returns empty results without error.
+func TestEngine_EmptyChain(t *testing.T) {
+	e := NewEngine([]Searcher{})
+	results, err := e.Search(Options{Query: "test", MaxResults: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results from empty chain, got %d", len(results))
+	}
+}
+
+// TestEngine_TopNRespected: results capped at MaxResults even when more are found.
+func TestEngine_TopNRespected(t *testing.T) {
+	s1 := &mockSearcher{name: "repo", results: map[string][]storage.SearchResult{
+		"AND-curated": {
+			makeResult("a", 5.0, "curated"),
+			makeResult("b", 4.0, "curated"),
+			makeResult("c", 3.0, "curated"),
+			makeResult("d", 2.0, "curated"),
+			makeResult("e", 1.0, "curated"),
+		},
+	}}
+	e := NewEngine([]Searcher{s1})
+	results, err := e.Search(Options{Query: "test", MaxResults: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results (MaxResults), got %d", len(results))
+	}
+	if results[0].ID != "a" {
+		t.Errorf("expected top result to be 'a', got %q", results[0].ID)
+	}
+}

--- a/cli/internal/recall/scope_searcher.go
+++ b/cli/internal/recall/scope_searcher.go
@@ -1,0 +1,29 @@
+package recall
+
+import (
+	"github.com/momhq/mom/cli/internal/adapters/storage"
+)
+
+// ScopeSearcher implements Searcher for a single local .mom/ scope
+// backed by a shared IndexedAdapter.
+type ScopeSearcher struct {
+	adapter   *storage.IndexedAdapter
+	scopePath string
+}
+
+// NewScopeSearcher creates a ScopeSearcher for the given scope path.
+// The adapter is shared across scopes; scopePath limits results to this scope.
+func NewScopeSearcher(adapter *storage.IndexedAdapter, scopePath string) *ScopeSearcher {
+	return &ScopeSearcher{adapter: adapter, scopePath: scopePath}
+}
+
+// Search queries this scope with the given query type and quality filter.
+func (s *ScopeSearcher) Search(query string, queryType storage.QueryType, includeDrafts bool, limit int) ([]storage.SearchResult, error) {
+	return s.adapter.Search(storage.SearchOptions{
+		Query:         query,
+		QueryType:     queryType,
+		ScopePaths:    []string{s.scopePath},
+		ExcludeDrafts: !includeDrafts,
+		Limit:         limit,
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #199.

New `recall` package implementing [ADR 0006](https://github.com/momhq/mom/blob/main/adr/0006-unified-recall-progressive-escalation.md).

### `Searcher` interface

One method: `Search(query, queryType, includeDrafts, limit)`. Local SQLite scopes are implemented by `ScopeSearcher` (wraps `IndexedAdapter` + a scope path). Future vault scopes implement the same interface and append to the chain — the engine loop is unchanged.

### `Engine` — two-pass escalation

**Pass 1 (curated):** for each scope in the ordered chain, try `QueryAND` → `QueryOR`. Stops as soon as `seen >= recallEscalationThreshold`.

**Pass 2 (draft fallback):** same chain with `includeDrafts=true`, only when Pass 1 did not reach the threshold.

Results from all queried scopes are merged by doc ID, keeping the highest score per document. Sorted by score, top-N returned.

`recallEscalationThreshold = 3` — named constant, not configurable yet.

## Scope

[PRD 0002 — Recall v2](https://github.com/momhq/mom/blob/main/prd/0002-recall-v2.md)
[ADR 0006 — Unified recall with progressive escalation](https://github.com/momhq/mom/blob/main/adr/0006-unified-recall-progressive-escalation.md)

## Blocked by

#198 (merged) ✓

## Test plan

9 unit tests with mock `Searcher` — all passing:

- [x] `TestEngine_ANDSuccess` — AND meets threshold, no OR or escalation
- [x] `TestEngine_ANDORFallback` — AND sparse, OR fills gap within scope
- [x] `TestEngine_ScopeEscalation` — repo insufficient, escalates to org
- [x] `TestEngine_DraftFallback` — curated empty, draft pass fires
- [x] `TestEngine_NoDraftFallbackWhenCuratedSufficient` — draft pass skipped
- [x] `TestEngine_MergeRerank` — higher score wins across searches
- [x] `TestEngine_ThresholdBoundary` — exactly threshold stops escalation
- [x] `TestEngine_EmptyChain` — no searchers returns empty without error
- [x] `TestEngine_TopNRespected` — MaxResults cap honoured