### PR TITLE
fix(upgrade): remove retired constraints from v0.14 audit

### DIFF
--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -192,6 +192,10 @@ func upgradeSingleDir(cmd *cobra.Command, projectRoot string, dryRun bool) error
 			"peer-review-automatic",
 			"token-economy-caveman",
 			"token-economy-model-selection",
+			"evidence-over-claim",
+			"inheritance",
+			"metrics-collection",
+			"propagation",
 		}
 		constraintsDir := filepath.Join(leoDir, "constraints")
 		for _, name := range retiredConstraints {


### PR DESCRIPTION
## Summary

The v0.14 constraints audit (#208) retired four constraints — `evidence-over-claim`, `inheritance`, `metrics-collection`, `propagation` — by removing them from `coreConstraints()`. However, they were not added to the `retiredConstraints` list in `upgrade.go`, so existing `.mom/` directories still had the stale files on disk after running `mom upgrade`.

## Fix

Added the four constraint names to `retiredConstraints` so `mom upgrade` removes them across all scopes.

## Test plan

- [ ] Run `/tmp/mom upgrade` on a `.mom/` that has the old constraint files
- [ ] Verify `evidence-over-claim.json`, `inheritance.json`, `metrics-collection.json`, `propagation.json` are deleted
- [ ] Verify `mom_status` shows only `anti-hallucination` and `escalation-triggers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)