### PR TITLE
fix(scope): default $HOME/.mom/ to user label

### DIFF
--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -72,6 +72,10 @@ func Walk(cwd string) []Scope {
 		candidate := filepath.Join(dir, ".mom")
 		if isRealDir(candidate) {
 			label := loadScopeLabel(candidate)
+			// $HOME/.mom/ with no explicit scope config defaults to "user".
+			if label == "repo" && dir == home {
+				label = "user"
+			}
 			scopes = append(scopes, Scope{Path: candidate, Label: label})
 		}
 


### PR DESCRIPTION
## Summary

- `scope.Walk` was labeling every config-less `.mom/` directory as `repo`, including the user's `$HOME/.mom/` vault.
- Special-case `$HOME/.mom/` to default to the `user` label. Explicit scope configs still take precedence.

Closes #219.

## Test plan

- [ ] `mom status` from a directory under `$HOME` (no repo `.mom/` ahead of it) reports `user` scope, not `repo`
- [ ] Repo with explicit `.mom/scope.yaml` still uses the configured label
- [ ] `mom lens` shows `user` label in the scope switcher for `$HOME/.mom/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)