### PR TITLE
feat(store): MemoryStore + GraphStore (#235)

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.1
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/google/uuid v1.6.0
 	github.com/jdkato/prose/v2 v2.0.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
@@ -33,7 +34,6 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/cli/internal/store/errors.go
+++ b/cli/internal/store/errors.go
@@ -1,0 +1,6 @@
+package store
+
+import "errors"
+
+// ErrNotFound is returned by lookups that find no matching row.
+var ErrNotFound = errors.New("store: not found")

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -69,7 +69,12 @@ func (s *MemoryStore) Insert(m Memory) (Memory, error) {
 		m.PromotionState = "draft"
 	}
 	if m.CreatedAt.IsZero() {
-		m.CreatedAt = time.Now().UTC()
+		// Round(0) strips the monotonic clock reading so the returned
+		// Memory.CreatedAt is byte-identical to what Get will return
+		// later (Get parses RFC3339Nano which has no monotonic).
+		// Without this, struct equality (==) on CreatedAt would
+		// silently fail even though Equal() succeeds.
+		m.CreatedAt = time.Now().UTC().Round(0)
 	}
 
 	contentJSON, err := json.Marshal(m.Content)
@@ -166,10 +171,27 @@ func (s *MemoryStore) SetCentralityScore(id string, score *float64) error {
 	return s.updateOperationalField(id, "centrality_score", score)
 }
 
+// allowedOperationalColumns is the whitelist of column names
+// updateOperationalField will accept. The value is parameterised
+// safely; the column name is concatenated into the SQL string, so a
+// whitelist removes any risk if this helper is ever called with a
+// caller-supplied value (defense in depth — current callers are all
+// in-package Set* methods).
+var allowedOperationalColumns = map[string]bool{
+	"type":             true,
+	"promotion_state":  true,
+	"landmark":         true,
+	"centrality_score": true,
+}
+
 // updateOperationalField runs a single-column UPDATE on memories,
 // returning ErrNotFound if the row does not exist. The column name is
-// trusted (caller is in-package); the value is parameterised.
+// validated against allowedOperationalColumns; the value is
+// parameterised.
 func (s *MemoryStore) updateOperationalField(id, column string, value any) error {
+	if !allowedOperationalColumns[column] {
+		return fmt.Errorf("updateOperationalField: column %q not allowed", column)
+	}
 	return s.v.Tx(func(tx *sql.Tx) error {
 		res, err := tx.Exec(
 			fmt.Sprintf(`UPDATE memories SET %s = ? WHERE id = ?`, column),

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -202,8 +202,16 @@ func NewGraphStore(v *vault.Vault) *GraphStore {
 
 // UpsertEntity returns the existing entity's ID for the given (type,
 // display_name), or creates a new entity (with a fresh UUID) and
-// returns the new ID. Idempotent on (type, display_name).
+// returns the new ID. Idempotent on (type, display_name). Rejects
+// empty type or display_name — empty identifiers are not meaningful
+// and are almost always upstream bugs.
 func (g *GraphStore) UpsertEntity(typ, displayName string) (string, error) {
+	if typ == "" {
+		return "", fmt.Errorf("UpsertEntity: type cannot be empty")
+	}
+	if displayName == "" {
+		return "", fmt.Errorf("UpsertEntity: display_name cannot be empty")
+	}
 	var id string
 	err := g.v.Tx(func(tx *sql.Tx) error {
 		row := tx.QueryRow(
@@ -368,7 +376,12 @@ func (g *GraphStore) MemoriesByTag(tagName string) ([]string, error) {
 // UpsertTag returns the existing tag's ID for the given name, or
 // creates a new tag (with a fresh UUID) and returns the new ID.
 // Idempotent: repeated calls with the same name return the same ID.
+// Rejects empty name — empty identifiers are not meaningful and are
+// almost always upstream bugs.
 func (g *GraphStore) UpsertTag(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("UpsertTag: name cannot be empty")
+	}
 	var id string
 	err := g.v.Tx(func(tx *sql.Tx) error {
 		row := tx.QueryRow(`SELECT id FROM tags WHERE name = ?`, name)

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -17,6 +17,12 @@ import (
 // Memory is the v0.30 in-memory shape of a memory document. Substance
 // fields are immutable after Insert; operational fields are mutated
 // only via the explicit Set* methods on MemoryStore.
+//
+// A Memory value returned by Insert or Get is a snapshot — modifying
+// its fields does not persist to the database. To update operational
+// fields after Insert, call SetType / SetPromotionState / SetLandmark
+// / SetCentralityScore on MemoryStore. Substance fields cannot be
+// changed after Insert; create a new memory and supersede instead.
 type Memory struct {
 	// Substance — immutable after Insert.
 	ID                     string
@@ -371,6 +377,12 @@ func (g *GraphStore) LinkTag(memoryID, tagID string) error {
 // MemoriesByTag returns the IDs of all memories linked to the tag with
 // the given name. Returns an empty slice if no such tag exists or no
 // memories are linked.
+//
+// TODO(post-v0.30): result is unbounded. At v0.30 alpha vault sizes
+// this is acceptable; if vaults grow large enough that a single tag
+// could match millions of memories, add pagination (limit/offset) or
+// a streaming variant. Recall (#238) will likely build a bounded
+// query layer on top of this.
 func (g *GraphStore) MemoriesByTag(tagName string) ([]string, error) {
 	var ids []string
 	err := g.v.Query(

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -1,0 +1,374 @@
+// Package store is the v0.30 domain layer over the SQLite vault. It
+// owns the MemoryStore (CRUD on memories with substance immutability)
+// and the GraphStore (tags, entities, edges).
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// Memory is the v0.30 in-memory shape of a memory document. Substance
+// fields are immutable after Insert; operational fields are mutated
+// only via the explicit Set* methods on MemoryStore.
+type Memory struct {
+	// Substance — immutable after Insert.
+	ID                     string
+	Type                   string
+	Summary                string
+	Content                map[string]any
+	CreatedAt              time.Time
+	SessionID              string
+	ProvenanceActor        string
+	ProvenanceSourceType   string
+	ProvenanceTriggerEvent string
+
+	// Operational — mutable via Set* methods.
+	PromotionState  string
+	Landmark        bool
+	CentralityScore *float64
+}
+
+// MemoryStore is the CRUD surface for memories. Substance immutability
+// is enforced by API absence: there is no public method to mutate
+// substance fields after Insert.
+type MemoryStore struct {
+	v *vault.Vault
+}
+
+// NewMemoryStore returns a MemoryStore backed by the given vault.
+func NewMemoryStore(v *vault.Vault) *MemoryStore {
+	return &MemoryStore{v: v}
+}
+
+// nowTimestamp returns the current UTC time formatted for storage in
+// the *_at TEXT columns. RFC3339 with nanosecond precision keeps
+// ordering stable for high-frequency capture.
+func nowTimestamp() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+// Insert persists the memory and returns the canonical Memory with ID
+// and CreatedAt populated. ID is minted as a UUID v4 if empty; Type
+// defaults to "untyped"; PromotionState defaults to "draft"; CreatedAt
+// defaults to time.Now().UTC().
+func (s *MemoryStore) Insert(m Memory) (Memory, error) {
+	if m.ID == "" {
+		m.ID = uuid.NewString()
+	}
+	if m.Type == "" {
+		m.Type = "untyped"
+	}
+	if m.PromotionState == "" {
+		m.PromotionState = "draft"
+	}
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = time.Now().UTC()
+	}
+
+	contentJSON, err := json.Marshal(m.Content)
+	if err != nil {
+		return Memory{}, fmt.Errorf("marshal content: %w", err)
+	}
+
+	err = s.v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO memories (
+				id, type, summary, content, created_at, session_id,
+				provenance_actor, provenance_source_type, provenance_trigger_event,
+				promotion_state, landmark, centrality_score
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			m.ID, m.Type, m.Summary, string(contentJSON), m.CreatedAt.Format(time.RFC3339Nano),
+			m.SessionID, m.ProvenanceActor, m.ProvenanceSourceType, m.ProvenanceTriggerEvent,
+			m.PromotionState, m.Landmark, m.CentralityScore,
+		)
+		return err
+	})
+	if err != nil {
+		return Memory{}, fmt.Errorf("insert memory: %w", err)
+	}
+	return m, nil
+}
+
+// Get retrieves a memory by ID. Returns ErrNotFound if no such memory
+// exists.
+func (s *MemoryStore) Get(id string) (Memory, error) {
+	var (
+		m         Memory
+		contentJS string
+		createdAt string
+	)
+	err := s.v.Query(
+		`SELECT id, type, summary, content, created_at, session_id,
+			provenance_actor, provenance_source_type, provenance_trigger_event,
+			promotion_state, landmark, centrality_score
+		 FROM memories WHERE id = ?`,
+		[]any{id},
+		func(rows *sql.Rows) error {
+			if !rows.Next() {
+				return ErrNotFound
+			}
+			return rows.Scan(
+				&m.ID, &m.Type, &m.Summary, &contentJS, &createdAt, &m.SessionID,
+				&m.ProvenanceActor, &m.ProvenanceSourceType, &m.ProvenanceTriggerEvent,
+				&m.PromotionState, &m.Landmark, &m.CentralityScore,
+			)
+		},
+	)
+	if err != nil {
+		return Memory{}, err
+	}
+	if err := json.Unmarshal([]byte(contentJS), &m.Content); err != nil {
+		return Memory{}, fmt.Errorf("unmarshal content: %w", err)
+	}
+	t, err := time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		return Memory{}, fmt.Errorf("parse created_at: %w", err)
+	}
+	m.CreatedAt = t
+	return m, nil
+}
+
+// SetType mutates the type field of an existing memory. Returns
+// ErrNotFound if no memory with the given ID exists. Substance fields
+// are untouched.
+func (s *MemoryStore) SetType(id, t string) error {
+	return s.updateOperationalField(id, "type", t)
+}
+
+// SetPromotionState mutates the promotion_state field of an existing
+// memory. Returns ErrNotFound if no memory with the given ID exists.
+func (s *MemoryStore) SetPromotionState(id, state string) error {
+	return s.updateOperationalField(id, "promotion_state", state)
+}
+
+// SetLandmark marks (or unmarks) a memory as a landmark.
+func (s *MemoryStore) SetLandmark(id string, landmark bool) error {
+	return s.updateOperationalField(id, "landmark", landmark)
+}
+
+// SetCentralityScore sets the centrality_score field. A nil pointer
+// sets the column to NULL (the default state for non-landmark
+// memories); a non-nil pointer stores the dereferenced value.
+func (s *MemoryStore) SetCentralityScore(id string, score *float64) error {
+	return s.updateOperationalField(id, "centrality_score", score)
+}
+
+// updateOperationalField runs a single-column UPDATE on memories,
+// returning ErrNotFound if the row does not exist. The column name is
+// trusted (caller is in-package); the value is parameterised.
+func (s *MemoryStore) updateOperationalField(id, column string, value any) error {
+	return s.v.Tx(func(tx *sql.Tx) error {
+		res, err := tx.Exec(
+			fmt.Sprintf(`UPDATE memories SET %s = ? WHERE id = ?`, column),
+			value, id,
+		)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
+// GraphStore manages tags, entities, and the edges that connect
+// memories to them.
+type GraphStore struct {
+	v *vault.Vault
+}
+
+// NewGraphStore returns a GraphStore backed by the given vault.
+func NewGraphStore(v *vault.Vault) *GraphStore {
+	return &GraphStore{v: v}
+}
+
+// UpsertEntity returns the existing entity's ID for the given (type,
+// display_name), or creates a new entity (with a fresh UUID) and
+// returns the new ID. Idempotent on (type, display_name).
+func (g *GraphStore) UpsertEntity(typ, displayName string) (string, error) {
+	var id string
+	err := g.v.Tx(func(tx *sql.Tx) error {
+		row := tx.QueryRow(
+			`SELECT id FROM entities WHERE type = ? AND display_name = ?`,
+			typ, displayName,
+		)
+		if err := row.Scan(&id); err == nil {
+			return nil
+		}
+		id = uuid.NewString()
+		_, err := tx.Exec(
+			`INSERT INTO entities (id, type, display_name, created_at)
+			 VALUES (?, ?, ?, ?)`,
+			id, typ, displayName, nowTimestamp(),
+		)
+		return err
+	})
+	if err != nil {
+		return "", fmt.Errorf("upsert entity (%s, %s): %w", typ, displayName, err)
+	}
+	return id, nil
+}
+
+// LinkEntity connects a memory to an entity with a relationship label
+// (e.g. "created_by"). Idempotent on (memory_id, entity_id, relationship).
+func (g *GraphStore) LinkEntity(memoryID, entityID, relationship string) error {
+	return g.v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT OR IGNORE INTO memory_entities (memory_id, entity_id, relationship, created_at)
+			 VALUES (?, ?, ?, ?)`,
+			memoryID, entityID, relationship,
+			nowTimestamp(),
+		)
+		return err
+	})
+}
+
+// RenameTag changes the name of an existing tag. Only the tags row is
+// mutated — memory_tags edges still reference the same tag.id, and
+// memory substance is untouched (ADR 0010). Returns ErrNotFound if no
+// tag with oldName exists.
+func (g *GraphStore) RenameTag(oldName, newName string) error {
+	return g.v.Tx(func(tx *sql.Tx) error {
+		res, err := tx.Exec(
+			`UPDATE tags SET name = ? WHERE name = ?`,
+			newName, oldName,
+		)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
+// MergeTags repoints all memory_tags edges from the source tag to the
+// target tag, then deletes the source tag row. If a memory is already
+// linked to both source and target, the duplicate edge is dropped (the
+// PRIMARY KEY constraint is honored via INSERT OR IGNORE). Memory
+// substance is untouched (ADR 0010 — graph-level operation). Returns
+// ErrNotFound if either tag does not exist.
+func (g *GraphStore) MergeTags(sourceName, targetName string) error {
+	return g.v.Tx(func(tx *sql.Tx) error {
+		var srcID, tgtID string
+		if err := tx.QueryRow(
+			`SELECT id FROM tags WHERE name = ?`, sourceName,
+		).Scan(&srcID); err != nil {
+			if err == sql.ErrNoRows {
+				return ErrNotFound
+			}
+			return err
+		}
+		if err := tx.QueryRow(
+			`SELECT id FROM tags WHERE name = ?`, targetName,
+		).Scan(&tgtID); err != nil {
+			if err == sql.ErrNoRows {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		// Add (memory, target) for any memory currently linked to source
+		// but not yet to target. Original created_at is preserved.
+		if _, err := tx.Exec(
+			`INSERT OR IGNORE INTO memory_tags (memory_id, tag_id, created_at)
+			 SELECT memory_id, ?, created_at FROM memory_tags WHERE tag_id = ?`,
+			tgtID, srcID,
+		); err != nil {
+			return err
+		}
+		// Remove all (memory, source) edges.
+		if _, err := tx.Exec(
+			`DELETE FROM memory_tags WHERE tag_id = ?`, srcID,
+		); err != nil {
+			return err
+		}
+		// Drop the source tag row.
+		if _, err := tx.Exec(
+			`DELETE FROM tags WHERE id = ?`, srcID,
+		); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// LinkTag connects a memory to a tag. Idempotent — re-linking the same
+// pair is a no-op (matches ON CONFLICT DO NOTHING semantics).
+func (g *GraphStore) LinkTag(memoryID, tagID string) error {
+	return g.v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT OR IGNORE INTO memory_tags (memory_id, tag_id, created_at)
+			 VALUES (?, ?, ?)`,
+			memoryID, tagID, nowTimestamp(),
+		)
+		return err
+	})
+}
+
+// MemoriesByTag returns the IDs of all memories linked to the tag with
+// the given name. Returns an empty slice if no such tag exists or no
+// memories are linked.
+func (g *GraphStore) MemoriesByTag(tagName string) ([]string, error) {
+	var ids []string
+	err := g.v.Query(
+		`SELECT mt.memory_id FROM memory_tags mt
+		 JOIN tags t ON t.id = mt.tag_id
+		 WHERE t.name = ?`,
+		[]any{tagName},
+		func(rows *sql.Rows) error {
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					return err
+				}
+				ids = append(ids, id)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+// UpsertTag returns the existing tag's ID for the given name, or
+// creates a new tag (with a fresh UUID) and returns the new ID.
+// Idempotent: repeated calls with the same name return the same ID.
+func (g *GraphStore) UpsertTag(name string) (string, error) {
+	var id string
+	err := g.v.Tx(func(tx *sql.Tx) error {
+		row := tx.QueryRow(`SELECT id FROM tags WHERE name = ?`, name)
+		if err := row.Scan(&id); err == nil {
+			return nil
+		}
+		id = uuid.NewString()
+		_, err := tx.Exec(
+			`INSERT INTO tags (id, name, created_at) VALUES (?, ?, ?)`,
+			id, name, nowTimestamp(),
+		)
+		return err
+	})
+	if err != nil {
+		return "", fmt.Errorf("upsert tag %q: %w", name, err)
+	}
+	return id, nil
+}

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -112,6 +112,12 @@ func (s *MemoryStore) Get(id string) (Memory, error) {
 		[]any{id},
 		func(rows *sql.Rows) error {
 			if !rows.Next() {
+				// rows.Next() returns false on either end-of-results
+				// OR a mid-iteration failure. Surface the real error
+				// rather than reporting it as ErrNotFound.
+				if err := rows.Err(); err != nil {
+					return err
+				}
 				return ErrNotFound
 			}
 			return rows.Scan(
@@ -264,8 +270,17 @@ func (g *GraphStore) RenameTag(oldName, newName string) error {
 // linked to both source and target, the duplicate edge is dropped (the
 // PRIMARY KEY constraint is honored via INSERT OR IGNORE). Memory
 // substance is untouched (ADR 0010 — graph-level operation). Returns
-// ErrNotFound if either tag does not exist.
+// ErrNotFound if either tag does not exist. Returns an error if source
+// and target are the same name — without this guard, a typo would
+// silently wipe all edges and the tag itself.
+//
+// Comparison is case-sensitive: MergeTags("mcp", "MCP") is a valid
+// merge of two distinct tags. Tag-name normalization (kebab-case) is
+// a convention, not enforced by the schema.
 func (g *GraphStore) MergeTags(sourceName, targetName string) error {
+	if sourceName == targetName {
+		return fmt.Errorf("MergeTags: source and target are the same (%q)", sourceName)
+	}
 	return g.v.Tx(func(tx *sql.Tx) error {
 		var srcID, tgtID string
 		if err := tx.QueryRow(

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -530,3 +530,33 @@ func TestGraphStore_MergeTags(t *testing.T) {
 	}
 	assertSubstanceUnchanged(t, gotFixture, fixture)
 }
+
+// T14: MergeTags rejects source == target. Without the guard, a typo
+// (or argument swap) would wipe all memory_tags edges for that tag and
+// delete the tag itself — irrecoverable data loss from one mistaken
+// keystroke.
+func TestGraphStore_MergeTags_RejectsSelfMerge(t *testing.T) {
+	ms, gs, _ := newStore(t)
+
+	fixture := insertedFixture(t, ms)
+	tagID, err := gs.UpsertTag("recall")
+	if err != nil {
+		t.Fatalf("UpsertTag: %v", err)
+	}
+	if err := gs.LinkTag(fixture.ID, tagID); err != nil {
+		t.Fatalf("LinkTag: %v", err)
+	}
+
+	if err := gs.MergeTags("recall", "recall"); err == nil {
+		t.Errorf("expected error from MergeTags(x, x), got nil")
+	}
+
+	// Tag and link still intact.
+	ids, err := gs.MemoriesByTag("recall")
+	if err != nil {
+		t.Fatalf("MemoriesByTag: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != fixture.ID {
+		t.Errorf("expected link preserved after rejected self-merge, got %v", ids)
+	}
+}

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -1,0 +1,532 @@
+package store_test
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/momhq/mom/cli/internal/store"
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// newStore opens a fresh Vault in a temp dir and returns a MemoryStore
+// + GraphStore wired to it. Cleanup is registered via t.Cleanup.
+func newStore(t *testing.T) (*store.MemoryStore, *store.GraphStore, *vault.Vault) {
+	t.Helper()
+	dir := t.TempDir()
+	v, err := vault.Open(filepath.Join(dir, "mom.db"))
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	return store.NewMemoryStore(v), store.NewGraphStore(v), v
+}
+
+// T1 (tracer bullet): Insert a memory with substance + operational
+// fields, Get it back, verify the substance round-trips.
+func TestMemoryStore_InsertAndGetRoundTrip(t *testing.T) {
+	ms, _, _ := newStore(t)
+
+	in := store.Memory{
+		Type:                   "semantic",
+		Summary:                "test summary",
+		Content:                map[string]any{"text": "test body"},
+		SessionID:              "session-1",
+		ProvenanceActor:        "claude-code",
+		ProvenanceSourceType:   "transcript-extraction",
+		ProvenanceTriggerEvent: "session-end",
+	}
+
+	inserted, err := ms.Insert(in)
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if inserted.ID == "" {
+		t.Fatalf("expected Insert to mint an ID")
+	}
+
+	got, err := ms.Get(inserted.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", inserted.ID, err)
+	}
+
+	if got.ID != inserted.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, inserted.ID)
+	}
+	if got.Type != "semantic" {
+		t.Errorf("Type: got %q, want %q", got.Type, "semantic")
+	}
+	if got.Summary != in.Summary {
+		t.Errorf("Summary: got %q, want %q", got.Summary, in.Summary)
+	}
+	if got.SessionID != in.SessionID {
+		t.Errorf("SessionID: got %q, want %q", got.SessionID, in.SessionID)
+	}
+	if got.ProvenanceActor != in.ProvenanceActor {
+		t.Errorf("ProvenanceActor: got %q, want %q", got.ProvenanceActor, in.ProvenanceActor)
+	}
+	if text, _ := got.Content["text"].(string); text != "test body" {
+		t.Errorf("Content.text: got %v, want %q", got.Content["text"], "test body")
+	}
+}
+
+// T2: When the caller provides no ID, Insert mints a UUID v4. Locks
+// in ADR 0013 — IDs are opaque UUIDs, not slugs or session-derived.
+func TestMemoryStore_Insert_MintsUUIDv4WhenIDEmpty(t *testing.T) {
+	ms, _, _ := newStore(t)
+
+	inserted, err := ms.Insert(store.Memory{
+		Content: map[string]any{"text": "x"},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if inserted.ID == "" {
+		t.Fatalf("expected ID to be minted, got empty")
+	}
+	parsed, err := uuid.Parse(inserted.ID)
+	if err != nil {
+		t.Fatalf("expected valid UUID, got %q: %v", inserted.ID, err)
+	}
+	if got := parsed.Version(); got != 4 {
+		t.Errorf("expected UUIDv4, got version %d", got)
+	}
+}
+
+// T3+T4: When fields are zero, Insert applies sensible defaults —
+// Type="untyped" (ADR 0012), PromotionState="draft", CreatedAt=now.
+// All defaults persist through Get.
+func TestMemoryStore_Insert_AppliesDefaults(t *testing.T) {
+	ms, _, _ := newStore(t)
+
+	before := time.Now().UTC()
+	inserted, err := ms.Insert(store.Memory{
+		Content: map[string]any{"text": "x"},
+	})
+	after := time.Now().UTC()
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if inserted.Type != "untyped" {
+		t.Errorf("Type default: got %q, want %q", inserted.Type, "untyped")
+	}
+	if inserted.PromotionState != "draft" {
+		t.Errorf("PromotionState default: got %q, want %q", inserted.PromotionState, "draft")
+	}
+	if inserted.CreatedAt.Before(before) || inserted.CreatedAt.After(after) {
+		t.Errorf("CreatedAt %v outside expected range [%v, %v]", inserted.CreatedAt, before, after)
+	}
+
+	got, err := ms.Get(inserted.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Type != "untyped" {
+		t.Errorf("Type after Get: got %q, want %q", got.Type, "untyped")
+	}
+	if got.PromotionState != "draft" {
+		t.Errorf("PromotionState after Get: got %q, want %q", got.PromotionState, "draft")
+	}
+}
+
+// T8: Get returns ErrNotFound when the ID does not exist. Sentinel
+// error so callers can distinguish "missing" from other failures.
+func TestMemoryStore_Get_ReturnsErrNotFoundForUnknownID(t *testing.T) {
+	ms, _, _ := newStore(t)
+
+	_, err := ms.Get("00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// insertedFixture is a helper that inserts a memory with known
+// substance fields so operational-setter tests can verify substance
+// remains untouched.
+func insertedFixture(t *testing.T, ms *store.MemoryStore) store.Memory {
+	t.Helper()
+	in, err := ms.Insert(store.Memory{
+		Type:                   "untyped",
+		Summary:                "original summary",
+		Content:                map[string]any{"text": "original body"},
+		SessionID:              "session-1",
+		ProvenanceActor:        "claude-code",
+		ProvenanceSourceType:   "transcript-extraction",
+		ProvenanceTriggerEvent: "session-end",
+	})
+	if err != nil {
+		t.Fatalf("fixture Insert: %v", err)
+	}
+	return in
+}
+
+// assertSubstanceUnchanged verifies all substance fields on got match
+// the fixture. Callers run after a Set* method to prove the operational
+// mutation did not bleed into substance.
+func assertSubstanceUnchanged(t *testing.T, got, fixture store.Memory) {
+	t.Helper()
+	if got.ID != fixture.ID {
+		t.Errorf("ID changed: %q -> %q", fixture.ID, got.ID)
+	}
+	if got.Summary != fixture.Summary {
+		t.Errorf("Summary changed: %q -> %q", fixture.Summary, got.Summary)
+	}
+	if text, _ := got.Content["text"].(string); text != "original body" {
+		t.Errorf("Content.text changed: %v", got.Content["text"])
+	}
+	if !got.CreatedAt.Equal(fixture.CreatedAt) {
+		t.Errorf("CreatedAt changed: %v -> %v", fixture.CreatedAt, got.CreatedAt)
+	}
+	if got.SessionID != fixture.SessionID {
+		t.Errorf("SessionID changed: %q -> %q", fixture.SessionID, got.SessionID)
+	}
+	if got.ProvenanceActor != fixture.ProvenanceActor {
+		t.Errorf("ProvenanceActor changed: %q -> %q", fixture.ProvenanceActor, got.ProvenanceActor)
+	}
+	if got.ProvenanceSourceType != fixture.ProvenanceSourceType {
+		t.Errorf("ProvenanceSourceType changed: %q -> %q", fixture.ProvenanceSourceType, got.ProvenanceSourceType)
+	}
+	if got.ProvenanceTriggerEvent != fixture.ProvenanceTriggerEvent {
+		t.Errorf("ProvenanceTriggerEvent changed: %q -> %q", fixture.ProvenanceTriggerEvent, got.ProvenanceTriggerEvent)
+	}
+}
+
+// T5: SetType mutates only the type column. Substance fields remain
+// untouched (ADR 0011 — operational metadata mutable, substance
+// immutable).
+func TestMemoryStore_SetType(t *testing.T) {
+	ms, _, _ := newStore(t)
+	fixture := insertedFixture(t, ms)
+
+	if err := ms.SetType(fixture.ID, "semantic"); err != nil {
+		t.Fatalf("SetType: %v", err)
+	}
+
+	got, err := ms.Get(fixture.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Type != "semantic" {
+		t.Errorf("Type: got %q, want %q", got.Type, "semantic")
+	}
+	assertSubstanceUnchanged(t, got, fixture)
+}
+
+// T6: SetPromotionState mutates only the promotion_state column.
+func TestMemoryStore_SetPromotionState(t *testing.T) {
+	ms, _, _ := newStore(t)
+	fixture := insertedFixture(t, ms)
+
+	if err := ms.SetPromotionState(fixture.ID, "curated"); err != nil {
+		t.Fatalf("SetPromotionState: %v", err)
+	}
+
+	got, _ := ms.Get(fixture.ID)
+	if got.PromotionState != "curated" {
+		t.Errorf("PromotionState: got %q, want %q", got.PromotionState, "curated")
+	}
+	assertSubstanceUnchanged(t, got, fixture)
+}
+
+// T7: SetLandmark and SetCentralityScore mutate only their respective
+// columns. SetCentralityScore uses *float64 — nil sets the column to
+// NULL (the default state for non-landmark memories); a value pointer
+// sets a numeric centrality.
+func TestMemoryStore_SetLandmarkAndCentralityScore(t *testing.T) {
+	ms, _, _ := newStore(t)
+	fixture := insertedFixture(t, ms)
+
+	if err := ms.SetLandmark(fixture.ID, true); err != nil {
+		t.Fatalf("SetLandmark true: %v", err)
+	}
+
+	score := 0.87
+	if err := ms.SetCentralityScore(fixture.ID, &score); err != nil {
+		t.Fatalf("SetCentralityScore: %v", err)
+	}
+
+	got, _ := ms.Get(fixture.ID)
+	if !got.Landmark {
+		t.Errorf("Landmark: got false, want true")
+	}
+	if got.CentralityScore == nil || *got.CentralityScore != 0.87 {
+		t.Errorf("CentralityScore: got %v, want 0.87", got.CentralityScore)
+	}
+	assertSubstanceUnchanged(t, got, fixture)
+
+	// Clearing centrality back to NULL (e.g. demote from landmark)
+	if err := ms.SetCentralityScore(fixture.ID, nil); err != nil {
+		t.Fatalf("SetCentralityScore nil: %v", err)
+	}
+	if err := ms.SetLandmark(fixture.ID, false); err != nil {
+		t.Fatalf("SetLandmark false: %v", err)
+	}
+	got2, _ := ms.Get(fixture.ID)
+	if got2.Landmark {
+		t.Errorf("Landmark after clear: got true, want false")
+	}
+	if got2.CentralityScore != nil {
+		t.Errorf("CentralityScore after clear: got %v, want nil", got2.CentralityScore)
+	}
+	assertSubstanceUnchanged(t, got2, fixture)
+}
+
+// T9: UpsertTag returns the same ID on re-call with the same name.
+// Tag identity is by name; second upsert is a no-op (no new row).
+func TestGraphStore_UpsertTag_Idempotent(t *testing.T) {
+	_, gs, _ := newStore(t)
+
+	id1, err := gs.UpsertTag("recall")
+	if err != nil {
+		t.Fatalf("first UpsertTag: %v", err)
+	}
+	if id1 == "" {
+		t.Fatalf("expected non-empty tag ID")
+	}
+
+	id2, err := gs.UpsertTag("recall")
+	if err != nil {
+		t.Fatalf("second UpsertTag: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("expected same tag ID on re-upsert: %q -> %q", id1, id2)
+	}
+
+	// A different name produces a different ID.
+	id3, err := gs.UpsertTag("graph")
+	if err != nil {
+		t.Fatalf("UpsertTag graph: %v", err)
+	}
+	if id3 == id1 {
+		t.Errorf("different names should have different IDs")
+	}
+}
+
+// T10: LinkTag connects a memory to a tag; MemoriesByTag returns the
+// memory IDs for a given tag name. Tag-based recall uses joins on
+// memory_tags (ADR 0010), not denormalized arrays.
+func TestGraphStore_LinkTag_MemoriesByTag(t *testing.T) {
+	ms, gs, _ := newStore(t)
+
+	m, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	tagID, err := gs.UpsertTag("recall")
+	if err != nil {
+		t.Fatalf("UpsertTag: %v", err)
+	}
+
+	if err := gs.LinkTag(m.ID, tagID); err != nil {
+		t.Fatalf("LinkTag: %v", err)
+	}
+
+	ids, err := gs.MemoriesByTag("recall")
+	if err != nil {
+		t.Fatalf("MemoriesByTag: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != m.ID {
+		t.Errorf("MemoriesByTag(recall): got %v, want [%q]", ids, m.ID)
+	}
+
+	none, err := gs.MemoriesByTag("never-used")
+	if err != nil {
+		t.Fatalf("MemoriesByTag never-used: %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("expected empty result for unknown tag, got %v", none)
+	}
+}
+
+// T11: UpsertEntity is idempotent on (type, display_name); LinkEntity
+// connects a memory to an entity with a relationship label
+// ("created_by" is the v0.30 case per ADR 0010).
+func TestGraphStore_UpsertEntity_LinkEntity(t *testing.T) {
+	ms, gs, v := newStore(t)
+
+	id1, err := gs.UpsertEntity("user", "Vinicius")
+	if err != nil {
+		t.Fatalf("UpsertEntity 1: %v", err)
+	}
+	id2, err := gs.UpsertEntity("user", "Vinicius")
+	if err != nil {
+		t.Fatalf("UpsertEntity 2: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("expected idempotent UpsertEntity, got %q vs %q", id1, id2)
+	}
+
+	idOther, err := gs.UpsertEntity("user", "Other")
+	if err != nil {
+		t.Fatalf("UpsertEntity Other: %v", err)
+	}
+	if idOther == id1 {
+		t.Errorf("different display_name should produce different entity ID")
+	}
+
+	m, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}})
+	if err != nil {
+		t.Fatalf("Insert memory: %v", err)
+	}
+
+	if err := gs.LinkEntity(m.ID, id1, "created_by"); err != nil {
+		t.Fatalf("LinkEntity: %v", err)
+	}
+
+	var gotRel string
+	err = v.Query(
+		`SELECT relationship FROM memory_entities WHERE memory_id = ? AND entity_id = ?`,
+		[]any{m.ID, id1},
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&gotRel)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("query memory_entities: %v", err)
+	}
+	if gotRel != "created_by" {
+		t.Errorf("relationship: got %q, want %q", gotRel, "created_by")
+	}
+}
+
+// T12: RenameTag changes only tags.name. memory_tags rows continue to
+// reference the same tag.id (no rewrite), and memory substance is
+// untouched. ADR 0010 — graph-level operation.
+func TestGraphStore_RenameTag(t *testing.T) {
+	ms, gs, v := newStore(t)
+	fixture := insertedFixture(t, ms)
+
+	tagID, err := gs.UpsertTag("mcp")
+	if err != nil {
+		t.Fatalf("UpsertTag: %v", err)
+	}
+	if err := gs.LinkTag(fixture.ID, tagID); err != nil {
+		t.Fatalf("LinkTag: %v", err)
+	}
+
+	if err := gs.RenameTag("mcp", "MCP"); err != nil {
+		t.Fatalf("RenameTag: %v", err)
+	}
+
+	// Tag row's name is updated; ID is preserved.
+	var name string
+	err = v.Query(
+		`SELECT name FROM tags WHERE id = ?`,
+		[]any{tagID},
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&name)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("query tags: %v", err)
+	}
+	if name != "MCP" {
+		t.Errorf("tag name: got %q, want %q", name, "MCP")
+	}
+
+	// Lookup by new name still returns the same memory (memory_tags
+	// rows were not rewritten).
+	ids, err := gs.MemoriesByTag("MCP")
+	if err != nil {
+		t.Fatalf("MemoriesByTag MCP: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != fixture.ID {
+		t.Errorf("MemoriesByTag(MCP): got %v, want [%q]", ids, fixture.ID)
+	}
+
+	// Memory substance is unchanged.
+	got, err := ms.Get(fixture.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	assertSubstanceUnchanged(t, got, fixture)
+}
+
+// T13: MergeTags repoints memory_tags edges from source to target,
+// drops the source tag row, and leaves memory substance untouched.
+// Handles the case where a memory is already linked to both source
+// and target without creating a duplicate edge.
+func TestGraphStore_MergeTags(t *testing.T) {
+	ms, gs, v := newStore(t)
+
+	fixture := insertedFixture(t, ms)
+
+	m2, err := ms.Insert(store.Memory{Content: map[string]any{"text": "y"}})
+	if err != nil {
+		t.Fatalf("Insert m2: %v", err)
+	}
+
+	srcID, err := gs.UpsertTag("foo")
+	if err != nil {
+		t.Fatalf("UpsertTag foo: %v", err)
+	}
+	tgtID, err := gs.UpsertTag("bar")
+	if err != nil {
+		t.Fatalf("UpsertTag bar: %v", err)
+	}
+	if err := gs.LinkTag(fixture.ID, srcID); err != nil {
+		t.Fatalf("LinkTag fixture->foo: %v", err)
+	}
+	if err := gs.LinkTag(m2.ID, tgtID); err != nil {
+		t.Fatalf("LinkTag m2->bar: %v", err)
+	}
+	// fixture is also already on bar to prove duplicate handling.
+	if err := gs.LinkTag(fixture.ID, tgtID); err != nil {
+		t.Fatalf("LinkTag fixture->bar: %v", err)
+	}
+
+	if err := gs.MergeTags("foo", "bar"); err != nil {
+		t.Fatalf("MergeTags: %v", err)
+	}
+
+	// Source tag is gone.
+	var srcCount int
+	err = v.Query(
+		`SELECT COUNT(*) FROM tags WHERE id = ?`,
+		[]any{srcID},
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&srcCount)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("query tags count: %v", err)
+	}
+	if srcCount != 0 {
+		t.Errorf("expected source tag deleted, found %d", srcCount)
+	}
+
+	// Both memories now reachable via target tag.
+	ids, err := gs.MemoriesByTag("bar")
+	if err != nil {
+		t.Fatalf("MemoriesByTag bar: %v", err)
+	}
+	idSet := map[string]bool{}
+	for _, id := range ids {
+		idSet[id] = true
+	}
+	if !idSet[fixture.ID] || !idSet[m2.ID] || len(ids) != 2 {
+		t.Errorf("MemoriesByTag(bar): got %v, want both fixture and m2", ids)
+	}
+
+	// Memory substance is unchanged.
+	gotFixture, err := ms.Get(fixture.ID)
+	if err != nil {
+		t.Fatalf("Get fixture: %v", err)
+	}
+	assertSubstanceUnchanged(t, gotFixture, fixture)
+}

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -560,3 +560,20 @@ func TestGraphStore_MergeTags_RejectsSelfMerge(t *testing.T) {
 		t.Errorf("expected link preserved after rejected self-merge, got %v", ids)
 	}
 }
+
+// T15: Empty names are not meaningful identifiers. UpsertTag and
+// UpsertEntity reject empty inputs early so a buggy upstream caller
+// doesn't silently create zombie rows.
+func TestGraphStore_RejectsEmptyNames(t *testing.T) {
+	_, gs, _ := newStore(t)
+
+	if _, err := gs.UpsertTag(""); err == nil {
+		t.Errorf("UpsertTag(\"\"): expected error")
+	}
+	if _, err := gs.UpsertEntity("", "X"); err == nil {
+		t.Errorf("UpsertEntity(\"\", \"X\"): expected error for empty type")
+	}
+	if _, err := gs.UpsertEntity("user", ""); err == nil {
+		t.Errorf("UpsertEntity(\"user\", \"\"): expected error for empty display_name")
+	}
+}

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -561,6 +561,29 @@ func TestGraphStore_MergeTags_RejectsSelfMerge(t *testing.T) {
 	}
 }
 
+// T16: The Memory returned by Insert has a CreatedAt that is byte-
+// identical to what Get later returns. Without stripping the monotonic
+// clock from the stored time, struct equality (==) would silently
+// fail even though Equal() succeeds — a foot-gun for any caller that
+// uses the returned Memory as a cache key or comparison target.
+func TestMemoryStore_Insert_CreatedAtIsByteIdenticalToGet(t *testing.T) {
+	ms, _, _ := newStore(t)
+
+	inserted, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	got, err := ms.Get(inserted.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if inserted.CreatedAt != got.CreatedAt {
+		t.Errorf("CreatedAt should be == after round-trip; inserted=%v got=%v",
+			inserted.CreatedAt, got.CreatedAt)
+	}
+}
+
 // T15: Empty names are not meaningful identifiers. UpsertTag and
 // UpsertEntity reject empty inputs early so a buggy upstream caller
 // doesn't silently create zombie rows.

--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -75,7 +75,8 @@ var migrations = []migration{
 			id           TEXT PRIMARY KEY,
 			type         TEXT NOT NULL,
 			display_name TEXT,
-			created_at   TEXT NOT NULL
+			created_at   TEXT NOT NULL,
+			UNIQUE (type, display_name)
 		)`,
 		`CREATE TABLE IF NOT EXISTS tags (
 			id         TEXT PRIMARY KEY,

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -340,6 +340,37 @@ func TestMigrate_RollsBackOnPartialFailure(t *testing.T) {
 	}
 }
 
+// T17: entities enforces UNIQUE(type, display_name). Two rows with the
+// same type and same display_name cannot coexist — the database
+// guarantees the contract that GraphStore.UpsertEntity assumes.
+func TestEntities_UniqueOnTypeAndDisplayName(t *testing.T) {
+	v, _ := newVault(t)
+
+	err := v.Tx(func(tx *sql.Tx) error {
+		_, e := tx.Exec(
+			`INSERT INTO entities (id, type, display_name, created_at)
+			 VALUES (?, ?, ?, ?)`,
+			"id1", "user", "Vinicius", "2026-05-03T00:00:00Z",
+		)
+		return e
+	})
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	err = v.Tx(func(tx *sql.Tx) error {
+		_, e := tx.Exec(
+			`INSERT INTO entities (id, type, display_name, created_at)
+			 VALUES (?, ?, ?, ?)`,
+			"id2", "user", "Vinicius", "2026-05-03T00:00:01Z",
+		)
+		return e
+	})
+	if err == nil {
+		t.Errorf("expected UNIQUE(type, display_name) violation on duplicate")
+	}
+}
+
 // T13: memories.content is enforced as valid JSON via a CHECK
 // constraint. The schema contract says content is JSON (e.g.
 // {"text": "..."}); rejecting non-JSON at INSERT prevents the FTS5


### PR DESCRIPTION
## Summary

- New \`cli/internal/store/\` with **MemoryStore** (CRUD on memories, substance immutability enforced at API) and **GraphStore** (tags, entities, edges)
- Discrete operational setters: \`SetType\`, \`SetPromotionState\`, \`SetLandmark\`, \`SetCentralityScore\` — substance fields are unreachable from any public method
- Tag operations are graph-level: \`RenameTag\` mutates only \`tags.name\`; \`MergeTags\` repoints \`memory_tags\` edges without rewriting any memory
- 12 tests covering insert/get round-trip, UUID minting, defaults, ErrNotFound, every setter (with substance-unchanged assertions), tag/entity upsert idempotency, link round-trip, rename safety, merge with duplicate handling

## Closes

Closes #235

## References

- PRD: https://github.com/momhq/mom/blob/main/prd/0003-v0-30.md
- ADRs: [0010](https://github.com/momhq/mom/blob/main/adr/0010-graph-fluent-schema-normalization.md), [0011](https://github.com/momhq/mom/blob/main/adr/0011-substance-immutability-operational-mutability.md), [0012](https://github.com/momhq/mom/blob/main/adr/0012-tulving-typology-default-untyped.md), [0013](https://github.com/momhq/mom/blob/main/adr/0013-uuid-only-memory-ids.md)

## Test plan

- [x] \`go test ./internal/store/...\` — 12/12 pass
- [x] \`go test ./...\` — full project still green
- [x] Substance immutability enforced by API absence: no public path to mutate \`id\`, \`content\`, \`summary\`, \`created_at\`, \`session_id\`, or any \`provenance_*\` field after \`Insert\`
- [x] Tag rename / merge verified to leave memory substance untouched
- [x] \`MergeTags\` handles the case where a memory is already linked to both source and target (PRIMARY KEY constraint honored)

## Out of scope

- Deletion of legacy \`cli/internal/memory/\` + JSON file writers — still consumed by drafter, watcher, cartographer; each migrates in its own slice (#240, etc.). Final cleanup after last consumer migrates.
- Memory deletion (no acceptance criterion in #235)
- Bulk Insert / batch operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)