### PR TITLE
test(memory): remove TestLiveMemoryFiles — couples tests to local vault

### DIFF
--- a/cli/internal/memory/memory_schema_test.go
+++ b/cli/internal/memory/memory_schema_test.go
@@ -278,55 +278,6 @@ func TestProvenanceRawExhaustRef(t *testing.T) {
 	}
 }
 
-// findRepoMemoryDir walks up from the current directory looking for .mom/memory.
-func findRepoMemoryDir() (string, bool) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", false
-	}
-	for {
-		candidate := filepath.Join(dir, ".mom", "memory")
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			return candidate, true
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", false
-		}
-		dir = parent
-	}
-}
-
-// TestLiveMemoryFiles verifies all memory files in the repo's own .mom/memory/
-// continue to load and validate without error after the schema evolution.
-func TestLiveMemoryFiles(t *testing.T) {
-	memoryDir, found := findRepoMemoryDir()
-	if !found {
-		t.Skip("skipping live memory test: .mom/memory not found in any ancestor directory")
-	}
-
-	entries, err := os.ReadDir(memoryDir)
-	if err != nil {
-		t.Skipf("skipping live memory test: cannot read %s: %v", memoryDir, err)
-	}
-
-	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
-			continue
-		}
-		t.Run(e.Name(), func(t *testing.T) {
-			path := filepath.Join(memoryDir, e.Name())
-			doc, err := LoadDoc(path)
-			if err != nil {
-				t.Fatalf("LoadDoc failed: %v", err)
-			}
-			if err := doc.Validate(); err != nil {
-				t.Errorf("Validate failed: %v", err)
-			}
-		})
-	}
-}
-
 // TestNewDoc_WriteEmitsFields ensures new docs emit all applicable fields.
 func TestNewDoc_WriteEmitsFields(t *testing.T) {
 	score := 0.72


### PR DESCRIPTION
## Summary

`TestLiveMemoryFiles` walked up from CWD to find any `.mom/memory/` and validated whatever it found. The result:

- The test read dev-local data, not repo-controlled fixtures.
- Passed/failed depending on the contents of each contributor's vault.
- Silently skipped in CI (the only environment with a clean baseline).
- Failed on dev machines holding memories that no longer match today's schema validation, even though the product itself loads them fine.

This is "tests on my machine" — we should run the same things our users run.

If the original intent (round-trip compatibility for old docs after schema evolution) is worth keeping, add it back later as deterministic golden fixtures under `cli/internal/memory/testdata/`.

Closes #230.

## Test plan

- [x] `go test ./internal/memory/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)