### PR TITLE
feat(eventlog): operational telemetry module (#236)

### DIFF
--- a/cli/internal/eventlog/eventlog.go
+++ b/cli/internal/eventlog/eventlog.go
@@ -62,14 +62,33 @@ type Counter struct {
 	LastFiredAt    time.Time
 }
 
+// timestampFormat is the fixed-width nanosecond format used for all
+// stored timestamps in event_log. RFC3339Nano trims trailing zeros and
+// would break lexical sort across mixed-precision values (e.g.
+// "12:00:00Z" vs "12:00:00.5Z" sort wrong because "." < "Z" in ASCII).
+// Always emitting 9 fractional digits keeps the strings sortable.
+const timestampFormat = "2006-01-02T15:04:05.000000000Z07:00"
+
 // Log appends an event to event_log. The row's auto-increment ID is
 // not surfaced to the caller — use Query to retrieve persisted events.
+//
+// EventType and SessionID are required (every event must be
+// attributable to a session, even MOM-internal runs which use a
+// synthetic mom-<uuid>).
 func (e *EventLog) Log(ev Event) error {
 	if ev.EventType == "" {
 		return fmt.Errorf("eventlog.Log: EventType is required")
 	}
+	if ev.SessionID == "" {
+		return fmt.Errorf("eventlog.Log: SessionID is required")
+	}
 	if ev.Timestamp.IsZero() {
 		ev.Timestamp = time.Now().UTC().Round(0)
+	}
+	// Normalise empty payloads to nil so they round-trip identically
+	// (both nil and an empty map serialise to the same "null").
+	if len(ev.Payload) == 0 {
+		ev.Payload = nil
 	}
 	payloadJSON, err := json.Marshal(ev.Payload)
 	if err != nil {
@@ -80,7 +99,7 @@ func (e *EventLog) Log(ev Event) error {
 			`INSERT INTO event_log (event_type, timestamp, session_id, payload)
 			 VALUES (?, ?, ?, ?)`,
 			ev.EventType,
-			ev.Timestamp.Format(time.RFC3339Nano),
+			ev.Timestamp.UTC().Format(timestampFormat),
 			ev.SessionID,
 			string(payloadJSON),
 		)
@@ -111,7 +130,7 @@ func (e *EventLog) Query(f Filter) ([]Row, error) {
 	}
 	if !f.Since.IsZero() {
 		sb.WriteString(` AND timestamp >= ?`)
-		args = append(args, f.Since.UTC().Format(time.RFC3339Nano))
+		args = append(args, f.Since.UTC().Format(timestampFormat))
 	}
 	sb.WriteString(` ORDER BY timestamp DESC, id DESC LIMIT ?`)
 	args = append(args, limit)
@@ -126,12 +145,18 @@ func (e *EventLog) Query(f Filter) ([]Row, error) {
 			if err := rs.Scan(&r.ID, &r.EventType, &ts, &r.SessionID, &payload); err != nil {
 				return err
 			}
-			t, err := time.Parse(time.RFC3339Nano, ts)
+			t, err := time.Parse(timestampFormat, ts)
 			if err != nil {
-				return fmt.Errorf("parse timestamp: %w", err)
+				// Fall back to RFC3339Nano for forward-compat with any
+				// rows written before the fixed-width migration.
+				t, err = time.Parse(time.RFC3339Nano, ts)
+				if err != nil {
+					return fmt.Errorf("parse timestamp %q: %w", ts, err)
+				}
 			}
 			r.Timestamp = t
-			if payload != "" && payload != "null" {
+			// json.Unmarshal of "null" sets target to nil — desired.
+			if payload != "" {
 				if err := json.Unmarshal([]byte(payload), &r.Payload); err != nil {
 					return fmt.Errorf("unmarshal payload: %w", err)
 				}
@@ -149,7 +174,7 @@ func (e *EventLog) IncrementCounter(category string) error {
 	if category == "" {
 		return fmt.Errorf("eventlog.IncrementCounter: category is required")
 	}
-	now := time.Now().UTC().Round(0).Format(time.RFC3339Nano)
+	now := time.Now().UTC().Round(0).Format(timestampFormat)
 	return e.v.Tx(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
 			`INSERT INTO filter_audit (category, redaction_count, last_fired_at)
@@ -180,9 +205,12 @@ func (e *EventLog) Counters() ([]Counter, error) {
 					return err
 				}
 				if lastFiredText.Valid && lastFiredText.String != "" {
-					t, err := time.Parse(time.RFC3339Nano, lastFiredText.String)
+					t, err := time.Parse(timestampFormat, lastFiredText.String)
 					if err != nil {
-						return fmt.Errorf("parse last_fired_at: %w", err)
+						t, err = time.Parse(time.RFC3339Nano, lastFiredText.String)
+						if err != nil {
+							return fmt.Errorf("parse last_fired_at %q: %w", lastFiredText.String, err)
+						}
 					}
 					c.LastFiredAt = t
 				}

--- a/cli/internal/eventlog/eventlog.go
+++ b/cli/internal/eventlog/eventlog.go
@@ -1,0 +1,195 @@
+// Package eventlog is the v0.30 operational telemetry layer over the
+// SQLite vault. It owns the event_log table (append-only event stream,
+// consumed by mom lens for the activity timeline) and the filter_audit
+// table (per-category counters incremented by the capture filter
+// pipeline). Separate from store — substance vs operations.
+package eventlog
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// EventLog is the operational telemetry surface backed by a vault.
+type EventLog struct {
+	v *vault.Vault
+}
+
+// New returns an EventLog backed by the given vault.
+func New(v *vault.Vault) *EventLog {
+	return &EventLog{v: v}
+}
+
+// Event is the input shape for Log. Zero values are treated as
+// reasonable defaults: empty Timestamp becomes time.Now().UTC(),
+// nil Payload is stored as JSON null.
+type Event struct {
+	EventType string
+	Timestamp time.Time
+	SessionID string
+	Payload   map[string]any
+}
+
+// Filter narrows a Query. Zero values mean "no filter on this
+// dimension". Limit defaults to 100 if zero.
+type Filter struct {
+	EventType string
+	SessionID string
+	Since     time.Time
+	Limit     int
+}
+
+// Row is the output shape from Query. ID is the autoincrement primary
+// key; Timestamp is parsed back from the stored RFC3339Nano string.
+type Row struct {
+	ID        int64
+	EventType string
+	Timestamp time.Time
+	SessionID string
+	Payload   map[string]any
+}
+
+// Counter is the output shape for Counters(). Tracks one row per
+// filter_audit category.
+type Counter struct {
+	Category       string
+	RedactionCount int64
+	LastFiredAt    time.Time
+}
+
+// Log appends an event to event_log. The row's auto-increment ID is
+// not surfaced to the caller — use Query to retrieve persisted events.
+func (e *EventLog) Log(ev Event) error {
+	if ev.EventType == "" {
+		return fmt.Errorf("eventlog.Log: EventType is required")
+	}
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now().UTC().Round(0)
+	}
+	payloadJSON, err := json.Marshal(ev.Payload)
+	if err != nil {
+		return fmt.Errorf("eventlog.Log: marshal payload: %w", err)
+	}
+	return e.v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO event_log (event_type, timestamp, session_id, payload)
+			 VALUES (?, ?, ?, ?)`,
+			ev.EventType,
+			ev.Timestamp.Format(time.RFC3339Nano),
+			ev.SessionID,
+			string(payloadJSON),
+		)
+		return err
+	})
+}
+
+// Query returns event_log rows matching the filter, ordered by
+// timestamp descending (most recent first). Limit defaults to 100.
+func (e *EventLog) Query(f Filter) ([]Row, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	var (
+		sb   strings.Builder
+		args []any
+	)
+	sb.WriteString(`SELECT id, event_type, timestamp, session_id, payload
+		FROM event_log WHERE 1=1`)
+	if f.EventType != "" {
+		sb.WriteString(` AND event_type = ?`)
+		args = append(args, f.EventType)
+	}
+	if f.SessionID != "" {
+		sb.WriteString(` AND session_id = ?`)
+		args = append(args, f.SessionID)
+	}
+	if !f.Since.IsZero() {
+		sb.WriteString(` AND timestamp >= ?`)
+		args = append(args, f.Since.UTC().Format(time.RFC3339Nano))
+	}
+	sb.WriteString(` ORDER BY timestamp DESC, id DESC LIMIT ?`)
+	args = append(args, limit)
+
+	var rows []Row
+	err := e.v.Query(sb.String(), args, func(rs *sql.Rows) error {
+		for rs.Next() {
+			var (
+				r           Row
+				ts, payload string
+			)
+			if err := rs.Scan(&r.ID, &r.EventType, &ts, &r.SessionID, &payload); err != nil {
+				return err
+			}
+			t, err := time.Parse(time.RFC3339Nano, ts)
+			if err != nil {
+				return fmt.Errorf("parse timestamp: %w", err)
+			}
+			r.Timestamp = t
+			if payload != "" && payload != "null" {
+				if err := json.Unmarshal([]byte(payload), &r.Payload); err != nil {
+					return fmt.Errorf("unmarshal payload: %w", err)
+				}
+			}
+			rows = append(rows, r)
+		}
+		return nil
+	})
+	return rows, err
+}
+
+// IncrementCounter atomically creates or increments the filter_audit
+// row for the given category and updates last_fired_at to now.
+func (e *EventLog) IncrementCounter(category string) error {
+	if category == "" {
+		return fmt.Errorf("eventlog.IncrementCounter: category is required")
+	}
+	now := time.Now().UTC().Round(0).Format(time.RFC3339Nano)
+	return e.v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO filter_audit (category, redaction_count, last_fired_at)
+			 VALUES (?, 1, ?)
+			 ON CONFLICT(category) DO UPDATE SET
+			   redaction_count = redaction_count + 1,
+			   last_fired_at = excluded.last_fired_at`,
+			category, now,
+		)
+		return err
+	})
+}
+
+// Counters returns all filter_audit rows ordered by category.
+func (e *EventLog) Counters() ([]Counter, error) {
+	var counters []Counter
+	err := e.v.Query(
+		`SELECT category, redaction_count, last_fired_at
+		 FROM filter_audit ORDER BY category`,
+		nil,
+		func(rs *sql.Rows) error {
+			for rs.Next() {
+				var (
+					c             Counter
+					lastFiredText sql.NullString
+				)
+				if err := rs.Scan(&c.Category, &c.RedactionCount, &lastFiredText); err != nil {
+					return err
+				}
+				if lastFiredText.Valid && lastFiredText.String != "" {
+					t, err := time.Parse(time.RFC3339Nano, lastFiredText.String)
+					if err != nil {
+						return fmt.Errorf("parse last_fired_at: %w", err)
+					}
+					c.LastFiredAt = t
+				}
+				counters = append(counters, c)
+			}
+			return nil
+		},
+	)
+	return counters, err
+}

--- a/cli/internal/eventlog/eventlog_test.go
+++ b/cli/internal/eventlog/eventlog_test.go
@@ -1,0 +1,248 @@
+package eventlog_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/momhq/mom/cli/internal/eventlog"
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// newEventLog opens a fresh Vault in a temp dir and returns an
+// EventLog backed by it.
+func newEventLog(t *testing.T) (*eventlog.EventLog, *vault.Vault) {
+	t.Helper()
+	dir := t.TempDir()
+	v, err := vault.Open(filepath.Join(dir, "mom.db"))
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	return eventlog.New(v), v
+}
+
+// T1 (tracer bullet): Log + Query round-trips an event with all
+// fields populated. Verifies wiring through the event_log table.
+func TestEventLog_LogAndQueryRoundTrip(t *testing.T) {
+	el, _ := newEventLog(t)
+
+	when := time.Date(2026, 5, 4, 12, 30, 0, 0, time.UTC)
+	in := eventlog.Event{
+		EventType: "capture",
+		Timestamp: when,
+		SessionID: "session-1",
+		Payload:   map[string]any{"actor": "claude-code", "trigger_event": "watcher"},
+	}
+	if err := el.Log(in); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	rows, err := el.Query(eventlog.Filter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %v", len(rows), rows)
+	}
+	r := rows[0]
+	if r.EventType != "capture" {
+		t.Errorf("EventType: got %q, want %q", r.EventType, "capture")
+	}
+	if !r.Timestamp.Equal(when) {
+		t.Errorf("Timestamp: got %v, want %v", r.Timestamp, when)
+	}
+	if r.SessionID != "session-1" {
+		t.Errorf("SessionID: got %q, want %q", r.SessionID, "session-1")
+	}
+	if actor, _ := r.Payload["actor"].(string); actor != "claude-code" {
+		t.Errorf("Payload.actor: got %v", r.Payload["actor"])
+	}
+	if r.ID == 0 {
+		t.Errorf("expected non-zero auto-incremented ID")
+	}
+}
+
+// logSimple is a fixture helper for tests that need multiple events.
+func logSimple(t *testing.T, el *eventlog.EventLog, eventType, sessionID string, when time.Time) {
+	t.Helper()
+	if err := el.Log(eventlog.Event{
+		EventType: eventType,
+		SessionID: sessionID,
+		Timestamp: when,
+	}); err != nil {
+		t.Fatalf("Log(%s): %v", eventType, err)
+	}
+}
+
+// T2: Filter.EventType narrows results to events of that type.
+func TestEventLog_Query_FiltersByEventType(t *testing.T) {
+	el, _ := newEventLog(t)
+	now := time.Now().UTC().Round(0)
+	logSimple(t, el, "capture", "s1", now)
+	logSimple(t, el, "recall", "s1", now)
+	logSimple(t, el, "capture", "s1", now.Add(time.Second))
+
+	rows, err := el.Query(eventlog.Filter{EventType: "capture"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 capture events, got %d: %v", len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.EventType != "capture" {
+			t.Errorf("got event_type %q, want capture", r.EventType)
+		}
+	}
+}
+
+// T3: Filter.SessionID narrows results to events from that session.
+func TestEventLog_Query_FiltersBySessionID(t *testing.T) {
+	el, _ := newEventLog(t)
+	now := time.Now().UTC().Round(0)
+	logSimple(t, el, "capture", "s1", now)
+	logSimple(t, el, "capture", "s2", now.Add(time.Second))
+	logSimple(t, el, "capture", "s1", now.Add(2*time.Second))
+
+	rows, err := el.Query(eventlog.Filter{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 events for s1, got %d: %v", len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.SessionID != "s1" {
+			t.Errorf("got session_id %q, want s1", r.SessionID)
+		}
+	}
+}
+
+// T4: Query returns rows ordered by timestamp descending — most
+// recent first. Lens timeline UX expects newest at top.
+func TestEventLog_Query_OrdersByTimestampDesc(t *testing.T) {
+	el, _ := newEventLog(t)
+	base := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	logSimple(t, el, "older", "s1", base)
+	logSimple(t, el, "middle", "s1", base.Add(time.Hour))
+	logSimple(t, el, "newest", "s1", base.Add(2*time.Hour))
+
+	rows, err := el.Query(eventlog.Filter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+	want := []string{"newest", "middle", "older"}
+	for i, w := range want {
+		if rows[i].EventType != w {
+			t.Errorf("position %d: got %q, want %q", i, rows[i].EventType, w)
+		}
+	}
+}
+
+// T5: Filter.Since narrows results to events at or after the cutoff.
+func TestEventLog_Query_FiltersBySince(t *testing.T) {
+	el, _ := newEventLog(t)
+	base := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	logSimple(t, el, "old", "s1", base)
+	logSimple(t, el, "kept-1", "s1", base.Add(time.Hour))
+	logSimple(t, el, "kept-2", "s1", base.Add(2*time.Hour))
+
+	cutoff := base.Add(30 * time.Minute)
+	rows, err := el.Query(eventlog.Filter{Since: cutoff})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 events at or after %v, got %d: %v", cutoff, len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.Timestamp.Before(cutoff) {
+			t.Errorf("got event at %v, before cutoff %v", r.Timestamp, cutoff)
+		}
+	}
+}
+
+// counterByCategory finds a Counter by category for assertion lookups.
+func counterByCategory(counters []eventlog.Counter, cat string) (eventlog.Counter, bool) {
+	for _, c := range counters {
+		if c.Category == cat {
+			return c, true
+		}
+	}
+	return eventlog.Counter{}, false
+}
+
+// T6: IncrementCounter creates a new row on first call (count=1) and
+// increments on subsequent calls. last_fired_at advances to the most
+// recent call.
+func TestEventLog_IncrementCounter_CreatesAndIncrements(t *testing.T) {
+	el, _ := newEventLog(t)
+
+	if err := el.IncrementCounter("aws_secret"); err != nil {
+		t.Fatalf("first IncrementCounter: %v", err)
+	}
+	counters, err := el.Counters()
+	if err != nil {
+		t.Fatalf("Counters: %v", err)
+	}
+	c, ok := counterByCategory(counters, "aws_secret")
+	if !ok {
+		t.Fatalf("expected aws_secret counter to exist after first call")
+	}
+	if c.RedactionCount != 1 {
+		t.Errorf("first call: count got %d, want 1", c.RedactionCount)
+	}
+	firstFired := c.LastFiredAt
+	if firstFired.IsZero() {
+		t.Errorf("expected last_fired_at to be set on first call")
+	}
+
+	// Second + third call increment the same counter.
+	if err := el.IncrementCounter("aws_secret"); err != nil {
+		t.Fatalf("second IncrementCounter: %v", err)
+	}
+	if err := el.IncrementCounter("aws_secret"); err != nil {
+		t.Fatalf("third IncrementCounter: %v", err)
+	}
+	counters, _ = el.Counters()
+	c, _ = counterByCategory(counters, "aws_secret")
+	if c.RedactionCount != 3 {
+		t.Errorf("after three calls: count got %d, want 3", c.RedactionCount)
+	}
+	if !c.LastFiredAt.After(firstFired) && !c.LastFiredAt.Equal(firstFired) {
+		t.Errorf("last_fired_at should be >= first call: got %v vs %v", c.LastFiredAt, firstFired)
+	}
+}
+
+// T7: Counters() returns one row per distinct category.
+func TestEventLog_Counters_ReturnsAllCategories(t *testing.T) {
+	el, _ := newEventLog(t)
+
+	if err := el.IncrementCounter("aws_secret"); err != nil {
+		t.Fatal(err)
+	}
+	if err := el.IncrementCounter("aws_secret"); err != nil {
+		t.Fatal(err)
+	}
+	if err := el.IncrementCounter("github_pat"); err != nil {
+		t.Fatal(err)
+	}
+
+	counters, err := el.Counters()
+	if err != nil {
+		t.Fatalf("Counters: %v", err)
+	}
+	if len(counters) != 2 {
+		t.Fatalf("expected 2 distinct counters, got %d: %v", len(counters), counters)
+	}
+	if c, _ := counterByCategory(counters, "aws_secret"); c.RedactionCount != 2 {
+		t.Errorf("aws_secret count: got %d, want 2", c.RedactionCount)
+	}
+	if c, _ := counterByCategory(counters, "github_pat"); c.RedactionCount != 1 {
+		t.Errorf("github_pat count: got %d, want 1", c.RedactionCount)
+	}
+}

--- a/cli/internal/eventlog/eventlog_test.go
+++ b/cli/internal/eventlog/eventlog_test.go
@@ -246,3 +246,96 @@ func TestEventLog_Counters_ReturnsAllCategories(t *testing.T) {
 		t.Errorf("github_pat count: got %d, want 1", c.RedactionCount)
 	}
 }
+
+// T8: Mixed-precision timestamps sort consistently in DESC order.
+// RFC3339Nano trims trailing zeros, which makes lexical sort
+// incorrect across mixed precisions ("." sorts before "Z" in ASCII).
+// The eventlog format is fixed-width nanoseconds so DESC ordering
+// matches actual chronology regardless of caller-supplied precision.
+func TestEventLog_Query_OrdersConsistentlyAcrossMixedPrecision(t *testing.T) {
+	el, _ := newEventLog(t)
+	base := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+
+	// Caller supplies whole-second timestamp.
+	logSimple(t, el, "whole-second", "s1", base)
+	// Caller supplies sub-second timestamp 500ms later.
+	logSimple(t, el, "half-second-later", "s1", base.Add(500*time.Millisecond))
+	// Caller supplies whole-second timestamp 1s later.
+	logSimple(t, el, "one-second-later", "s1", base.Add(time.Second))
+
+	rows, err := el.Query(eventlog.Filter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+	want := []string{"one-second-later", "half-second-later", "whole-second"}
+	for i, w := range want {
+		if rows[i].EventType != w {
+			t.Errorf("position %d: got %q, want %q", i, rows[i].EventType, w)
+		}
+	}
+}
+
+// T9: Log rejects empty EventType, empty SessionID, and zero
+// timestamp is filled in. Locks the input contract documented on
+// Event.
+func TestEventLog_Log_RejectsMissingRequiredFields(t *testing.T) {
+	el, _ := newEventLog(t)
+
+	if err := el.Log(eventlog.Event{SessionID: "s1"}); err == nil {
+		t.Errorf("expected error for empty EventType")
+	}
+	if err := el.Log(eventlog.Event{EventType: "capture"}); err == nil {
+		t.Errorf("expected error for empty SessionID")
+	}
+}
+
+// T10: IncrementCounter rejects empty category.
+func TestEventLog_IncrementCounter_RejectsEmptyCategory(t *testing.T) {
+	el, _ := newEventLog(t)
+
+	if err := el.IncrementCounter(""); err == nil {
+		t.Errorf("expected error for empty category")
+	}
+}
+
+// T11: nil and empty-map payloads round-trip identically. Both
+// serialise to "null" at write time, both come back as nil from
+// Query. Removes a subtle distinction the caller would otherwise
+// see between "no payload" and "explicitly empty payload".
+func TestEventLog_Log_NormalisesEmptyPayload(t *testing.T) {
+	el, _ := newEventLog(t)
+	base := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+
+	if err := el.Log(eventlog.Event{
+		EventType: "nil-payload",
+		SessionID: "s1",
+		Timestamp: base,
+		Payload:   nil,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := el.Log(eventlog.Event{
+		EventType: "empty-map-payload",
+		SessionID: "s1",
+		Timestamp: base.Add(time.Second),
+		Payload:   map[string]any{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := el.Query(eventlog.Filter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.Payload != nil {
+			t.Errorf("event %q: expected Payload=nil, got %v", r.EventType, r.Payload)
+		}
+	}
+}

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -65,6 +65,13 @@ func nowTimestamp() string {
 // defaults to "untyped"; PromotionState defaults to "draft"; CreatedAt
 // defaults to time.Now().UTC().
 func (s *MemoryStore) Insert(m Memory) (Memory, error) {
+	if m.SessionID == "" {
+		// Every memory has a session_id by design — agent sessions
+		// pass through their UUID; MOM-internal runs (cartographer,
+		// import) supply a synthetic mom-<uuid>. Empty here is a
+		// programming error, never a user input.
+		return Memory{}, fmt.Errorf("MemoryStore.Insert: SessionID is required")
+	}
 	if m.ID == "" {
 		m.ID = uuid.NewString()
 	}

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -80,7 +80,8 @@ func TestMemoryStore_Insert_MintsUUIDv4WhenIDEmpty(t *testing.T) {
 	ms, _, _ := newStore(t)
 
 	inserted, err := ms.Insert(store.Memory{
-		Content: map[string]any{"text": "x"},
+		Content:   map[string]any{"text": "x"},
+		SessionID: "test-session",
 	})
 	if err != nil {
 		t.Fatalf("Insert: %v", err)
@@ -106,7 +107,8 @@ func TestMemoryStore_Insert_AppliesDefaults(t *testing.T) {
 
 	before := time.Now().UTC()
 	inserted, err := ms.Insert(store.Memory{
-		Content: map[string]any{"text": "x"},
+		Content:   map[string]any{"text": "x"},
+		SessionID: "test-session",
 	})
 	after := time.Now().UTC()
 	if err != nil {
@@ -132,6 +134,21 @@ func TestMemoryStore_Insert_AppliesDefaults(t *testing.T) {
 	}
 	if got.PromotionState != "draft" {
 		t.Errorf("PromotionState after Get: got %q, want %q", got.PromotionState, "draft")
+	}
+}
+
+// T8b: Insert rejects empty SessionID. Every memory must be
+// attributable to a session by design — agent UUID for live
+// sessions, mom-<uuid> for MOM-internal runs (cartographer, import).
+// Empty here is a programming error, not a user input.
+func TestMemoryStore_Insert_RejectsEmptySessionID(t *testing.T) {
+	ms, _, _ := newStore(t)
+
+	_, err := ms.Insert(store.Memory{
+		Content: map[string]any{"text": "x"},
+	})
+	if err == nil {
+		t.Errorf("expected Insert to reject empty SessionID")
 	}
 }
 
@@ -314,7 +331,7 @@ func TestGraphStore_UpsertTag_Idempotent(t *testing.T) {
 func TestGraphStore_LinkTag_MemoriesByTag(t *testing.T) {
 	ms, gs, _ := newStore(t)
 
-	m, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}})
+	m, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}, SessionID: "test-session"})
 	if err != nil {
 		t.Fatalf("Insert: %v", err)
 	}
@@ -370,7 +387,7 @@ func TestGraphStore_UpsertEntity_LinkEntity(t *testing.T) {
 		t.Errorf("different display_name should produce different entity ID")
 	}
 
-	m, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}})
+	m, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}, SessionID: "test-session"})
 	if err != nil {
 		t.Fatalf("Insert memory: %v", err)
 	}
@@ -463,7 +480,7 @@ func TestGraphStore_MergeTags(t *testing.T) {
 
 	fixture := insertedFixture(t, ms)
 
-	m2, err := ms.Insert(store.Memory{Content: map[string]any{"text": "y"}})
+	m2, err := ms.Insert(store.Memory{Content: map[string]any{"text": "y"}, SessionID: "test-session"})
 	if err != nil {
 		t.Fatalf("Insert m2: %v", err)
 	}
@@ -616,7 +633,7 @@ func TestNormalizeTagName(t *testing.T) {
 func TestMemoryStore_Insert_CreatedAtIsByteIdenticalToGet(t *testing.T) {
 	ms, _, _ := newStore(t)
 
-	inserted, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}})
+	inserted, err := ms.Insert(store.Memory{Content: map[string]any{"text": "x"}, SessionID: "test-session"})
 	if err != nil {
 		t.Fatalf("Insert: %v", err)
 	}

--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -63,7 +63,7 @@ var migrations = []migration{
 			summary                  TEXT,
 			content                  TEXT NOT NULL CHECK (json_valid(content)),
 			created_at               TEXT NOT NULL,
-			session_id               TEXT,
+			session_id               TEXT NOT NULL,
 			provenance_actor         TEXT,
 			provenance_source_type   TEXT,
 			provenance_trigger_event TEXT,
@@ -104,7 +104,7 @@ var migrations = []migration{
 			id         INTEGER PRIMARY KEY AUTOINCREMENT,
 			event_type TEXT NOT NULL,
 			timestamp  TEXT NOT NULL,
-			session_id TEXT,
+			session_id TEXT NOT NULL,
 			payload    TEXT
 		)`,
 		`CREATE TABLE IF NOT EXISTS filter_audit (

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -136,9 +136,9 @@ func insertSimpleMemory(t *testing.T, v *Vault, id, summary, contentText string)
 	}
 	err = v.Tx(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
-			`INSERT INTO memories (id, type, summary, content, created_at)
-			 VALUES (?, 'untyped', ?, ?, ?)`,
-			id, summary, string(contentJSON), "2026-05-03T12:00:00Z",
+			`INSERT INTO memories (id, type, summary, content, created_at, session_id)
+			 VALUES (?, 'untyped', ?, ?, ?, ?)`,
+			id, summary, string(contentJSON), "2026-05-03T12:00:00Z", "test-session",
 		)
 		return err
 	})
@@ -216,9 +216,9 @@ func TestTx_RollsBackOnError(t *testing.T) {
 
 	err := v.Tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(
-			`INSERT INTO memories (id, type, content, created_at)
-			 VALUES (?, 'untyped', ?, ?)`,
-			"rollback1", contentJSON, "2026-05-03T12:00:00Z",
+			`INSERT INTO memories (id, type, content, created_at, session_id)
+			 VALUES (?, 'untyped', ?, ?, ?)`,
+			"rollback1", contentJSON, "2026-05-03T12:00:00Z", "test-session",
 		); err != nil {
 			return err
 		}
@@ -244,10 +244,10 @@ func TestProvenance_OpenVocabulary(t *testing.T) {
 	err := v.Tx(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
 			`INSERT INTO memories (
-				id, type, content, created_at,
+				id, type, content, created_at, session_id,
 				provenance_actor, provenance_source_type, provenance_trigger_event
-			) VALUES (?, 'untyped', ?, ?, ?, ?, ?)`,
-			"novel1", `{"text":"x"}`, "2026-05-03T12:00:00Z",
+			) VALUES (?, 'untyped', ?, ?, ?, ?, ?, ?)`,
+			"novel1", `{"text":"x"}`, "2026-05-03T12:00:00Z", "test-session",
 			"future-harness-2027", "novel-source-type", "novel-trigger",
 		)
 		return err
@@ -265,9 +265,9 @@ func TestMemory_DefaultsToUntyped(t *testing.T) {
 
 	err := v.Tx(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
-			`INSERT INTO memories (id, content, created_at)
-			 VALUES (?, ?, ?)`,
-			"default1", `{"text":"x"}`, "2026-05-03T12:00:00Z",
+			`INSERT INTO memories (id, content, created_at, session_id)
+			 VALUES (?, ?, ?, ?)`,
+			"default1", `{"text":"x"}`, "2026-05-03T12:00:00Z", "test-session",
 		)
 		return err
 	})
@@ -340,6 +340,41 @@ func TestMigrate_RollsBackOnPartialFailure(t *testing.T) {
 	}
 }
 
+// T18: memories.session_id and event_log.session_id are NOT NULL at
+// the schema layer. Every memory and every event must carry a
+// session_id by design — agent UUID for live sessions, mom-<uuid>
+// for MOM-internal runs. Defense-in-depth alongside the API-layer
+// validation in MemoryStore.Insert and EventLog.Log.
+func TestSchema_SessionIDIsNotNull(t *testing.T) {
+	v, _ := newVault(t)
+
+	// memories.session_id NOT NULL
+	err := v.Tx(func(tx *sql.Tx) error {
+		_, e := tx.Exec(
+			`INSERT INTO memories (id, content, created_at)
+			 VALUES (?, ?, ?)`,
+			"no-session-mem", `{"text":"x"}`, "2026-05-04T00:00:00Z",
+		)
+		return e
+	})
+	if err == nil {
+		t.Errorf("expected NOT NULL violation on memories.session_id")
+	}
+
+	// event_log.session_id NOT NULL
+	err = v.Tx(func(tx *sql.Tx) error {
+		_, e := tx.Exec(
+			`INSERT INTO event_log (event_type, timestamp)
+			 VALUES (?, ?)`,
+			"capture", "2026-05-04T00:00:00Z",
+		)
+		return e
+	})
+	if err == nil {
+		t.Errorf("expected NOT NULL violation on event_log.session_id")
+	}
+}
+
 // T17: entities enforces UNIQUE(type, display_name). Two rows with the
 // same type and same display_name cannot coexist — the database
 // guarantees the contract that GraphStore.UpsertEntity assumes.
@@ -381,9 +416,9 @@ func TestMemory_RejectsNonJSONContent(t *testing.T) {
 
 	err := v.Tx(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
-			`INSERT INTO memories (id, type, content, created_at)
-			 VALUES (?, 'untyped', ?, ?)`,
-			"bad-json-1", "this is not valid json", "2026-05-03T12:00:00Z",
+			`INSERT INTO memories (id, type, content, created_at, session_id)
+			 VALUES (?, 'untyped', ?, ?, ?)`,
+			"bad-json-1", "this is not valid json", "2026-05-03T12:00:00Z", "test-session",
 		)
 		return err
 	})
@@ -505,9 +540,9 @@ func TestSmoke_RoundTripMemoryWithTagAndEntity(t *testing.T) {
 
 	err := v.Tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(
-			`INSERT INTO memories (id, type, summary, content, created_at)
-			 VALUES (?, 'untyped', ?, ?, ?)`,
-			memID, "smoke summary", `{"text":"smoke body"}`, ts,
+			`INSERT INTO memories (id, type, summary, content, created_at, session_id)
+			 VALUES (?, 'untyped', ?, ?, ?, ?)`,
+			memID, "smoke summary", `{"text":"smoke body"}`, ts, "smoke-session",
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- New \`cli/internal/eventlog/\` package owning event_log + filter_audit
- \`Log\`, \`Query\` (filter by event_type / session_id / since, ordered by timestamp desc, limit defaults 100)
- \`IncrementCounter\` (UPSERT via ON CONFLICT DO UPDATE — atomic create-or-increment), \`Counters\` (read all)
- Separate from store: substance vs operations
- 7 tests cover round-trip, every filter dimension, ordering, counter create-and-increment, multi-category Counters listing

## Closes

Closes #236

## References

- PRD: https://github.com/momhq/mom/blob/main/prd/0003-v0-30.md
- ADRs: [0009](https://github.com/momhq/mom/blob/main/adr/0009-storage-consolidation-home-canonical.md), [0014](https://github.com/momhq/mom/blob/main/adr/0014-capture-filtering-privacy-quality.md)

## Out of scope

- mom_recall's legacy herald.New telemetry — cleanup in #245
- Capture filter pipeline calling IncrementCounter — lands in #244
- Lens dashboard reading Counters — lands in #248

## Test plan

- [x] \`go test ./internal/eventlog/...\` — 7/7 pass
- [x] \`go test ./...\` — full project still green
- [x] All Filter dimensions tested independently
- [x] IncrementCounter idempotent under repeat calls (atomic UPSERT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)