### PR TITLE
refactor(constraints): audit and rewrite constraint/skill layer (#158)

### DIFF
--- a/cli/internal/cmd/core_memory.go
+++ b/cli/internal/cmd/core_memory.go
@@ -7,7 +7,7 @@ func coreConstraints() map[string]string {
   "id": "anti-hallucination",
   "type": "constraint",
   "boot": true,
-  "summary": "Verify before asserting. Use [RECALL] and [INFERRED] when source matters. Never fill gaps with confident-sounding assumptions.",
+  "summary": "Verify before asserting. Mark [RECALL] for memory-sourced claims, [INFERRED] for deductions. No exceptions.",
   "lifecycle": "permanent",
   "scope": "core",
   "tags": ["honesty", "verification", "trust", "evidence"],
@@ -95,7 +95,8 @@ func coreSkills() map[string]string {
   "updated_by": "system",
   "content": {
     "description": "Curates session memories by surfacing what the Drafter captured automatically, identifying what is worth promoting to curated memory, and executing promotions. Can be run mid-session (e.g., before /clear) or at end of session.",
-    "triggers": ["wrap up", "close the session", "done for today", "finalize", "fecha a sessão", "consolida aí", "pronto por hoje", "pode fechar"],
+    "triggers": ["wrap up", "close session", "done for today", "finalize"],
+    "trigger_guidance": "These keywords are the canonical trigger. Also recognize equivalent intent in any language — when the user signals they want to curate memories, consolidate work, or close out a session. Do not require exact phrasing.",
     "invoked_by": "mom",
     "steps": [
       {"name": "Surface", "instruction": "Call mom_recall with a broad query and include drafts. Focus on the last hour of activity. This returns what the Drafter automatically captured from this session — do not reconstruct from context window.", "wait_for_approval": false},

--- a/cli/internal/cmd/core_memory.go
+++ b/cli/internal/cmd/core_memory.go
@@ -1,34 +1,41 @@
 package cmd
 
-// coreConstraints returns the core constraint documents that ship with every leo init.
+// coreConstraints returns the core constraint documents that ship with every mom init.
 func coreConstraints() map[string]string {
 	return map[string]string{
 		"anti-hallucination": `{
   "id": "anti-hallucination",
   "type": "constraint",
   "boot": true,
-  "summary": "When unsure, say you don't know. Mark assertions with [INFERRED]/[RECALL]/[GUESS]. Never fill gaps with confident-sounding assumptions.",
+  "summary": "Verify before asserting. Use [RECALL] and [INFERRED] when source matters. Never fill gaps with confident-sounding assumptions.",
   "lifecycle": "permanent",
   "scope": "core",
   "tags": ["honesty", "verification", "trust", "evidence"],
   "created": "2026-04-08T00:00:00Z",
   "created_by": "system",
-  "updated": "2026-04-15T00:00:00Z",
+  "updated": "2026-04-29T00:00:00Z",
   "updated_by": "system",
   "content": {
-    "constraint": "When you're not sure about something, say you don't know. Don't fill gaps with plausible-sounding assumptions. Invented information delivered with a confident tone is the worst possible failure.",
+    "constraint": "Verify before asserting. Never fill gaps with confident-sounding assumptions. Invented information delivered with a confident tone is the worst possible failure.",
     "why": "The user tolerates 'I don't know' — they can verify, search, ask. The user does not tolerate a confident answer that later turns out to be false, because decisions have already been made based on it.",
+    "epistemic_markers": {
+      "[RECALL]": "Required when sourcing from memory or prior sessions — not optional. Memory ages; verify against current state before asserting as current fact.",
+      "[INFERRED]": "Required when deducing rather than directly observing — not optional. Makes the logical leap visible to the user."
+    },
     "how_to_apply": [
-      "Mark origin when non-trivial: [INFERRED] for logical deduction, [RECALL] for training/previous sessions, [GUESS] for hunches",
-      "Verify before asserting: read the file, grep the symbol, check docs, run the command. If you can't verify, say '[GUESS]: ...' explicitly",
-      "Memories age: verify against current state before asserting based on memory",
-      "Ask when the doubt is strategic: if no verifiable source exists for a strategic question, ask the user"
+      "Use [RECALL] when citing something from memory or a prior session",
+      "Use [INFERRED] when deducing rather than observing",
+      "If you cannot verify, say 'I don't know' or 'I'm not sure' in plain language",
+      "Show your verification: paste build/test output, read the file before asserting it exists, grep the symbol before claiming it's defined",
+      "For deliveries: paste the output, cite the source, explain the root cause — the user should be able to check without asking"
     ],
     "responsibility": "All agents, without exception.",
     "anti_patterns": [
       "Saying 'Build passed' without pasting the output",
       "Asserting a file exists without reading it",
-      "Citing a memory as fact without checking if it's still current"
+      "Citing a memory as current fact without re-verifying",
+      "'Fixed the bug' without explaining what was wrong",
+      "'Tested and it works' without describing what was tested"
     ]
   }
 }`,
@@ -36,184 +43,75 @@ func coreConstraints() map[string]string {
   "id": "escalation-triggers",
   "type": "constraint",
   "boot": true,
-  "summary": "Stop and ask the user before: spending money, external publication, destructive actions, structural changes, or unresolvable ambiguity.",
+  "summary": "Explicit instruction before action, always. A question is not permission. An assumption about what the user wants is not permission.",
   "lifecycle": "permanent",
   "scope": "core",
   "tags": ["escalation", "approval", "safety", "owner-decision"],
   "created": "2026-04-08T00:00:00Z",
   "created_by": "system",
-  "updated": "2026-04-15T00:00:00Z",
+  "updated": "2026-04-29T00:00:00Z",
   "updated_by": "system",
   "content": {
-    "constraint": "There are situations where no agent can proceed without explicit approval from the user. When you hit any trigger, stop, document the situation, present options, and wait.",
-    "why": "Actions taken without an answer can generate lost work or a real problem. Each instance is new — the user approving something yesterday does not grant permission today.",
+    "constraint": "Explicit instruction before action, always. A question in the conversation is not permission to act. An assumption about what the user probably wants is not permission to act. Only an explicit instruction is.",
+    "why": "The most damaging agent failures are not errors — they are correct executions of the wrong intent. Each session is new; approval yesterday does not grant permission today.",
+    "triggers": [
+      "Making a purchase or incurring a cost on someone's behalf",
+      "Publishing or sending something externally that cannot be recalled",
+      "Deleting or overwriting something that cannot be recovered",
+      "Starting a task while still waiting for a response to a question",
+      "Changing something outside the explicitly agreed scope"
+    ],
     "how_to_apply": [
-      "Spending money: paid API calls, cloud deploys, domain/license purchases",
-      "External publication: git push to main on public repo, merging PR, social media post, app store release",
-      "Destructive action: rm -rf, git reset --hard, force push, drop table, mass delete",
-      "Structural change: adding/modifying a core rule, architecture change outside task scope",
-      "Unresolvable ambiguity: contradiction between rules, strategic decisions requiring inference of user intent"
+      "Stop as soon as you recognize a trigger",
+      "State clearly what you were about to do and why you stopped",
+      "Present at least 2 options and wait for explicit instruction"
     ],
     "responsibility": "All agents without exception.",
     "anti_patterns": [
       "Asking permission for everything — escalation is for this list only",
       "Skipping a trigger because the user approved something similar before",
-      "Escalating without options — always present at least 2 options"
-    ]
-  }
-}`,
-		"evidence-over-claim": `{
-  "id": "evidence-over-claim",
-  "type": "constraint",
-  "boot": true,
-  "summary": "Every delivery must come with verifiable evidence. If you don't have evidence, the work is not done.",
-  "lifecycle": "permanent",
-  "scope": "core",
-  "tags": ["evidence", "verification", "delivery", "quality"],
-  "created": "2026-04-08T00:00:00Z",
-  "created_by": "system",
-  "updated": "2026-04-15T00:00:00Z",
-  "updated_by": "system",
-  "content": {
-    "constraint": "The user shouldn't need to believe you. They should be able to check. Every delivery must come with verifiable evidence.",
-    "why": "Claude has a strong tendency to say 'done, passed, works' without verifying. 'Said it passed' and 'passed' are different things.",
-    "how_to_apply": [
-      "Dev: paste output of build, test, lint. Screenshot for UI changes",
-      "Research: sources cited with URL, author, date",
-      "Writing: final text pasted, not 'I wrote it and it's good'"
-    ],
-    "responsibility": "All agents. MOM rejects deliveries without evidence.",
-    "anti_patterns": [
-      "'Build passed' without the output",
-      "'Tested and it works' without describing what was tested",
-      "'Fixed the bug' without explaining root cause"
-    ]
-  }
-}`,
-		"metrics-collection": `{
-  "id": "metrics-collection",
-  "type": "constraint",
-  "boot": true,
-  "summary": "Every session leaves one session-log doc in .mom/logs/. Collection is enforced by the session-wrap-up skill.",
-  "lifecycle": "permanent",
-  "scope": "core",
-  "tags": ["metrics", "quality", "refinement", "measurement"],
-  "created": "2026-04-08T00:00:00Z",
-  "created_by": "system",
-  "updated": "2026-04-17T00:00:00Z",
-  "updated_by": "system",
-  "content": {
-    "constraint": "Every session leaves one session-log doc in .mom/logs/. MOM produces logs at wrap-up, never consumes them — monitoring is external.",
-    "why": "Without metrics, refining the core becomes guesswork. With metrics, we look at the worst numbers and go straight to the pain. If MOM forgets to log, the dataset becomes skewed.",
-    "how_to_apply": [
-      "Collection happens at session wrap-up via the session-wrap-up skill step 'Write session log'",
-      "Session-logs include: tasks performed, wrap-up revision count",
-      "Session-log docs are stored in .mom/logs/, never indexed, never loaded at boot",
-      "External T1 scripts read session-log files from disk for metrics dashboards"
-    ],
-    "responsibility": "Enforced by the session-wrap-up skill. MOM provides the data, external scripts consume it.",
-    "anti_patterns": [
-      "Skipping session-log for 'trivial' sessions",
-      "Loading session-log docs at boot or during work",
-      "Adding session-log docs to index.json"
-    ]
-  }
-}`,
-		"propagation": `{
-  "id": "propagation",
-  "type": "constraint",
-  "boot": true,
-  "summary": "No task is complete until the memory reflects what changed. Decisions, patterns, facts, and learnings must be materialized before reporting done.",
-  "lifecycle": "permanent",
-  "scope": "core",
-  "tags": ["propagation", "wrap-up", "persistence", "knowledge-management"],
-  "created": "2026-04-08T00:00:00Z",
-  "created_by": "system",
-  "updated": "2026-04-15T00:00:00Z",
-  "updated_by": "system",
-  "content": {
-    "constraint": "No task is complete until the memory reflects what changed. Decisions, patterns, facts, and learnings must be materialized as JSON docs in memory before reporting done.",
-    "why": "Without propagation, knowledge stays in conversation context and dies with the session. Memory is the system's long-term store — if it doesn't reflect what happened, the next session starts blind.",
-    "how_to_apply": [
-      "Primary trigger: explicit user end-of-session signal invokes session-wrap-up skill",
-      "Secondary trigger: when a decision is clearly locked mid-session, create a single memory doc immediately",
-      "Safety net: if many decisions accumulate without a closing signal, ask once",
-      "When in doubt about propagating mid-session, wait for wrap-up"
-    ],
-    "responsibility": "MOM is solely responsible for propagation. Only MOM writes to memory.",
-    "anti_patterns": [
-      "Running full wrap-up without explicit trigger",
-      "Writing 'current project status' docs that will be stale in a week",
-      "Propagating implementation details that live in code"
-    ]
-  }
-}`,
-		"inheritance": `{
-  "id": "inheritance",
-  "type": "constraint",
-  "boot": true,
-  "summary": "Project memory docs extend core memory docs — they specialize, never override. Core provides the foundation, project adds specifics.",
-  "lifecycle": "permanent",
-  "scope": "core",
-  "tags": ["inheritance", "extension", "core-project", "propagation"],
-  "created": "2026-04-08T00:00:00Z",
-  "created_by": "system",
-  "updated": "2026-04-15T00:00:00Z",
-  "updated_by": "system",
-  "content": {
-    "constraint": "Project memory docs (scope: project) complement core memory docs (scope: core) — they extend, never override. The principle 'extend never override' is structural.",
-    "why": "This lets the core update rules, patterns, and identity without breaking projects. Without it, a project would copy core content and lose the benefit of global updates.",
-    "how_to_apply": [
-      "Core docs (scope: core) define universal behavior. Project docs (scope: project) add specifics",
-      "Project can add stricter rules but cannot disable or weaken a core constraint",
-      "leo update syncs core-scoped docs to downstream projects"
-    ],
-    "responsibility": "MOM loads both core and project docs. MOM can explain which came from core vs project.",
-    "anti_patterns": [
-      "Removing core behavior from a project",
-      "Inlining core content into project docs",
-      "Contradicting core principles"
+      "Escalating without options — always present at least 2 options",
+      "Starting work in parallel while waiting for a response to a question"
     ]
   }
 }`,
 	}
 }
 
-// coreSkills returns the core skill documents that ship with every leo init.
+// coreSkills returns the core skill documents that ship with every mom init.
 func coreSkills() map[string]string {
 	return map[string]string{
 		"session-wrap-up": `{
   "id": "session-wrap-up",
   "type": "skill",
   "boot": true,
-  "summary": "End-of-session knowledge propagation: inventory changes, classify, present plan, write memory docs, write session log, report.",
+  "summary": "Session memories curation: surface recent drafts, identify what is worth promoting, execute promotions.",
   "lifecycle": "permanent",
   "scope": "core",
-  "tags": ["wrap-up", "propagation", "persistence", "session"],
+  "tags": ["wrap-up", "curation", "promotion", "session"],
   "created": "2026-04-08T00:00:00Z",
   "created_by": "system",
-  "updated": "2026-04-18T00:00:00Z",
+  "updated": "2026-04-29T00:00:00Z",
   "updated_by": "system",
   "content": {
-    "description": "Orchestrates end-of-session knowledge propagation and session logging.",
+    "description": "Curates session memories by surfacing what the Drafter captured automatically, identifying what is worth promoting to curated memory, and executing promotions. Can be run mid-session (e.g., before /clear) or at end of session.",
     "triggers": ["wrap up", "close the session", "done for today", "finalize", "fecha a sessão", "consolida aí", "pronto por hoje", "pode fechar"],
     "invoked_by": "mom",
     "steps": [
-      {"name": "Inventory", "instruction": "List what changed: decisions, state changes, artifacts, learnings. Skip implementation details.", "wait_for_approval": false},
-      {"name": "Classify", "instruction": "For each item: determine type, lifecycle, tags, id. Check index for existing docs to update.", "wait_for_approval": false},
-      {"name": "Present plan", "instruction": "Show the user: new docs, updates, skipped items, commit strategy. Wait for approval.", "wait_for_approval": true},
-      {"name": "Execute", "instruction": "Write JSON docs to .mom/memory/ following schema with promotion_state: 'curated'. Do NOT write memory docs to .mom/logs/ — that directory is for session-log entries only. Stage exact files. Commit with clear message.", "wait_for_approval": false},
-      {"name": "Write session log", "instruction": "Write a session-log doc to .mom/logs/ using this template: {id: 'session-YYYY-MM-DD-XXXX', type: 'session-log', lifecycle: 'state', scope: 'project', tags: ['session-log'], content: {session_id: (same as id), timestamp: (now), repo: (repo name), communication_mode: (active mode from config), wrap_up_revisions: (count of rejected plans), tasks: [{task_id, timestamp, summary, tags}]}}. Create .mom/logs/ directory if it doesn't exist. Session-logs are NOT indexed and NOT loaded at boot.", "wait_for_approval": false},
-      {"name": "Report", "instruction": "Brief report: commit SHA, files changed, session log written, deferred items.", "wait_for_approval": false}
+      {"name": "Surface", "instruction": "Call mom_recall with a broad query and include drafts. Focus on the last hour of activity. This returns what the Drafter automatically captured from this session — do not reconstruct from context window.", "wait_for_approval": false},
+      {"name": "Synthesize", "instruction": "Read each draft's content and tags. Distill a one-liner summary per draft. Group related drafts that cover the same topic. Apply judgment: is this decision, pattern, or fact worth preserving across sessions?", "wait_for_approval": false},
+      {"name": "Present plan", "instruction": "Show only the recommended promotions — not everything found. Format each as: draft ID, one-line summary, tags, promote/discard recommendation. Do not show discarded items unless the user asks. Wait for approval.", "wait_for_approval": true},
+      {"name": "Execute", "instruction": "For each approved promotion, call create_memory_draft. No action needed for discarded drafts.", "wait_for_approval": false},
+      {"name": "Report", "instruction": "Brief summary: how many drafts found, how many promoted, how many discarded.", "wait_for_approval": false}
     ],
     "do_not": [
       "Run without explicit trigger from user",
       "Skip the approval step",
-      "Manufacture propagation when inventory is empty",
-      "Load or read session-log docs — monitoring is external",
-      "Index session-log docs in index.json"
+      "Present discarded drafts unless the user asks",
+      "Reconstruct history from context window — use mom_recall instead",
+      "Write session log docs — session logging is automated by Logbook"
     ],
-    "output_format": "## Wrap-up complete\n\n**Committed:** [SHA]\n**Session log:** [written/skipped]\n**Deferred:** [list or nothing]"
+    "output_format": "## Wrap-up complete\n\n**Promoted:** [N memories]\n**Discarded:** [N drafts]\n**Deferred:** [list or nothing]"
   }
 }`,
 	}


### PR DESCRIPTION
## Summary

- **Retire 4 constraints** that describe behavior now automated in code
- **Rewrite 2 constraints** for real-world effectiveness
- **Redesign session-wrap-up** as a draft curation ritual powered by `mom_recall`

All changes in `core_memory.go`. Deployed to users via `mom upgrade`.

## What changed

**Retired:**
- `evidence-over-claim` — merged into `anti-hallucination`
- `inheritance` — LEO-era symlink architecture, never implemented in code; constraints now live in the binary
- `metrics-collection` — automated by Logbook/Herald since v0.13
- `propagation` — automated by tail transcript + Drafter; agent judgment on mid-session triggers is unreliable

**Rewritten — `anti-hallucination`:**
- `[RECALL]` and `[INFERRED]` are now **mandatory** markers in specific situations, not optional guidance
- `[GUESS]` retired — agents use plain language instead ("I don't know")
- Added "show your verification" obligation (paste output, read before asserting, explain root cause)
- `evidence-over-claim` anti-patterns merged in

**Rewritten — `escalation-triggers`:**
- New organizing principle: *explicit instruction before action, always*
- Trigger list rewritten in behavior terms, not tool terms — covers non-technical users
- Added: "starting a task while waiting for a response" (real failure mode)

**Redesigned — `session-wrap-up`:**
- Renamed concept: "Session memories curation" (can run mid-session, not just end-of-session)
- Replaces context-window inventory (unreliable after `/clear`) with `mom_recall` draft surfacing
- Presents only recommended promotions — agent filters noise
- Uses `create_memory_draft` for execution
- Removes stale session-log step (automated by Logbook)

## Test plan

- [x] `go build ./...` clean
- [x] `TestMomStatusConstraintsLoaded` — passes (already expected exactly `anti-hallucination` + `escalation-triggers`)
- [x] `TestMomStatusSkillsLoaded` — passes (session-wrap-up still present)
- [x] All `internal/cmd` and `internal/mcp` tests green

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)