### PR TITLE
feat(vault): v0.30 Schema + Vault module (#233)

### DIFF
--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -133,14 +133,20 @@ const dsnPragmas = "?_pragma=foreign_keys(1)" +
 	"&_pragma=synchronous(NORMAL)" +
 	"&_pragma=cache_size(-8000)"
 
-// Open opens or creates the SQLite database at path and returns a usable
-// Vault. Callers must Close the Vault when done.
+// Open opens or creates the SQLite database at path, applies pragmas,
+// runs any pending schema migrations, and returns a usable Vault.
+// Callers must Close the Vault when done.
 //
 // On POSIX systems, the database file is created (or chmod'd if it
 // already exists) with mode 0600. The vault may contain captured
 // memories; group/world readability is the wrong default. modernc.org/
 // sqlite does not expose a perms DSN parameter, so the file is
 // materialized here before sql.Open.
+//
+// Migration is run automatically: a returned Vault is always at the
+// current schema version. There is no opt-out — every consumer wants a
+// migrated vault, and the central vault has no inspect-before-migrate
+// use case (mom upgrade reads legacy per-folder vaults, not this one).
 func Open(path string) (*Vault, error) {
 	if runtime.GOOS != "windows" {
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
@@ -162,7 +168,13 @@ func Open(path string) (*Vault, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("setting journal_mode=WAL: %w", err)
 	}
-	return &Vault{db: db}, nil
+
+	v := &Vault{db: db}
+	if err := v.Migrate(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrating vault at %s: %w", path, err)
+	}
+	return v, nil
 }
 
 // Close releases the underlying database connection.

--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -6,6 +6,8 @@ package vault
 import (
 	"database/sql"
 	"fmt"
+	"os"
+	"runtime"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -35,7 +37,7 @@ var migrations = []migration{
 			id                       TEXT PRIMARY KEY,
 			type                     TEXT NOT NULL DEFAULT 'untyped',
 			summary                  TEXT,
-			content                  TEXT NOT NULL,
+			content                  TEXT NOT NULL CHECK (json_valid(content)),
 			created_at               TEXT NOT NULL,
 			session_id               TEXT,
 			provenance_actor         TEXT,
@@ -119,29 +121,46 @@ type Vault struct {
 	db *sql.DB
 }
 
-// pragmas applied once after opening the database. These are the
-// production defaults inherited from the pre-0.30 storage layer:
-// WAL for concurrent readers, foreign keys enforced, normal sync for
-// good performance with WAL safety, ~8 MB page cache.
-var openPragmas = []string{
-	"PRAGMA journal_mode=WAL",
-	"PRAGMA foreign_keys=ON",
-	"PRAGMA synchronous=NORMAL",
-	"PRAGMA cache_size=-8000",
-}
+// dsnPragmas are SQLite pragmas embedded in the connection string so
+// modernc.org/sqlite applies them on EVERY new connection in the pool.
+// Per-connection pragmas (foreign_keys, synchronous, cache_size) do not
+// persist across pool growth when applied via db.Exec; embedding them
+// in the DSN is the documented fix.
+//
+// WAL mode is database-wide (persists in the file) and is set separately
+// via db.Exec after Open since it is not a per-connection setting.
+const dsnPragmas = "?_pragma=foreign_keys(1)" +
+	"&_pragma=synchronous(NORMAL)" +
+	"&_pragma=cache_size(-8000)"
 
 // Open opens or creates the SQLite database at path and returns a usable
 // Vault. Callers must Close the Vault when done.
+//
+// On POSIX systems, the database file is created (or chmod'd if it
+// already exists) with mode 0600. The vault may contain captured
+// memories; group/world readability is the wrong default. modernc.org/
+// sqlite does not expose a perms DSN parameter, so the file is
+// materialized here before sql.Open.
 func Open(path string) (*Vault, error) {
-	db, err := sql.Open("sqlite", path)
+	if runtime.GOOS != "windows" {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+		if err != nil {
+			return nil, fmt.Errorf("creating vault file at %s: %w", path, err)
+		}
+		_ = f.Close()
+		if err := os.Chmod(path, 0600); err != nil {
+			return nil, fmt.Errorf("chmod %s to 0600: %w", path, err)
+		}
+	}
+
+	db, err := sql.Open("sqlite", path+dsnPragmas)
 	if err != nil {
 		return nil, fmt.Errorf("opening sqlite at %s: %w", path, err)
 	}
-	for _, pragma := range openPragmas {
-		if _, err := db.Exec(pragma); err != nil {
-			_ = db.Close()
-			return nil, fmt.Errorf("applying %q: %w", pragma, err)
-		}
+	// WAL is database-wide — set once via Exec; persists in the file.
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("setting journal_mode=WAL: %w", err)
 	}
 	return &Vault{db: db}, nil
 }

--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -1,0 +1,236 @@
+// Package vault is the persistent memory store for v0.30. It owns the
+// SQLite connection at $HOME/.mom/mom.db, runs schema migrations, and
+// mediates all reads and writes so callers never touch *sql.DB directly.
+package vault
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// migration is one applied schema change identified by an integer
+// version. Each migration carries one or more statements applied as a
+// unit; version is recorded in schema_migrations on success.
+type migration struct {
+	version int
+	stmts   []string
+}
+
+// migrations is the ordered list of schema changes for v0.30.
+// Re-runs of Migrate skip versions already recorded in schema_migrations.
+//
+// Provenance columns (provenance_actor, provenance_source_type,
+// provenance_trigger_event) are plain TEXT with no CHECK constraints —
+// see ADR 0015 (open vocabularies, UTM-style).
+//
+// type defaults to 'untyped' per ADR 0012; promotion_state defaults to
+// 'draft'. There is no valid_to column — temporal validity moves to
+// edges in the future relations layer (ADR 0011).
+var migrations = []migration{
+	{1, []string{
+		`CREATE TABLE IF NOT EXISTS memories (
+			id                       TEXT PRIMARY KEY,
+			type                     TEXT NOT NULL DEFAULT 'untyped',
+			summary                  TEXT,
+			content                  TEXT NOT NULL,
+			created_at               TEXT NOT NULL,
+			session_id               TEXT,
+			provenance_actor         TEXT,
+			provenance_source_type   TEXT,
+			provenance_trigger_event TEXT,
+			promotion_state          TEXT NOT NULL DEFAULT 'draft',
+			landmark                 INTEGER NOT NULL DEFAULT 0,
+			centrality_score         REAL
+		)`,
+		`CREATE TABLE IF NOT EXISTS entities (
+			id           TEXT PRIMARY KEY,
+			type         TEXT NOT NULL,
+			display_name TEXT,
+			created_at   TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS tags (
+			id         TEXT PRIMARY KEY,
+			name       TEXT NOT NULL UNIQUE,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS memory_tags (
+			memory_id  TEXT NOT NULL,
+			tag_id     TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (memory_id, tag_id),
+			FOREIGN KEY (memory_id) REFERENCES memories(id),
+			FOREIGN KEY (tag_id)    REFERENCES tags(id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS memory_entities (
+			memory_id    TEXT NOT NULL,
+			entity_id    TEXT NOT NULL,
+			relationship TEXT NOT NULL,
+			created_at   TEXT NOT NULL,
+			PRIMARY KEY (memory_id, entity_id, relationship),
+			FOREIGN KEY (memory_id) REFERENCES memories(id),
+			FOREIGN KEY (entity_id) REFERENCES entities(id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS event_log (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			event_type TEXT NOT NULL,
+			timestamp  TEXT NOT NULL,
+			session_id TEXT,
+			payload    TEXT
+		)`,
+		`CREATE TABLE IF NOT EXISTS filter_audit (
+			category        TEXT PRIMARY KEY,
+			redaction_count INTEGER NOT NULL DEFAULT 0,
+			last_fired_at   TEXT
+		)`,
+		// FTS5 virtual table indexing the searchable content of memories.
+		// content_text is extracted from the `content` JSON's `$.text`
+		// field by the sync triggers below. Per ADR 0007: bm25 weights
+		// applied at query time as bm25(memories_fts, 0, 2, 10) — zero
+		// on id (opaque UUID), light on summary, heavy on content. Tags
+		// are not in FTS5 in v0.30; tag-based recall uses SQL joins on
+		// memory_tags (ADR 0010).
+		`CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+			id UNINDEXED,
+			summary,
+			content_text,
+			tokenize='porter unicode61'
+		)`,
+		`CREATE TRIGGER IF NOT EXISTS memories_fts_ai AFTER INSERT ON memories BEGIN
+			INSERT INTO memories_fts(rowid, id, summary, content_text)
+			VALUES (new.rowid, new.id, COALESCE(new.summary, ''), COALESCE(json_extract(new.content, '$.text'), ''));
+		END`,
+		`CREATE TRIGGER IF NOT EXISTS memories_fts_ad AFTER DELETE ON memories BEGIN
+			DELETE FROM memories_fts WHERE rowid = old.rowid;
+		END`,
+		`CREATE TRIGGER IF NOT EXISTS memories_fts_au AFTER UPDATE ON memories BEGIN
+			DELETE FROM memories_fts WHERE rowid = old.rowid;
+			INSERT INTO memories_fts(rowid, id, summary, content_text)
+			VALUES (new.rowid, new.id, COALESCE(new.summary, ''), COALESCE(json_extract(new.content, '$.text'), ''));
+		END`,
+	}},
+}
+
+// Vault is the SQLite-backed memory store. The zero value is not usable;
+// construct via Open.
+type Vault struct {
+	db *sql.DB
+}
+
+// pragmas applied once after opening the database. These are the
+// production defaults inherited from the pre-0.30 storage layer:
+// WAL for concurrent readers, foreign keys enforced, normal sync for
+// good performance with WAL safety, ~8 MB page cache.
+var openPragmas = []string{
+	"PRAGMA journal_mode=WAL",
+	"PRAGMA foreign_keys=ON",
+	"PRAGMA synchronous=NORMAL",
+	"PRAGMA cache_size=-8000",
+}
+
+// Open opens or creates the SQLite database at path and returns a usable
+// Vault. Callers must Close the Vault when done.
+func Open(path string) (*Vault, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("opening sqlite at %s: %w", path, err)
+	}
+	for _, pragma := range openPragmas {
+		if _, err := db.Exec(pragma); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("applying %q: %w", pragma, err)
+		}
+	}
+	return &Vault{db: db}, nil
+}
+
+// Close releases the underlying database connection.
+func (v *Vault) Close() error {
+	if v.db == nil {
+		return nil
+	}
+	return v.db.Close()
+}
+
+// Migrate applies any pending schema migrations to bring the vault to the
+// current schema version. Safe to call multiple times — already-applied
+// migrations are skipped via the schema_migrations tracking table.
+func (v *Vault) Migrate() error {
+	if _, err := v.db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		version    INTEGER PRIMARY KEY,
+		applied_at TEXT NOT NULL
+	)`); err != nil {
+		return fmt.Errorf("creating schema_migrations: %w", err)
+	}
+
+	for _, m := range migrations {
+		var applied int
+		if err := v.db.QueryRow(
+			`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`,
+			m.version,
+		).Scan(&applied); err != nil {
+			return fmt.Errorf("checking migration %d: %w", m.version, err)
+		}
+		if applied > 0 {
+			continue
+		}
+		// Each migration runs atomically: all statements + the
+		// schema_migrations row commit together, or none do.
+		if err := v.Tx(func(tx *sql.Tx) error {
+			for _, stmt := range m.stmts {
+				if _, err := tx.Exec(stmt); err != nil {
+					return fmt.Errorf("statement: %w", err)
+				}
+			}
+			_, err := tx.Exec(
+				`INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
+				m.version,
+				time.Now().UTC().Format(time.RFC3339),
+			)
+			return err
+		}); err != nil {
+			return fmt.Errorf("applying migration %d: %w", m.version, err)
+		}
+	}
+	return nil
+}
+
+// Query runs a read-only query and invokes scan with the resulting rows.
+// Vault closes the *sql.Rows after scan returns. Callers never see
+// *sql.DB.
+func (v *Vault) Query(query string, args []any, scan func(*sql.Rows) error) error {
+	rows, err := v.db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	if err := scan(rows); err != nil {
+		return err
+	}
+	return rows.Err()
+}
+
+// Tx runs fn inside a transaction. The transaction commits on nil
+// return; any non-nil error (or panic) rolls it back. Callers receive a
+// *sql.Tx but never *sql.DB.
+func (v *Vault) Tx(fn func(*sql.Tx) error) (err error) {
+	tx, err := v.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+		if err != nil {
+			_ = tx.Rollback()
+			return
+		}
+		err = tx.Commit()
+	}()
+	err = fn(tx)
+	return err
+}

--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -21,6 +21,30 @@ type migration struct {
 	stmts   []string
 }
 
+// init validates that the migrations slice is sorted by version and
+// contains no duplicate versions. A bad slice is a programming error
+// detected at package load — preferable to silently applying
+// migrations in the wrong order or skipping one because of a duplicate
+// version number.
+func init() {
+	if err := validateMigrations(migrations); err != nil {
+		panic("vault: invalid migrations: " + err.Error())
+	}
+}
+
+// validateMigrations returns an error if versions are not strictly
+// increasing (out of order or duplicated). Pure function, exposed for
+// testing. Empty slice is valid.
+func validateMigrations(ms []migration) error {
+	for i := 1; i < len(ms); i++ {
+		if ms[i].version <= ms[i-1].version {
+			return fmt.Errorf("migration %d follows %d (must be strictly increasing)",
+				ms[i].version, ms[i-1].version)
+		}
+	}
+	return nil
+}
+
 // migrations is the ordered list of schema changes for v0.30.
 // Re-runs of Migrate skip versions already recorded in schema_migrations.
 //
@@ -177,12 +201,15 @@ func Open(path string) (*Vault, error) {
 	return v, nil
 }
 
-// Close releases the underlying database connection.
+// Close releases the underlying database connection. Idempotent —
+// calling Close on an already-closed Vault is a no-op.
 func (v *Vault) Close() error {
 	if v.db == nil {
 		return nil
 	}
-	return v.db.Close()
+	err := v.db.Close()
+	v.db = nil
+	return err
 }
 
 // Migrate applies any pending schema migrations to bring the vault to the
@@ -227,6 +254,11 @@ func (v *Vault) Migrate() error {
 	}
 	return nil
 }
+
+// TODO(#238): add QueryContext / TxContext variants when Recall needs
+// query cancellation / timeout. Current callers are all CLI-bound and
+// don't yet have a context to thread; adding speculative ctx-taking
+// methods now would be premature.
 
 // Query runs a read-only query and invokes scan with the resulting rows.
 // Vault closes the *sql.Rows after scan returns. Callers never see

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -334,6 +334,54 @@ func TestMemory_DefaultsToUntyped(t *testing.T) {
 	}
 }
 
+// T14: A migration that fails partway rolls back atomically — the
+// statements that ran before the failure leave no schema artifacts,
+// and the migration version is not recorded in schema_migrations.
+// Forces injection of a deliberately bad migration via the package-
+// level slice; cleanup restores the original.
+func TestMigrate_RollsBackOnPartialFailure(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("baseline Migrate: %v", err)
+	}
+
+	saved := migrations
+	t.Cleanup(func() { migrations = saved })
+
+	migrations = append(append([]migration{}, saved...), migration{
+		version: 999,
+		stmts: []string{
+			`CREATE TABLE will_be_rolled_back (id INTEGER PRIMARY KEY)`,
+			`THIS IS DELIBERATELY NOT VALID SQL`,
+		},
+	})
+
+	if err := v.Migrate(); err == nil {
+		t.Fatal("expected Migrate to return an error from the failing migration")
+	}
+
+	if hasTable(t, v, "will_be_rolled_back") {
+		t.Errorf("partial migration committed: will_be_rolled_back table exists after rollback")
+	}
+
+	var version999Count int
+	if err := v.Query(
+		`SELECT COUNT(*) FROM schema_migrations WHERE version = 999`,
+		nil,
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&version999Count)
+			}
+			return nil
+		},
+	); err != nil {
+		t.Fatalf("query schema_migrations for version 999: %v", err)
+	}
+	if version999Count != 0 {
+		t.Errorf("expected version 999 NOT to be in schema_migrations, got count=%d", version999Count)
+	}
+}
+
 // T13: memories.content is enforced as valid JSON via a CHECK
 // constraint. The schema contract says content is JSON (e.g.
 // {"text": "..."}); rejecting non-JSON at INSERT prevents the FTS5

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -330,6 +331,84 @@ func TestMemory_DefaultsToUntyped(t *testing.T) {
 
 	if typeVal != "untyped" {
 		t.Errorf("expected default type='untyped', got %q", typeVal)
+	}
+}
+
+// T13: memories.content is enforced as valid JSON via a CHECK
+// constraint. The schema contract says content is JSON (e.g.
+// {"text": "..."}); rejecting non-JSON at INSERT prevents the FTS5
+// trigger from exploding on json_extract and gives a clear error
+// rather than a confusing trigger failure.
+func TestMemory_RejectsNonJSONContent(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	err := v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO memories (id, type, content, created_at)
+			 VALUES (?, 'untyped', ?, ?)`,
+			"bad-json-1", "this is not valid json", "2026-05-03T12:00:00Z",
+		)
+		return err
+	})
+	if err == nil {
+		t.Errorf("expected CHECK (json_valid(content)) to reject non-JSON content")
+	}
+}
+
+// T12: A freshly opened vault has file mode 0600. The DB file may
+// contain captured memories, redaction-adjacent transient state, and
+// audit metadata; group/world readability is the wrong default.
+// Skipped on Windows since POSIX mode bits do not apply.
+func TestOpen_FileModeIs0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file mode not applicable on Windows")
+	}
+
+	_, dbPath := newVault(t)
+
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dbPath, err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("expected file mode 0600, got %o", mode)
+	}
+}
+
+// T11: Foreign key enforcement is on for every connection in the pool.
+// Without the DSN-embedded `_pragma=foreign_keys(1)`, FK enforcement is
+// per-connection and may silently disable when the pool grows. We
+// force a fresh connection by closing idle ones, then verify both that
+// PRAGMA foreign_keys reports 1 and that an FK violation is rejected.
+func TestForeignKeys_EnforcedAcrossConnections(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	// Drop idle connections so the next query needs a fresh one.
+	v.db.SetMaxIdleConns(0)
+
+	var fk int
+	if err := v.db.QueryRow(`PRAGMA foreign_keys`).Scan(&fk); err != nil {
+		t.Fatalf("query PRAGMA foreign_keys: %v", err)
+	}
+	if fk != 1 {
+		t.Errorf("expected foreign_keys=1 on fresh connection, got %d", fk)
+	}
+
+	err := v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO memory_tags (memory_id, tag_id, created_at) VALUES (?, ?, ?)`,
+			"nonexistent-memory", "nonexistent-tag", "2026-05-03T12:00:00Z",
+		)
+		return err
+	})
+	if err == nil {
+		t.Errorf("expected FK violation inserting memory_tags with nonexistent FKs; foreign_keys not enforced")
 	}
 }
 

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -381,6 +381,54 @@ func TestOpen_FileModeIs0600(t *testing.T) {
 	}
 }
 
+// T15: The migrations slice is sorted by version with no duplicates.
+// Catches developer mistakes (declaring v3 before v2, accidentally
+// reusing a version number) at test time before they corrupt a real
+// vault. validateMigrations is also called from init() so a bad slice
+// panics at package load.
+func TestMigrations_AreSortedAndUnique(t *testing.T) {
+	if err := validateMigrations(migrations); err != nil {
+		t.Errorf("global migrations slice violates ordering: %v", err)
+	}
+}
+
+// T15b: validateMigrations rejects out-of-order versions and duplicates.
+func TestValidateMigrations(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   []migration
+		wantErr bool
+	}{
+		{"empty", nil, false},
+		{"single", []migration{{1, nil}}, false},
+		{"sorted", []migration{{1, nil}, {2, nil}, {5, nil}}, false},
+		{"out of order", []migration{{2, nil}, {1, nil}}, true},
+		{"duplicate version", []migration{{1, nil}, {1, nil}}, true},
+		{"duplicate non-adjacent", []migration{{1, nil}, {2, nil}, {1, nil}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateMigrations(c.input)
+			if (err != nil) != c.wantErr {
+				t.Errorf("validateMigrations(%v): err=%v, wantErr=%v", c.input, err, c.wantErr)
+			}
+		})
+	}
+}
+
+// T16: Close is idempotent — calling it on an already-closed Vault
+// returns nil without panicking.
+func TestClose_Idempotent(t *testing.T) {
+	v, _ := newVault(t)
+
+	if err := v.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := v.Close(); err != nil {
+		t.Errorf("second Close should be a no-op, got: %v", err)
+	}
+}
+
 // T11: Foreign key enforcement is on for every connection in the pool.
 // Without the DSN-embedded `_pragma=foreign_keys(1)`, FK enforcement is
 // per-connection and may silently disable when the pool grows. We

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -61,23 +61,6 @@ func hasTable(t *testing.T, v *Vault, name string) bool {
 	return found
 }
 
-// T2: Migrate on a fresh DB creates the memories table.
-func TestMigrate_CreatesMemoriesTable(t *testing.T) {
-	v, _ := newVault(t)
-
-	if hasTable(t, v, "memories") {
-		t.Fatalf("memories table should not exist before Migrate")
-	}
-
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
-
-	if !hasTable(t, v, "memories") {
-		t.Errorf("expected memories table after Migrate")
-	}
-}
-
 // countSchemaMigrations returns the number of applied migration rows.
 func countSchemaMigrations(t *testing.T, v *Vault) int {
 	t.Helper()
@@ -98,22 +81,19 @@ func countSchemaMigrations(t *testing.T, v *Vault) int {
 	return count
 }
 
-// T3: Migrate is idempotent — running it twice leaves schema_migrations
-// unchanged and is not an error. Forces the impl to track applied
-// migrations rather than relying solely on CREATE TABLE IF NOT EXISTS.
+// T3: Migrate is idempotent — calling it on an already-migrated vault
+// leaves schema_migrations unchanged. (Open auto-migrates, so newVault
+// returns a vault that has already had Migrate run once.)
 func TestMigrate_Idempotent(t *testing.T) {
 	v, _ := newVault(t)
 
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("first Migrate: %v", err)
-	}
 	first := countSchemaMigrations(t, v)
 	if first < 1 {
-		t.Fatalf("expected at least 1 applied migration after first run, got %d", first)
+		t.Fatalf("expected at least 1 applied migration from auto-migrate, got %d", first)
 	}
 
 	if err := v.Migrate(); err != nil {
-		t.Fatalf("second Migrate: %v", err)
+		t.Fatalf("explicit Migrate after auto-migrate: %v", err)
 	}
 	second := countSchemaMigrations(t, v)
 
@@ -126,10 +106,6 @@ func TestMigrate_Idempotent(t *testing.T) {
 // ADRs 0009/0010/0014.
 func TestMigrate_CreatesAllV030Tables(t *testing.T) {
 	v, _ := newVault(t)
-
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	expected := []string{
 		"memories",
@@ -176,9 +152,6 @@ func insertSimpleMemory(t *testing.T, v *Vault, id, summary, contentText string)
 // triggers keep it in sync with memories on insert.
 func TestFTS5_FindsInsertedMemory(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	insertSimpleMemory(t, v, "m1", "quick brown fox summary", "the quick brown fox jumps over the lazy dog")
 
@@ -225,9 +198,6 @@ func memoryExists(t *testing.T, v *Vault, id string) bool {
 // persist after the callback returns nil.
 func TestTx_CommitsOnSuccess(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	insertSimpleMemory(t, v, "commit1", "committed memory", "this should persist")
 
@@ -240,9 +210,6 @@ func TestTx_CommitsOnSuccess(t *testing.T) {
 // error, mutations performed inside the callback do not persist.
 func TestTx_RollsBackOnError(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	sentinel := errors.New("intentional rollback")
 	contentJSON := `{"text":"this should not persist"}`
@@ -273,9 +240,6 @@ func TestTx_RollsBackOnError(t *testing.T) {
 // forward-only, new values appear over time and are valid by appearing.
 func TestProvenance_OpenVocabulary(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	err := v.Tx(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
@@ -298,9 +262,6 @@ func TestProvenance_OpenVocabulary(t *testing.T) {
 // post-hoc through wrap-up or explicit user/agent action.
 func TestMemory_DefaultsToUntyped(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	err := v.Tx(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
@@ -341,9 +302,6 @@ func TestMemory_DefaultsToUntyped(t *testing.T) {
 // level slice; cleanup restores the original.
 func TestMigrate_RollsBackOnPartialFailure(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("baseline Migrate: %v", err)
-	}
 
 	saved := migrations
 	t.Cleanup(func() { migrations = saved })
@@ -389,9 +347,6 @@ func TestMigrate_RollsBackOnPartialFailure(t *testing.T) {
 // rather than a confusing trigger failure.
 func TestMemory_RejectsNonJSONContent(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	err := v.Tx(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
@@ -433,9 +388,6 @@ func TestOpen_FileModeIs0600(t *testing.T) {
 // PRAGMA foreign_keys reports 1 and that an FK violation is rejected.
 func TestForeignKeys_EnforcedAcrossConnections(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	// Drop idle connections so the next query needs a fresh one.
 	v.db.SetMaxIdleConns(0)
@@ -466,9 +418,6 @@ func TestForeignKeys_EnforcedAcrossConnections(t *testing.T) {
 // foreign key relationships introduced in migration 1.
 func TestSmoke_RoundTripMemoryWithTagAndEntity(t *testing.T) {
 	v, _ := newVault(t)
-	if err := v.Migrate(); err != nil {
-		t.Fatalf("Migrate: %v", err)
-	}
 
 	const ts = "2026-05-03T12:00:00Z"
 	memID := "smoke-mem-1"

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -1,0 +1,425 @@
+package vault
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// T1 (tracer bullet): Open on a fresh path creates the DB file and
+// returns a usable Vault.
+func TestOpen_FreshPath(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "mom.db")
+
+	v, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open(%s): %v", dbPath, err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Errorf("expected DB file at %s: %v", dbPath, err)
+	}
+}
+
+// newVault is a test helper that opens a fresh Vault in a temp dir and
+// registers cleanup. Returns the Vault and its on-disk path.
+func newVault(t *testing.T) (*Vault, string) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "mom.db")
+	v, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	return v, dbPath
+}
+
+// hasTable reports whether a table exists in the vault's schema.
+func hasTable(t *testing.T, v *Vault, name string) bool {
+	t.Helper()
+	var found bool
+	err := v.Query(
+		`SELECT 1 FROM sqlite_master WHERE type='table' AND name=?`,
+		[]any{name},
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				found = true
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("Query sqlite_master for %s: %v", name, err)
+	}
+	return found
+}
+
+// T2: Migrate on a fresh DB creates the memories table.
+func TestMigrate_CreatesMemoriesTable(t *testing.T) {
+	v, _ := newVault(t)
+
+	if hasTable(t, v, "memories") {
+		t.Fatalf("memories table should not exist before Migrate")
+	}
+
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	if !hasTable(t, v, "memories") {
+		t.Errorf("expected memories table after Migrate")
+	}
+}
+
+// countSchemaMigrations returns the number of applied migration rows.
+func countSchemaMigrations(t *testing.T, v *Vault) int {
+	t.Helper()
+	var count int
+	err := v.Query(
+		`SELECT COUNT(*) FROM schema_migrations`,
+		nil,
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&count)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("count schema_migrations: %v", err)
+	}
+	return count
+}
+
+// T3: Migrate is idempotent — running it twice leaves schema_migrations
+// unchanged and is not an error. Forces the impl to track applied
+// migrations rather than relying solely on CREATE TABLE IF NOT EXISTS.
+func TestMigrate_Idempotent(t *testing.T) {
+	v, _ := newVault(t)
+
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+	first := countSchemaMigrations(t, v)
+	if first < 1 {
+		t.Fatalf("expected at least 1 applied migration after first run, got %d", first)
+	}
+
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("second Migrate: %v", err)
+	}
+	second := countSchemaMigrations(t, v)
+
+	if first != second {
+		t.Errorf("schema_migrations count changed across re-run: %d -> %d", first, second)
+	}
+}
+
+// T4: Migrate creates the full v0.30 table set per the design doc and
+// ADRs 0009/0010/0014.
+func TestMigrate_CreatesAllV030Tables(t *testing.T) {
+	v, _ := newVault(t)
+
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	expected := []string{
+		"memories",
+		"entities",
+		"tags",
+		"memory_tags",
+		"memory_entities",
+		"event_log",
+		"filter_audit",
+		"schema_migrations",
+	}
+	for _, name := range expected {
+		if !hasTable(t, v, name) {
+			t.Errorf("expected table %q after Migrate", name)
+		}
+	}
+}
+
+// insertSimpleMemory writes a minimum memory row through the public Tx
+// API. Used by tests that need a memory present without going through
+// the full MemoryStore (which lives in #235). content is JSON-encoded
+// per the v0.30 schema contract: {"text": "..."}.
+func insertSimpleMemory(t *testing.T, v *Vault, id, summary, contentText string) {
+	t.Helper()
+	contentJSON, err := json.Marshal(map[string]string{"text": contentText})
+	if err != nil {
+		t.Fatalf("marshal content for %s: %v", id, err)
+	}
+	err = v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO memories (id, type, summary, content, created_at)
+			 VALUES (?, 'untyped', ?, ?, ?)`,
+			id, summary, string(contentJSON), "2026-05-03T12:00:00Z",
+		)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("insert memory %s: %v", id, err)
+	}
+}
+
+// T5: After Migrate, an inserted memory is findable via FTS5 search.
+// Verifies that the memories_fts virtual table is wired and that
+// triggers keep it in sync with memories on insert.
+func TestFTS5_FindsInsertedMemory(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	insertSimpleMemory(t, v, "m1", "quick brown fox summary", "the quick brown fox jumps over the lazy dog")
+
+	var foundID string
+	err := v.Query(
+		`SELECT id FROM memories_fts WHERE memories_fts MATCH ? LIMIT 1`,
+		[]any{"quick"},
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&foundID)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("FTS5 query: %v", err)
+	}
+	if foundID != "m1" {
+		t.Errorf("expected FTS5 to find m1 via 'quick', got %q", foundID)
+	}
+}
+
+// memoryExists is a query helper for the Tx tests.
+func memoryExists(t *testing.T, v *Vault, id string) bool {
+	t.Helper()
+	var found bool
+	err := v.Query(
+		`SELECT 1 FROM memories WHERE id = ?`,
+		[]any{id},
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				found = true
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("query memories for %s: %v", id, err)
+	}
+	return found
+}
+
+// T6: Tx commits on success — mutations performed inside the callback
+// persist after the callback returns nil.
+func TestTx_CommitsOnSuccess(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	insertSimpleMemory(t, v, "commit1", "committed memory", "this should persist")
+
+	if !memoryExists(t, v, "commit1") {
+		t.Errorf("expected commit1 to persist after Tx commit")
+	}
+}
+
+// T7: Tx rolls back on error — when the callback returns a non-nil
+// error, mutations performed inside the callback do not persist.
+func TestTx_RollsBackOnError(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	sentinel := errors.New("intentional rollback")
+	contentJSON := `{"text":"this should not persist"}`
+
+	err := v.Tx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(
+			`INSERT INTO memories (id, type, content, created_at)
+			 VALUES (?, 'untyped', ?, ?)`,
+			"rollback1", contentJSON, "2026-05-03T12:00:00Z",
+		); err != nil {
+			return err
+		}
+		return sentinel
+	})
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error from Tx, got %v", err)
+	}
+
+	if memoryExists(t, v, "rollback1") {
+		t.Errorf("expected rollback1 NOT to persist after Tx rollback")
+	}
+}
+
+// T8: Inserting novel provenance values succeeds — no CHECK constraints
+// on actor / source_type / trigger_event. This locks in the open
+// vocabulary contract (ADR 0015 / UTM principle): renames are
+// forward-only, new values appear over time and are valid by appearing.
+func TestProvenance_OpenVocabulary(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	err := v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO memories (
+				id, type, content, created_at,
+				provenance_actor, provenance_source_type, provenance_trigger_event
+			) VALUES (?, 'untyped', ?, ?, ?, ?, ?)`,
+			"novel1", `{"text":"x"}`, "2026-05-03T12:00:00Z",
+			"future-harness-2027", "novel-source-type", "novel-trigger",
+		)
+		return err
+	})
+	if err != nil {
+		t.Errorf("expected novel provenance values to succeed (open vocabulary): %v", err)
+	}
+}
+
+// T9: Inserting a memory without specifying type defaults to 'untyped'
+// (ADR 0012). Capture never assigns a real type; classification is
+// post-hoc through wrap-up or explicit user/agent action.
+func TestMemory_DefaultsToUntyped(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	err := v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO memories (id, content, created_at)
+			 VALUES (?, ?, ?)`,
+			"default1", `{"text":"x"}`, "2026-05-03T12:00:00Z",
+		)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	var typeVal string
+	err = v.Query(
+		`SELECT type FROM memories WHERE id = ?`,
+		[]any{"default1"},
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&typeVal)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("query type: %v", err)
+	}
+
+	if typeVal != "untyped" {
+		t.Errorf("expected default type='untyped', got %q", typeVal)
+	}
+}
+
+// T10 (smoke): round-trip a memory + a tag + an entity edge through
+// Tx, then read back the joined view. Exercises the v0.30 graph-fluent
+// schema end-to-end (memory + memory_tags + memory_entities) and the
+// foreign key relationships introduced in migration 1.
+func TestSmoke_RoundTripMemoryWithTagAndEntity(t *testing.T) {
+	v, _ := newVault(t)
+	if err := v.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	const ts = "2026-05-03T12:00:00Z"
+	memID := "smoke-mem-1"
+	tagID := "smoke-tag-1"
+	entityID := "smoke-ent-1"
+
+	err := v.Tx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(
+			`INSERT INTO memories (id, type, summary, content, created_at)
+			 VALUES (?, 'untyped', ?, ?, ?)`,
+			memID, "smoke summary", `{"text":"smoke body"}`, ts,
+		); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO tags (id, name, created_at) VALUES (?, ?, ?)`,
+			tagID, "smoke", ts,
+		); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO memory_tags (memory_id, tag_id, created_at) VALUES (?, ?, ?)`,
+			memID, tagID, ts,
+		); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO entities (id, type, display_name, created_at) VALUES (?, 'user', ?, ?)`,
+			entityID, "Smoke User", ts,
+		); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO memory_entities (memory_id, entity_id, relationship, created_at)
+			 VALUES (?, ?, 'created_by', ?)`,
+			memID, entityID, ts,
+		); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("round-trip Tx: %v", err)
+	}
+
+	var (
+		gotMem, gotTag, gotEntity, gotRel string
+	)
+	err = v.Query(
+		`SELECT m.id, t.name, e.display_name, me.relationship
+		 FROM memories m
+		 JOIN memory_tags mt     ON mt.memory_id = m.id
+		 JOIN tags t             ON t.id = mt.tag_id
+		 JOIN memory_entities me ON me.memory_id = m.id
+		 JOIN entities e         ON e.id = me.entity_id
+		 WHERE m.id = ?`,
+		[]any{memID},
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&gotMem, &gotTag, &gotEntity, &gotRel)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("joined query: %v", err)
+	}
+
+	if gotMem != memID {
+		t.Errorf("memory id = %q, want %q", gotMem, memID)
+	}
+	if gotTag != "smoke" {
+		t.Errorf("tag name = %q, want %q", gotTag, "smoke")
+	}
+	if gotEntity != "Smoke User" {
+		t.Errorf("entity display_name = %q, want %q", gotEntity, "Smoke User")
+	}
+	if gotRel != "created_by" {
+		t.Errorf("relationship = %q, want %q", gotRel, "created_by")
+	}
+}


### PR DESCRIPTION
## Summary

- New \`cli/internal/vault/\` package: SQLite connection, schema migrations, transactions, scoped read API
- v0.30 schema: memories + entities + tags + memory_tags + memory_entities + event_log + filter_audit + schema_migrations + memories_fts
- Production pragmas (WAL, foreign_keys=ON, synchronous=NORMAL); migration applied atomically per version
- 10 tests covering Open / Migrate / Tx / FTS5 / open-vocabulary contract / default-untyped / round-trip smoke

## Closes

Closes #233

## References

- PRD: https://github.com/momhq/mom/blob/main/prd/0003-v0-30.md
- ADRs: [0009](https://github.com/momhq/mom/blob/main/adr/0009-storage-consolidation-home-canonical.md), [0010](https://github.com/momhq/mom/blob/main/adr/0010-graph-fluent-schema-normalization.md), [0011](https://github.com/momhq/mom/blob/main/adr/0011-substance-immutability-operational-mutability.md), [0012](https://github.com/momhq/mom/blob/main/adr/0012-tulving-typology-default-untyped.md), [0013](https://github.com/momhq/mom/blob/main/adr/0013-uuid-only-memory-ids.md)

## Test plan

- [x] \`go test ./internal/vault/...\` — 10/10 pass
- [x] \`go test ./...\` — full project still green
- [x] Substance fields ready for MemoryStore (#235) to enforce immutability at the API
- [x] FTS5 virtual table + sync triggers wired; bm25 weights documented for recall (#238) application
- [x] Provenance columns are plain TEXT; novel actor/source_type/trigger_event values insertable (open vocabularies)
- [x] Migration is idempotent and atomic per version

🤖 Generated with [Claude Code](https://claude.com/claude-code)