### PR TITLE
fix(init): reconcile harnesses on reinit — enable selected, disable unselected

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,16 @@ A classification of Harness integration quality from MOM's perspective. Tier is 
 > **Dev:** "Should we add an MRP event for compaction?"
 > **Architect:** "Pi can support it natively — it's Native, the extension subscribes to compaction events. Claude is Fluent but happens to expose `PreCompact`, so we can wire it via hook. Windsurf is Functional; we won't capture compaction reliably and shouldn't promise it."
 
+## Dev conventions
+
+**Local build for testing**: before releasing from a `-dev` branch, build the binary locally and point it to `/tmp/mom` for testing without affecting the Homebrew installation:
+
+```bash
+cd cli && go build -ldflags "-X github.com/momhq/mom/cli/internal/cmd.Version=vX.X.X-dev" -o /tmp/mom ./cmd/mom/
+```
+
+Then run as `/tmp/mom <command>` from any directory.
+
 ## Coding conventions
 
 **Code comments**: Concise, objective, descriptive. Clarify what code does, not why a design was chosen. No ADR cross-references in `.go` files, no storytelling, no rationale prose. Rationale lives in commit messages, PR descriptions, and ADRs — not in code.

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -412,21 +412,32 @@ func runReinit(cmd *cobra.Command, cwd, leoDir string, result OnboardingResult, 
 		return nil
 	}
 
-	// Merge new runtimes into existing config.
+	// Reconcile harnesses: enable selected, disable unselected.
+	selected := make(map[string]bool, len(result.Harnesses))
+	for _, rt := range result.Harnesses {
+		selected[rt] = true
+	}
 	changed := false
 	for _, rt := range result.Harnesses {
-		if _, exists := cfg.Harnesses[rt]; !exists {
+		existing, exists := cfg.Harnesses[rt]
+		if !exists || !existing.Enabled {
 			cfg.Harnesses[rt] = config.HarnessConfig{Enabled: true}
+			changed = true
+		}
+	}
+	for rt, hc := range cfg.Harnesses {
+		if !selected[rt] && hc.Enabled {
+			cfg.Harnesses[rt] = config.HarnessConfig{Enabled: false}
 			changed = true
 		}
 	}
 
 	if !changed {
-		// Still register with global daemon even if runtimes unchanged.
+		// Still register with global daemon even if config unchanged.
 		if err := ensureGlobalDaemon(cwd, leoDir, cfg.EnabledRuntimes()); err != nil {
 			p.Warnf("watch daemon: %v", err)
 		}
-		p.Muted(".mom/ already configured with selected runtimes — nothing to update.")
+		p.Muted(".mom/ already up to date — nothing to update.")
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- `runReinit` only added new harnesses and never disabled existing ones, making it impossible to remove a harness via `mom init`
- New reconcile logic: enables harnesses in the selection, disables any not in the selection
- Fixes the "nothing to update" early return that fired even when harnesses needed to be disabled
- Updates "nothing to update" message to be less runtime-specific

## Root cause

```go
// Before: only added, never disabled
for _, rt := range result.Harnesses {
    if _, exists := cfg.Harnesses[rt]; !exists {
        cfg.Harnesses[rt] = config.HarnessConfig{Enabled: true}
        changed = true
    }
}
```

## Test plan

- [ ] Run `/tmp/mom init` on an existing `.mom/` — deselect a harness (e.g. Windsurf), select a new one (e.g. Pi)
- [ ] Verify `cat .mom/config.yaml` shows Windsurf disabled and Pi enabled
- [ ] Run `/tmp/mom init` again with same selection — verify "already up to date" message
- [ ] Run `/tmp/mom status` — verify harnesses reflect the updated selection

## Out of scope

Propagation to child scopes (org/user level cascading to repos) is tracked separately for v0.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)