### PR TITLE
feat(mcp): mom_record tool — explicit-write path to v0.30 vault (#239)

### DIFF
--- a/cli/internal/cmd/serve.go
+++ b/cli/internal/cmd/serve.go
@@ -15,6 +15,7 @@ import (
 	"github.com/momhq/mom/cli/internal/mcp"
 	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/ux"
+	"github.com/momhq/mom/cli/internal/vault"
 )
 
 var serveCmd = &cobra.Command{
@@ -80,6 +81,21 @@ func runServeMCP(_ *cobra.Command, _ []string) error {
 
 	mcp.Version = Version
 	srv := mcp.New(sc.Path)
+
+	// Wire the v0.30 central vault at $HOME/.mom/mom.db so tools that
+	// target the new vault (mom_record) work. If the vault cannot be
+	// opened (e.g. missing $HOME/.mom/), continue without it — legacy
+	// tools still function; v0.30 tools return a clear error.
+	if home, err := os.UserHomeDir(); err == nil {
+		momHome := filepath.Join(home, ".mom")
+		if err := os.MkdirAll(momHome, 0700); err == nil {
+			if v, err := vault.Open(filepath.Join(momHome, "mom.db")); err == nil {
+				srv.SetVault(v)
+				defer v.Close()
+			}
+		}
+	}
+
 	// Blocks until stdin is closed.
 	srv.Serve(os.Stdin, os.Stdout)
 	return nil

--- a/cli/internal/cmd/serve.go
+++ b/cli/internal/cmd/serve.go
@@ -84,15 +84,22 @@ func runServeMCP(_ *cobra.Command, _ []string) error {
 
 	// Wire the v0.30 central vault at $HOME/.mom/mom.db so tools that
 	// target the new vault (mom_record) work. If the vault cannot be
-	// opened (e.g. missing $HOME/.mom/), continue without it — legacy
-	// tools still function; v0.30 tools return a clear error.
-	if home, err := os.UserHomeDir(); err == nil {
+	// opened, continue without it — legacy tools still function and
+	// v0.30 tools return a clear error. Each failure path logs to
+	// stderr (stdout is reserved for JSON-RPC) so the operator can
+	// diagnose why mom_record reports "vault not configured".
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[mom] warning: cannot resolve $HOME for v0.30 vault: %v\n", err)
+	} else {
 		momHome := filepath.Join(home, ".mom")
-		if err := os.MkdirAll(momHome, 0700); err == nil {
-			if v, err := vault.Open(filepath.Join(momHome, "mom.db")); err == nil {
-				srv.SetVault(v)
-				defer v.Close()
-			}
+		if err := os.MkdirAll(momHome, 0700); err != nil {
+			fmt.Fprintf(os.Stderr, "[mom] warning: cannot create %s for v0.30 vault: %v\n", momHome, err)
+		} else if v, err := vault.Open(filepath.Join(momHome, "mom.db")); err != nil {
+			fmt.Fprintf(os.Stderr, "[mom] warning: cannot open v0.30 vault at %s: %v\n", filepath.Join(momHome, "mom.db"), err)
+		} else {
+			srv.SetVault(v)
+			defer v.Close()
 		}
 	}
 

--- a/cli/internal/mcp/mom_record.go
+++ b/cli/internal/mcp/mom_record.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/momhq/mom/cli/internal/store"
 )
@@ -93,7 +94,7 @@ func (s *Server) toolMomRecord(args map[string]any) (toolCallResult, error) {
 	resultDoc := map[string]any{
 		"id":              mem.ID,
 		"promotion_state": mem.PromotionState,
-		"created_at":      mem.CreatedAt.Format("2006-01-02T15:04:05.000000000Z"),
+		"created_at":      mem.CreatedAt.Format(time.RFC3339Nano),
 		"message":         fmt.Sprintf("Memory created with id=%s", mem.ID),
 	}
 	text, _ := json.MarshalIndent(resultDoc, "", "  ")

--- a/cli/internal/mcp/mom_record.go
+++ b/cli/internal/mcp/mom_record.go
@@ -1,0 +1,88 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/momhq/mom/cli/internal/store"
+)
+
+// toolMomRecord handles the mom_record MCP tool. Writes a memory to
+// the central vault via MemoryStore. Bypasses capture filters
+// (explicit user/agent write path per ADR 0014). Stamps the
+// server-side provenance fields trigger_event="record" and
+// source_type="manual-draft"; all other substance fields are
+// caller-provided and required.
+func (s *Server) toolMomRecord(args map[string]any) (toolCallResult, error) {
+	if s.vault == nil {
+		return toolCallResult{}, fmt.Errorf("mom_record: vault not configured on server")
+	}
+
+	summary := stringArg(args, "summary")
+	if summary == "" {
+		return toolCallResult{}, fmt.Errorf("mom_record: summary is required")
+	}
+	content, _ := args["content"].(map[string]any)
+	if content == nil {
+		return toolCallResult{}, fmt.Errorf("mom_record: content is required")
+	}
+	sessionID := stringArg(args, "session_id")
+	if sessionID == "" {
+		return toolCallResult{}, fmt.Errorf("mom_record: session_id is required")
+	}
+	actor := stringArg(args, "actor")
+	if actor == "" {
+		return toolCallResult{}, fmt.Errorf("mom_record: actor is required")
+	}
+	createdBy := stringArg(args, "created_by")
+	if createdBy == "" {
+		return toolCallResult{}, fmt.Errorf("mom_record: created_by is required")
+	}
+	memType := stringArg(args, "type")
+	tags := stringSliceArg(args, "tags")
+
+	ms := store.NewMemoryStore(s.vault)
+	mem, err := ms.Insert(store.Memory{
+		Type:                   memType,
+		Summary:                summary,
+		Content:                content,
+		SessionID:              sessionID,
+		ProvenanceActor:        actor,
+		ProvenanceSourceType:   "manual-draft",
+		ProvenanceTriggerEvent: "record",
+	})
+	if err != nil {
+		return toolCallResult{}, fmt.Errorf("mom_record: %w", err)
+	}
+
+	gs := store.NewGraphStore(s.vault)
+
+	// created_by edge: upsert the user entity (idempotent on
+	// (type, display_name)) and link the new memory to it.
+	entityID, err := gs.UpsertEntity("user", createdBy)
+	if err != nil {
+		return toolCallResult{}, fmt.Errorf("mom_record: upsert created_by entity %q: %w", createdBy, err)
+	}
+	if err := gs.LinkEntity(mem.ID, entityID, "created_by"); err != nil {
+		return toolCallResult{}, fmt.Errorf("mom_record: link created_by entity: %w", err)
+	}
+
+	for _, tag := range tags {
+		tagID, err := gs.UpsertTag(tag)
+		if err != nil {
+			return toolCallResult{}, fmt.Errorf("mom_record: upsert tag %q: %w", tag, err)
+		}
+		if err := gs.LinkTag(mem.ID, tagID); err != nil {
+			return toolCallResult{}, fmt.Errorf("mom_record: link tag %q: %w", tag, err)
+		}
+	}
+
+	resultDoc := map[string]any{
+		"id":              mem.ID,
+		"promotion_state": mem.PromotionState,
+		"created_at":      mem.CreatedAt.Format("2006-01-02T15:04:05.000000000Z"),
+		"message":         fmt.Sprintf("Memory created with id=%s", mem.ID),
+	}
+	text, _ := json.MarshalIndent(resultDoc, "", "  ")
+	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
+}

--- a/cli/internal/mcp/mom_record.go
+++ b/cli/internal/mcp/mom_record.go
@@ -39,7 +39,20 @@ func (s *Server) toolMomRecord(args map[string]any) (toolCallResult, error) {
 		return toolCallResult{}, fmt.Errorf("mom_record: created_by is required")
 	}
 	memType := stringArg(args, "type")
-	tags := stringSliceArg(args, "tags")
+
+	// Pre-validate tags: normalize each (T2 model from ADR 0010) and
+	// reject the whole request if any tag reduces to an empty string.
+	// Doing this before any DB write avoids orphan memory + entity rows
+	// when a tag like "!!!" or "   " is passed.
+	rawTags := stringSliceArg(args, "tags")
+	tags := make([]string, 0, len(rawTags))
+	for _, raw := range rawTags {
+		norm := store.NormalizeTagName(raw)
+		if norm == "" {
+			return toolCallResult{}, fmt.Errorf("mom_record: tag %q normalises to empty; tags must contain at least one alphanumeric character", raw)
+		}
+		tags = append(tags, norm)
+	}
 
 	ms := store.NewMemoryStore(s.vault)
 	mem, err := ms.Insert(store.Memory{

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -349,3 +349,100 @@ func TestToolsCallMomRecord_CreatedByLinksUserEntity(t *testing.T) {
 		}
 	}
 }
+
+// T18a: mom_record normalizes tags before linking. Caller-supplied
+// variations of the same intent ("My Tag", "my-tag", "MY_TAG") all
+// resolve to the same canonical tag row.
+func TestToolsCallMomRecord_NormalizesTags(t *testing.T) {
+	v, _ := newTestVault(t)
+
+	doc := callMomRecord(t, v, map[string]any{
+		"summary":    "normalize test",
+		"content":    map[string]any{"text": "x"},
+		"session_id": "s1",
+		"actor":      "claude-code",
+		"created_by": "Vinicius",
+		"tags":       []any{"My Tag", "v0.30", "Foo_Bar"},
+	})
+	id, _ := doc["id"].(string)
+	if id == "" {
+		t.Fatalf("missing id: %v", doc)
+	}
+
+	gs := store.NewGraphStore(v)
+	for _, want := range []string{"my-tag", "v0-30", "foo-bar"} {
+		ids, err := gs.MemoriesByTag(want)
+		if err != nil {
+			t.Fatalf("MemoriesByTag(%q): %v", want, err)
+		}
+		found := false
+		for _, mid := range ids {
+			if mid == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected tag %q to link to %s, got %v", want, id, ids)
+		}
+	}
+}
+
+// T18b: When a tag normalizes to empty (e.g. "!!!" or "   "),
+// mom_record rejects the entire request before persisting anything.
+// No orphan memory or partial graph state.
+func TestToolsCallMomRecord_RejectsEmptyTagWithoutOrphans(t *testing.T) {
+	v, _ := newTestVault(t)
+	leoDir := newTestLeoDir(t)
+	inW, outR, _ := runServerWithVault(t, leoDir, v)
+	defer inW.Close()
+
+	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
+	readResponse(t, outR)
+
+	sendRequest(t, inW, "tools/call", 2, map[string]any{
+		"name": "mom_record",
+		"arguments": map[string]any{
+			"summary":    "should not persist",
+			"content":    map[string]any{"text": "x"},
+			"session_id": "s1",
+			"actor":      "claude-code",
+			"created_by": "Vinicius",
+			"tags":       []any{"valid", "!!!"}, // "!!!" normalizes to ""
+		},
+	})
+	resp := readResponse(t, outR)
+	result, _ := resp["result"].(map[string]any)
+	isErr, _ := result["isError"].(bool)
+	if !isErr {
+		t.Errorf("expected isError=true for empty-after-normalization tag, got %v", result)
+	}
+
+	// No memory was persisted — fail-fast before Insert.
+	var memCount int
+	if err := v.Query(`SELECT COUNT(*) FROM memories`, nil, func(rows *sql.Rows) error {
+		if rows.Next() {
+			return rows.Scan(&memCount)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("count memories: %v", err)
+	}
+	if memCount != 0 {
+		t.Errorf("expected no memory persisted on rejected request, got %d", memCount)
+	}
+
+	// And no entities (created_by would have been upserted otherwise).
+	var entCount int
+	if err := v.Query(`SELECT COUNT(*) FROM entities`, nil, func(rows *sql.Rows) error {
+		if rows.Next() {
+			return rows.Scan(&entCount)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("count entities: %v", err)
+	}
+	if entCount != 0 {
+		t.Errorf("expected no entity persisted on rejected request, got %d", entCount)
+	}
+}

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -1,0 +1,351 @@
+package mcp_test
+
+import (
+	"bufio"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/momhq/mom/cli/internal/mcp"
+	"github.com/momhq/mom/cli/internal/store"
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// jsonUnmarshalString is a thin helper for tests that parse the JSON
+// payload embedded in a tool result's text content.
+func jsonUnmarshalString(s string, dst any) error {
+	return json.Unmarshal([]byte(s), dst)
+}
+
+// runServerWithVault is the runServer variant that wires a Vault into
+// the Server before Serve starts, so v0.30 tools that depend on the
+// vault (mom_record and friends) work.
+func runServerWithVault(t *testing.T, leoDir string, v *vault.Vault) (io.WriteCloser, *bufio.Reader, chan struct{}) {
+	t.Helper()
+	inR, inW := io.Pipe()
+	outR2, outW := io.Pipe()
+
+	srv := mcp.New(leoDir)
+	srv.SetVault(v)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.Serve(inR, outW)
+		_ = outW.Close()
+	}()
+	return inW, bufio.NewReader(outR2), done
+}
+
+// newTestVault opens a fresh Vault in a temp dir and returns it
+// alongside its filesystem path.
+func newTestVault(t *testing.T) (*vault.Vault, string) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "mom.db")
+	v, err := vault.Open(dbPath)
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	return v, dbPath
+}
+
+// T1 (tracer bullet): mom_record with all required args writes a
+// memory readable via MemoryStore.Get. The returned ID is a UUID v4.
+// Verifies the full path: MCP request → handler → MemoryStore →
+// Vault → SQLite, and back via Get.
+func TestToolsCallMomRecord_RoundTrip(t *testing.T) {
+	leoDir := newTestLeoDir(t)
+	v, _ := newTestVault(t)
+
+	inW, outR, _ := runServerWithVault(t, leoDir, v)
+	defer inW.Close()
+
+	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
+	readResponse(t, outR)
+
+	sendRequest(t, inW, "tools/call", 2, map[string]any{
+		"name": "mom_record",
+		"arguments": map[string]any{
+			"summary":    "test summary",
+			"content":    map[string]any{"text": "test body"},
+			"session_id": "session-1",
+			"actor":      "claude-code",
+			"created_by": "Vinicius",
+		},
+	})
+	resp := readResponse(t, outR)
+
+	if resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result not a map: %v", resp["result"])
+	}
+	if isErr, _ := result["isError"].(bool); isErr {
+		t.Fatalf("tool returned isError: %v", result)
+	}
+
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("content missing: %v", result)
+	}
+	first, _ := content[0].(map[string]any)
+	text, _ := first["text"].(string)
+
+	// Parse the JSON returned by the tool to extract the new ID.
+	var resultDoc map[string]any
+	if err := jsonUnmarshalString(text, &resultDoc); err != nil {
+		t.Fatalf("parse tool response %q: %v", text, err)
+	}
+	id, _ := resultDoc["id"].(string)
+	if id == "" {
+		t.Fatalf("response missing id: %v", resultDoc)
+	}
+	if _, err := uuid.Parse(id); err != nil {
+		t.Errorf("expected UUID id, got %q: %v", id, err)
+	}
+
+	// Read back via MemoryStore.
+	ms := store.NewMemoryStore(v)
+	got, err := ms.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", id, err)
+	}
+	if got.Summary != "test summary" {
+		t.Errorf("Summary: got %q, want %q", got.Summary, "test summary")
+	}
+	if txt, _ := got.Content["text"].(string); txt != "test body" {
+		t.Errorf("Content.text: got %v", got.Content["text"])
+	}
+}
+
+// callMomRecord is a small fixture that runs an MCP server with the
+// given vault, sends one mom_record request with the given args, and
+// returns the parsed result document.
+func callMomRecord(t *testing.T, v *vault.Vault, args map[string]any) map[string]any {
+	t.Helper()
+	leoDir := newTestLeoDir(t)
+	inW, outR, _ := runServerWithVault(t, leoDir, v)
+	defer inW.Close()
+
+	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
+	readResponse(t, outR)
+
+	sendRequest(t, inW, "tools/call", 2, map[string]any{
+		"name":      "mom_record",
+		"arguments": args,
+	})
+	resp := readResponse(t, outR)
+
+	if resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+	result, _ := resp["result"].(map[string]any)
+	content, _ := result["content"].([]any)
+	if len(content) == 0 {
+		t.Fatalf("no content in response: %v", result)
+	}
+	first, _ := content[0].(map[string]any)
+	text, _ := first["text"].(string)
+
+	var doc map[string]any
+	if err := jsonUnmarshalString(text, &doc); err != nil {
+		t.Fatalf("parse tool response %q: %v", text, err)
+	}
+	return doc
+}
+
+// T2: mom_record stamps server-side provenance — trigger_event="record"
+// and source_type="manual-draft" — regardless of what the caller
+// passes. The caller-supplied actor flows through.
+func TestToolsCallMomRecord_StampsServerSideProvenance(t *testing.T) {
+	v, _ := newTestVault(t)
+
+	doc := callMomRecord(t, v, map[string]any{
+		"summary":    "stamping test",
+		"content":    map[string]any{"text": "x"},
+		"session_id": "session-xyz",
+		"actor":      "codex",
+		"created_by": "Vinicius",
+	})
+
+	id, _ := doc["id"].(string)
+	if id == "" {
+		t.Fatalf("missing id in response: %v", doc)
+	}
+
+	ms := store.NewMemoryStore(v)
+	mem, err := ms.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if mem.ProvenanceTriggerEvent != "record" {
+		t.Errorf("trigger_event: got %q, want %q", mem.ProvenanceTriggerEvent, "record")
+	}
+	if mem.ProvenanceSourceType != "manual-draft" {
+		t.Errorf("source_type: got %q, want %q", mem.ProvenanceSourceType, "manual-draft")
+	}
+	if mem.ProvenanceActor != "codex" {
+		t.Errorf("actor: got %q, want %q", mem.ProvenanceActor, "codex")
+	}
+	if mem.SessionID != "session-xyz" {
+		t.Errorf("session_id: got %q, want %q", mem.SessionID, "session-xyz")
+	}
+}
+
+// T3: When mom_record receives tags, the handler upserts each tag and
+// links the new memory to it. MemoriesByTag returns the new memory ID
+// for each tag.
+func TestToolsCallMomRecord_TagsAreLinked(t *testing.T) {
+	v, _ := newTestVault(t)
+
+	doc := callMomRecord(t, v, map[string]any{
+		"summary":    "tagged memory",
+		"content":    map[string]any{"text": "x"},
+		"session_id": "s1",
+		"actor":      "claude-code",
+		"created_by": "Vinicius",
+		"tags":       []any{"recall", "graph"},
+	})
+	id, _ := doc["id"].(string)
+	if id == "" {
+		t.Fatalf("missing id: %v", doc)
+	}
+
+	gs := store.NewGraphStore(v)
+	for _, tag := range []string{"recall", "graph"} {
+		ids, err := gs.MemoriesByTag(tag)
+		if err != nil {
+			t.Fatalf("MemoriesByTag(%q): %v", tag, err)
+		}
+		found := false
+		for _, mid := range ids {
+			if mid == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("MemoriesByTag(%q) does not include %s; got %v", tag, id, ids)
+		}
+	}
+}
+
+// T4: mom_record returns an error when any required arg is missing.
+// Substance fields cannot be silently defaulted to empty — there is
+// no way to fill them in later (substance is immutable per ADR 0011).
+func TestToolsCallMomRecord_RejectsMissingRequiredArgs(t *testing.T) {
+	complete := map[string]any{
+		"summary":    "x",
+		"content":    map[string]any{"text": "y"},
+		"session_id": "s1",
+		"actor":      "claude-code",
+		"created_by": "Vinicius",
+	}
+
+	cases := []string{"summary", "content", "session_id", "actor", "created_by"}
+	for _, missing := range cases {
+		t.Run("missing_"+missing, func(t *testing.T) {
+			v, _ := newTestVault(t)
+			leoDir := newTestLeoDir(t)
+			inW, outR, _ := runServerWithVault(t, leoDir, v)
+			defer inW.Close()
+
+			sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
+			readResponse(t, outR)
+
+			args := make(map[string]any, len(complete))
+			for k, val := range complete {
+				if k != missing {
+					args[k] = val
+				}
+			}
+			sendRequest(t, inW, "tools/call", 2, map[string]any{
+				"name":      "mom_record",
+				"arguments": args,
+			})
+			resp := readResponse(t, outR)
+
+			result, _ := resp["result"].(map[string]any)
+			isErr, _ := result["isError"].(bool)
+			if !isErr {
+				t.Errorf("expected isError=true when %q is missing, got result=%v", missing, result)
+			}
+		})
+	}
+}
+
+// T5: mom_record upserts a user entity for created_by and links the
+// new memory to it with relationship="created_by". Second call with
+// the same created_by reuses the same entity (idempotent at the
+// entity layer).
+func TestToolsCallMomRecord_CreatedByLinksUserEntity(t *testing.T) {
+	v, _ := newTestVault(t)
+
+	doc1 := callMomRecord(t, v, map[string]any{
+		"summary":    "first memory",
+		"content":    map[string]any{"text": "x"},
+		"session_id": "s1",
+		"actor":      "claude-code",
+		"created_by": "Vinicius",
+	})
+	id1, _ := doc1["id"].(string)
+
+	doc2 := callMomRecord(t, v, map[string]any{
+		"summary":    "second memory",
+		"content":    map[string]any{"text": "y"},
+		"session_id": "s2",
+		"actor":      "claude-code",
+		"created_by": "Vinicius",
+	})
+	id2, _ := doc2["id"].(string)
+
+	// One entity row for ("user", "Vinicius") — idempotent across calls.
+	var entityCount int
+	if err := v.Query(
+		`SELECT COUNT(*) FROM entities WHERE type='user' AND display_name='Vinicius'`,
+		nil,
+		func(rows *sql.Rows) error {
+			if rows.Next() {
+				return rows.Scan(&entityCount)
+			}
+			return nil
+		},
+	); err != nil {
+		t.Fatalf("count entities: %v", err)
+	}
+	if entityCount != 1 {
+		t.Errorf("expected 1 user/Vinicius entity row, got %d", entityCount)
+	}
+
+	// Both memories have a created_by edge.
+	for _, id := range []string{id1, id2} {
+		var rel string
+		err := v.Query(
+			`SELECT me.relationship FROM memory_entities me
+			 JOIN entities e ON e.id = me.entity_id
+			 WHERE me.memory_id = ? AND e.type='user' AND e.display_name='Vinicius'`,
+			[]any{id},
+			func(rows *sql.Rows) error {
+				if rows.Next() {
+					return rows.Scan(&rel)
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("query edge for %s: %v", id, err)
+		}
+		if rel != "created_by" {
+			t.Errorf("memory %s relationship: got %q, want %q", id, rel, "created_by")
+		}
+	}
+}

--- a/cli/internal/mcp/server.go
+++ b/cli/internal/mcp/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/momhq/mom/cli/internal/recall"
 	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/ux"
+	"github.com/momhq/mom/cli/internal/vault"
 )
 
 // Version is set by the caller (cmd package) to match the CLI version.
@@ -62,6 +63,16 @@ type Server struct {
 	momDir string
 	idx    *storage.IndexedAdapter
 	engine *recall.Engine
+	vault  *vault.Vault
+}
+
+// SetVault wires the v0.30 Vault into the Server. Required by tools
+// that target the central vault (mom_record). Tools that still operate
+// against legacy per-folder storage do not require it. Production
+// callers always set this in serve.go; tests for legacy tools may
+// skip it.
+func (s *Server) SetVault(v *vault.Vault) {
+	s.vault = v
 }
 
 // New creates a new Server rooted at the given .mom/ directory.

--- a/cli/internal/mcp/server_test.go
+++ b/cli/internal/mcp/server_test.go
@@ -182,8 +182,8 @@ func TestToolsList(t *testing.T) {
 	if !ok {
 		t.Fatalf("tools not an array: %v", result["tools"])
 	}
-	if len(tools) != 7 {
-		t.Errorf("expected 7 tools, got %d", len(tools))
+	if len(tools) != 8 {
+		t.Errorf("expected 8 tools, got %d", len(tools))
 	}
 
 	names := make(map[string]bool)
@@ -195,7 +195,7 @@ func TestToolsList(t *testing.T) {
 		name, _ := tool["name"].(string)
 		names[name] = true
 	}
-	expected := []string{"get_memory", "list_scopes", "create_memory_draft", "list_landmarks", "mom_status", "mom_record_turn", "mom_recall"}
+	expected := []string{"get_memory", "list_scopes", "create_memory_draft", "list_landmarks", "mom_status", "mom_record_turn", "mom_recall", "mom_record"}
 	for _, n := range expected {
 		if !names[n] {
 			t.Errorf("tool %q missing from tools/list", n)

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -99,6 +99,23 @@ func allTools() []toolDef {
 			},
 		},
 		{
+			Name:        "mom_record",
+			Description: "Create a memory in the central vault ($HOME/.mom/mom.db). Bypasses capture filters — explicit user/agent write path. Stamps trigger_event='record', source_type='manual-draft'. All required substance fields must be provided.",
+			InputSchema: map[string]any{
+				"type":     "object",
+				"required": []string{"summary", "content", "session_id", "actor", "created_by"},
+				"properties": map[string]any{
+					"summary":    map[string]any{"type": "string", "description": "One-line distillation"},
+					"content":    map[string]any{"type": "object", "description": "Memory content; conventionally {text: ...}"},
+					"session_id": map[string]any{"type": "string", "description": "Session identifier"},
+					"actor":      map[string]any{"type": "string", "description": "Calling agent identity (e.g. claude-code, codex)"},
+					"created_by": map[string]any{"type": "string", "description": "Display name of the user entity to attribute as creator"},
+					"tags":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional kebab-case tags"},
+					"type":       map[string]any{"type": "string", "description": "Optional memory type (episodic|semantic|procedural|untyped); defaults to untyped"},
+				},
+			},
+		},
+		{
 			Name:        "mom_recall",
 			Description: "Search your memory for relevant context. Uses progressive scope escalation (repo→org→user) with AND→OR query relaxation and curated-first, draft-fallback quality tiers.",
 			InputSchema: map[string]any{
@@ -157,6 +174,8 @@ func (s *Server) handleToolsCall(params json.RawMessage) (any, *rpcError) {
 		result, err = s.toolRecordTurn(req.Arguments)
 	case "mom_recall":
 		result, err = s.toolMomRecall(req.Arguments)
+	case "mom_record":
+		result, err = s.toolMomRecord(req.Arguments)
 	default:
 		return nil, &rpcError{Code: errCodeMethodNotFound, Message: "unknown tool: " + req.Name}
 	}

--- a/cli/internal/store/normalize.go
+++ b/cli/internal/store/normalize.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"strings"
+	"unicode"
+)
+
+// NormalizeTagName returns the canonical form of a tag name. Tag
+// identity in v0.30 is convention-driven kebab-case; this helper
+// canonicalises caller-supplied tag strings so that variations of the
+// "same" intent collapse to one tag row.
+//
+// Rules (the "T2" model — see ADR 0010):
+//   - Lowercase (Unicode-aware)
+//   - Trim outer whitespace
+//   - Replace any run of non-alphanumeric characters (including
+//     whitespace, underscores, periods, slashes, punctuation) with a
+//     single hyphen
+//   - Unicode letters and digits are preserved (alphanumeric is
+//     unicode.IsLetter || unicode.IsDigit, NOT just [a-z0-9])
+//   - Trim leading/trailing hyphens
+//
+// Examples:
+//
+//	"My Tag"   -> "my-tag"
+//	"Foo_Bar"  -> "foo-bar"
+//	"v0.30"    -> "v0-30"
+//	"メモリ"    -> "メモリ"
+//	"!!!"      -> ""
+//
+// An empty input (or input that reduces entirely to separators) returns
+// the empty string. Callers that require a non-empty tag should check
+// the result and reject before calling UpsertTag.
+func NormalizeTagName(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	wroteAny := false
+	prevHyphen := true // suppress leading hyphens
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			wroteAny = true
+			prevHyphen = false
+			continue
+		}
+		if !prevHyphen {
+			b.WriteRune('-')
+			prevHyphen = true
+		}
+	}
+	if !wroteAny {
+		return ""
+	}
+	return strings.TrimRight(b.String(), "-")
+}

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -561,6 +561,53 @@ func TestGraphStore_MergeTags_RejectsSelfMerge(t *testing.T) {
 	}
 }
 
+// T17: NormalizeTagName produces canonical kebab-case while preserving
+// Unicode letters and digits. Lowercases, trims outer whitespace, and
+// collapses any run of non-alphanumeric characters into a single
+// hyphen. Trims leading/trailing hyphens. Empty input or input that
+// reduces to only separators returns empty string.
+func TestNormalizeTagName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		// Casing
+		{"MCP", "mcp"},
+		{"GraphQL", "graphql"},
+		// Whitespace and underscores
+		{"My Tag", "my-tag"},
+		{"Foo_Bar", "foo-bar"},
+		{"  spaced  out  ", "spaced-out"},
+		{"Foo__Bar", "foo-bar"},
+		// Punctuation collapses (T2 model)
+		{"v0.30", "v0-30"},
+		{"recall/v2", "recall-v2"},
+		{"MOM!", "mom"},
+		{"foo.bar.baz", "foo-bar-baz"},
+		// Trim leading/trailing
+		{"-tag-", "tag"},
+		{"!!!tag!!!", "tag"},
+		// Already canonical
+		{"my-tag", "my-tag"},
+		// Unicode preserved
+		{"メモリ", "メモリ"},
+		{"メモリ test", "メモリ-test"},
+		{"über", "über"},
+		// Edge cases
+		{"", ""},
+		{"   ", ""},
+		{"---", ""},
+		{"!!!", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := store.NormalizeTagName(c.in)
+			if got != c.want {
+				t.Errorf("NormalizeTagName(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 // T16: The Memory returned by Insert has a CreatedAt that is byte-
 // identical to what Get later returns. Without stripping the monotonic
 // clock from the stored time, struct equality (==) would silently


### PR DESCRIPTION
## Summary

- New \`mom_record\` MCP tool that writes a memory directly to \`\$HOME/.mom/mom.db\` via MemoryStore + GraphStore
- Bypasses capture filters per ADR 0014 (explicit user/agent write path)
- All substance args required (summary, content, session_id, actor, created_by); operational args (tags, type) optional
- Server-side stamping: \`trigger_event='record'\`, \`source_type='manual-draft'\`, UUID minted, defaults applied
- \`created_by\` upserts a user entity (idempotent) and links via \`memory_entities\` with relationship \`created_by\`
- Coexists with legacy \`create_memory_draft\` for now (per deferred-deletion rule; #245 will clean up)

## Plumbing

- \`Server\` gains a \`*vault.Vault\` field + \`SetVault(v)\` setter
- \`serve.go\` opens vault and wires it before \`Serve\`
- 5 new tests cover round-trip / stamping / tag linking / required-arg rejection / created_by edge idempotency
- \`TestToolsList\` updated from 7 → 8 tools

## Closes

Closes #239

## References

- PRD: https://github.com/momhq/mom/blob/main/prd/0003-v0-30.md
- ADRs: [0011](https://github.com/momhq/mom/blob/main/adr/0011-substance-immutability-operational-mutability.md), [0012](https://github.com/momhq/mom/blob/main/adr/0012-tulving-typology-default-untyped.md), [0014](https://github.com/momhq/mom/blob/main/adr/0014-capture-filtering-privacy-quality.md)

## Test plan

- [x] \`go test ./internal/mcp/...\` — 25/25 pass (5 new mom_record tests)
- [x] \`go test ./...\` — full project still green
- [x] Substance fields all required; missing-arg rejection covered for each
- [x] Server-side fields (trigger_event, source_type) cannot be overridden by caller
- [x] created_by produces idempotent user entity edge

## Out of scope

- Removing legacy \`create_memory_draft\` and \`mom_record_turn\` — defers to #245
- Composite Tx for atomic memory + tag + entity insert (PR #250 review concern #4) — defers
- Capture filter pipeline — filters land in #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)