### PR TITLE
fix(lens): live memory index, http timeouts, port fallback

### DIFF
--- a/cli/internal/cmd/lens.go
+++ b/cli/internal/cmd/lens.go
@@ -7,12 +7,15 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/momhq/mom/cli/internal/lens"
 	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/ux"
 	"github.com/spf13/cobra"
 )
+
+const defaultLensPort = 7474
 
 var lensCmd = &cobra.Command{
 	Use:   "lens",
@@ -27,11 +30,12 @@ Press Ctrl+C to stop the server.`,
 }
 
 func init() {
-	lensCmd.Flags().Int("port", 7474, "Port to listen on")
+	lensCmd.Flags().Int("port", defaultLensPort, "Port to listen on")
 }
 
 func runLens(cmd *cobra.Command, _ []string) error {
 	port, _ := cmd.Flags().GetInt("port")
+	portExplicit := cmd.Flags().Changed("port")
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -53,12 +57,18 @@ func runLens(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("starting lens: %w", err)
 	}
 
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	// Default port: try up to 10 fallbacks. Explicit --port: fail loud if taken.
+	fallbacks := 10
+	if portExplicit {
+		fallbacks = 0
+	}
+	ln, err := lens.ListenWithFallback("", port, fallbacks)
 	if err != nil {
 		return fmt.Errorf("listening on port %d: %w", port, err)
 	}
+	actualPort := ln.Addr().(*net.TCPAddr).Port
 
-	url := fmt.Sprintf("http://localhost:%d", port)
+	url := fmt.Sprintf("http://localhost:%d", actualPort)
 	p := ux.NewPrinter(cmd.OutOrStdout())
 	p.Checkf("mom lens → %s", url)
 	for _, s := range scopes {
@@ -72,7 +82,13 @@ func runLens(cmd *cobra.Command, _ []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	httpSrv := &http.Server{Handler: srv.Handler()}
+	httpSrv := &http.Server{
+		Handler:           srv.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 	go func() {
 		<-ctx.Done()
 		_ = httpSrv.Close()

--- a/cli/internal/lens/listener.go
+++ b/cli/internal/lens/listener.go
@@ -1,0 +1,38 @@
+package lens
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"syscall"
+)
+
+// ListenWithFallback binds a TCP listener on host:preferred. If the port is
+// taken, it tries up to `attempts` consecutive ports (preferred+1, preferred+2, ...).
+// attempts=0 disables fallback (use when the user explicitly chose the port).
+func ListenWithFallback(host string, preferred, attempts int) (net.Listener, error) {
+	addr := net.JoinHostPort(host, strconv.Itoa(preferred))
+	ln, err := net.Listen("tcp", addr)
+	if err == nil {
+		return ln, nil
+	}
+	if attempts <= 0 || !isAddrInUse(err) {
+		return nil, err
+	}
+	for i := 1; i <= attempts; i++ {
+		addr := net.JoinHostPort(host, strconv.Itoa(preferred+i))
+		ln, err := net.Listen("tcp", addr)
+		if err == nil {
+			return ln, nil
+		}
+		if !isAddrInUse(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("no free port in range %d..%d", preferred, preferred+attempts)
+}
+
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
+}

--- a/cli/internal/lens/server.go
+++ b/cli/internal/lens/server.go
@@ -81,12 +81,11 @@ type MetaResponse struct {
 	TotalMemories int         `json:"total_memories"`
 }
 
-// scopeData holds pre-built indexes for one scope.
+// scopeData carries scope identity. Memory and session data are read fresh
+// on each request — see loadMemoryIndex and loadSessions.
 type scopeData struct {
-	entry         ScopeEntry
-	key           string // "0", "1", ... set by New()
-	memIndex      map[string][]MemoryItem // session_id → memories
-	totalMemories int
+	entry ScopeEntry
+	key   string // "0", "1", ... set by New()
 }
 
 // Server serves the lens dashboard.
@@ -100,9 +99,7 @@ func New(scopes []ScopeEntry) (*Server, error) {
 	s := &Server{mux: http.NewServeMux()}
 
 	for i, e := range scopes {
-		sd := &scopeData{entry: e, key: strconv.Itoa(i)}
-		sd.buildMemoryIndex()
-		s.scopes = append(s.scopes, sd)
+		s.scopes = append(s.scopes, &scopeData{entry: e, key: strconv.Itoa(i)})
 	}
 
 	s.mux.Handle("GET /api/meta", http.HandlerFunc(s.handleMeta))
@@ -126,12 +123,16 @@ func New(scopes []ScopeEntry) (*Server, error) {
 // Handler returns the HTTP handler.
 func (s *Server) Handler() http.Handler { return s.mux }
 
-func (sd *scopeData) buildMemoryIndex() {
-	sd.memIndex = make(map[string][]MemoryItem)
+// loadMemoryIndex scans the scope's memory dir and returns a session_id →
+// memories map plus the total memory count. Called per request — cheap for
+// local dirs and avoids stale state when memories are written while lens runs.
+func (sd *scopeData) loadMemoryIndex() (map[string][]MemoryItem, int) {
+	index := make(map[string][]MemoryItem)
+	total := 0
 	memDir := filepath.Join(sd.entry.Path, "memory")
 	entries, err := os.ReadDir(memDir)
 	if err != nil {
-		return
+		return index, 0
 	}
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
@@ -141,9 +142,9 @@ func (sd *scopeData) buildMemoryIndex() {
 		if err != nil {
 			continue
 		}
-		sd.totalMemories++
+		total++
 		if doc.SessionID != "" {
-			sd.memIndex[doc.SessionID] = append(sd.memIndex[doc.SessionID], MemoryItem{
+			index[doc.SessionID] = append(index[doc.SessionID], MemoryItem{
 				ID:             doc.ID,
 				Summary:        doc.Summary,
 				Tags:           doc.Tags,
@@ -154,17 +155,21 @@ func (sd *scopeData) buildMemoryIndex() {
 			})
 		}
 	}
+	return index, total
 }
 
-// loadScopeSessionss returns sessions for a single scope.
-func (sd *scopeData) loadSessions() ([]SessionSummary, error) {
+// loadSessions returns sessions for a single scope, joined with the live
+// memory index for that scope.
+func (sd *scopeData) loadSessions() ([]SessionSummary, int, error) {
+	memIndex, totalMemories := sd.loadMemoryIndex()
+
 	logsDir := filepath.Join(sd.entry.Path, "logs")
 	entries, err := os.ReadDir(logsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, totalMemories, nil
 		}
-		return nil, err
+		return nil, totalMemories, err
 	}
 
 	var sessions []SessionSummary
@@ -184,12 +189,12 @@ func (sd *scopeData) loadSessions() ([]SessionSummary, error) {
 		if err := json.Unmarshal(data, &sl); err != nil {
 			continue
 		}
-		sessions = append(sessions, sd.toSummary(&sl))
+		sessions = append(sessions, sd.toSummary(&sl, memIndex))
 	}
-	return sessions, nil
+	return sessions, totalMemories, nil
 }
 
-func (sd *scopeData) toSummary(sl *logbook.SessionLog) SessionSummary {
+func (sd *scopeData) toSummary(sl *logbook.SessionLog, memIndex map[string][]MemoryItem) SessionSummary {
 	dur := 0.0
 	t1, err1 := time.Parse(time.RFC3339, sl.Started)
 	t2, err2 := time.Parse(time.RFC3339, sl.Ended)
@@ -209,7 +214,7 @@ func (sd *scopeData) toSummary(sl *logbook.SessionLog) SessionSummary {
 		costUSD = sl.Usage.CostUSD
 	}
 
-	memories := sd.memIndex[sl.SessionID]
+	memories := memIndex[sl.SessionID]
 	curatedCount := 0
 	for _, m := range memories {
 		if m.PromotionState == "curated" || m.Landmark {
@@ -239,13 +244,13 @@ func (s *Server) handleMeta(w http.ResponseWriter, _ *http.Request) {
 	seenIDs := make(map[string]bool)
 	totalSessions, totalMemories := 0, 0
 	for _, sd := range s.scopes {
-		sessions, _ := sd.loadSessions()
+		sessions, scopeMemories, _ := sd.loadSessions()
 		infos = append(infos, ScopeInfo{
 			Key:           sd.key,
 			Label:         sd.entry.Label,
 			PathHint:      filepath.Base(filepath.Dir(sd.entry.Path)),
 			TotalSessions: len(sessions),
-			TotalMemories: sd.totalMemories,
+			TotalMemories: scopeMemories,
 		})
 		for _, s := range sessions {
 			if !seenIDs[s.SessionID] {
@@ -253,7 +258,7 @@ func (s *Server) handleMeta(w http.ResponseWriter, _ *http.Request) {
 				totalSessions++
 			}
 		}
-		totalMemories += sd.totalMemories
+		totalMemories += scopeMemories
 	}
 	jsonResponse(w, MetaResponse{
 		Scopes:        infos,
@@ -270,7 +275,7 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 		if scopeFilter != "" && scopeFilter != "all" && sd.key != scopeFilter {
 			continue
 		}
-		sessions, err := sd.loadSessions()
+		sessions, _, err := sd.loadSessions()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -318,12 +323,13 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "malformed session log", http.StatusInternalServerError)
 			return
 		}
-		memories := sd.memIndex[id]
+		memIndex, _ := sd.loadMemoryIndex()
+		memories := memIndex[id]
 		if memories == nil {
 			memories = []MemoryItem{}
 		}
 		jsonResponse(w, SessionDetail{
-			SessionSummary: sd.toSummary(&sl),
+			SessionSummary: sd.toSummary(&sl, memIndex),
 			ToolCalls:      sl.ToolCalls,
 			Memories:       memories,
 		})

--- a/cli/internal/lens/server_test.go
+++ b/cli/internal/lens/server_test.go
@@ -1,0 +1,182 @@
+package lens
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeJSON writes v as JSON to path, creating parent dirs as needed.
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// fixtureScope creates a .mom/ scope with logs/ and memory/ subdirs.
+func fixtureScope(t *testing.T) string {
+	t.Helper()
+	momDir := filepath.Join(t.TempDir(), ".mom")
+	for _, sub := range []string{"logs", "memory"} {
+		if err := os.MkdirAll(filepath.Join(momDir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	return momDir
+}
+
+func writeSessionLog(t *testing.T, momDir, sessionID string) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	log := map[string]any{
+		"session_id":   sessionID,
+		"started":      now,
+		"ended":        now,
+		"interactions": 1,
+		"tool_calls":   map[string]any{},
+	}
+	writeJSON(t, filepath.Join(momDir, "logs", "session-"+sessionID+".json"), log)
+}
+
+func writeMemoryDoc(t *testing.T, momDir, id, sessionID string) {
+	t.Helper()
+	doc := map[string]any{
+		"id":         id,
+		"scope":      "project",
+		"tags":       []string{},
+		"created":    time.Now().UTC(),
+		"created_by": "test",
+		"session_id": sessionID,
+		"content":    map[string]any{},
+	}
+	writeJSON(t, filepath.Join(momDir, "memory", id+".json"), doc)
+}
+
+// fetchSessions hits GET /api/sessions and returns the parsed result.
+func fetchSessions(t *testing.T, h http.Handler) []SessionSummary {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got []SessionSummary
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return got
+}
+
+// TestSessions_PicksUpNewMemoriesWithoutRestart locks down bug #1 + #2:
+// memories created after Server.New() must show up on subsequent requests.
+func TestSessions_PicksUpNewMemoriesWithoutRestart(t *testing.T) {
+	momDir := fixtureScope(t)
+	const sid = "sess-aaa"
+
+	writeSessionLog(t, momDir, sid)
+	writeMemoryDoc(t, momDir, "mem-1", sid)
+
+	srv, err := New([]ScopeEntry{{Label: "test", Path: momDir}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got := fetchSessions(t, srv.Handler())
+	if len(got) != 1 || got[0].MemoryCount != 1 {
+		t.Fatalf("first read: want 1 session with 1 memory, got %+v", got)
+	}
+
+	// Memory created AFTER server start — must be visible on next request.
+	writeMemoryDoc(t, momDir, "mem-2", sid)
+
+	got = fetchSessions(t, srv.Handler())
+	if len(got) != 1 || got[0].MemoryCount != 2 {
+		t.Fatalf("second read: want 1 session with 2 memories, got %+v", got)
+	}
+}
+
+// TestMeta_ReflectsLiveMemoryCount locks down bug #1 for /api/meta.
+func TestMeta_ReflectsLiveMemoryCount(t *testing.T) {
+	momDir := fixtureScope(t)
+	writeMemoryDoc(t, momDir, "mem-1", "sess-x")
+
+	srv, err := New([]ScopeEntry{{Label: "test", Path: momDir}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	get := func() MetaResponse {
+		req := httptest.NewRequest(http.MethodGet, "/api/meta", nil)
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		var m MetaResponse
+		_ = json.Unmarshal(rec.Body.Bytes(), &m)
+		return m
+	}
+
+	if m := get(); m.TotalMemories != 1 {
+		t.Fatalf("first meta: want 1 memory, got %d", m.TotalMemories)
+	}
+
+	writeMemoryDoc(t, momDir, "mem-2", "sess-y")
+
+	if m := get(); m.TotalMemories != 2 {
+		t.Fatalf("second meta: want 2 memories, got %d", m.TotalMemories)
+	}
+}
+
+// TestListenWithFallback_BumpsToNextPort locks down bug #4:
+// when the preferred port is taken, the helper picks a free nearby port.
+func TestListenWithFallback_BumpsToNextPort(t *testing.T) {
+	occupier, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("seed listen: %v", err)
+	}
+	defer occupier.Close()
+
+	taken := occupier.Addr().(*net.TCPAddr).Port
+
+	ln, err := ListenWithFallback("127.0.0.1", taken, 5)
+	if err != nil {
+		t.Fatalf("ListenWithFallback: %v", err)
+	}
+	defer ln.Close()
+
+	got := ln.Addr().(*net.TCPAddr).Port
+	if got == taken {
+		t.Fatalf("expected fallback port, got the occupied one (%d)", got)
+	}
+	if got < taken+1 || got > taken+5 {
+		t.Fatalf("expected port in [%d, %d], got %d", taken+1, taken+5, got)
+	}
+}
+
+// TestListenWithFallback_ZeroAttemptsFailsCleanly: explicit-port behavior
+// (attempts=0 means no fallback, fail loud if taken).
+func TestListenWithFallback_ZeroAttemptsFailsCleanly(t *testing.T) {
+	occupier, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("seed listen: %v", err)
+	}
+	defer occupier.Close()
+
+	taken := occupier.Addr().(*net.TCPAddr).Port
+
+	if _, err := ListenWithFallback("127.0.0.1", taken, 0); err == nil {
+		t.Fatalf("expected error when port is taken and attempts=0")
+	}
+}


### PR DESCRIPTION
## Summary

- Memory index is now refreshed on every `/api/sessions`, `/api/sessions/{id}`, and `/api/meta` request — sessions or memories created while lens is running show up without a server restart.
- Removes the inconsistency where sessions were live but memories were cached (both now share `loadMemoryIndex` per request).
- Adds explicit `ReadHeaderTimeout`/`ReadTimeout`/`WriteTimeout`/`IdleTimeout` on `http.Server` (closes gosec G114).
- Default port (7474) falls back through the next 10 ports if taken; explicit `--port` still fails loud on conflict.
- New `ListenWithFallback` helper with deterministic unit tests.
- Stale comment (`loadScopeSessionss`) cleaned up in the refactor.

Closes #224.

## Test plan

- [x] `go test ./internal/lens/` green
- [ ] `mom lens` opens, then in another terminal record a session — refresh the dashboard, new row appears
- [ ] Start `mom lens` twice — second instance picks up port 7475 with a clear log line
- [ ] `mom lens --port 7474` (when occupied) errors out loud

🤖 Generated with [Claude Code](https://claude.com/claude-code)