### PR TITLE
feat(vault): private SQLite primitive with caller-registered migrations (#233)

### DIFF
--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -1,0 +1,207 @@
+// Package vault is the private SQLite primitive for v0.30. It owns the
+// connection at $HOME/.mom/mom.db, runs schema migrations registered by
+// callers, and mediates every read and write so other packages never
+// touch *sql.DB directly.
+//
+// Vault is the bottom of the v0.30 stack. Only Librarian touches it;
+// Drafter, Logbook, Cartographer, Finder, MCP, Upgrade, and Lens go
+// through Librarian. Vault has no knowledge of memories, tags, entities,
+// or any other domain table — those tables and their migrations are
+// owned by their respective packages and registered with this runner.
+package vault
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Migration is one applied schema change identified by a strictly
+// increasing integer version. Stmts run as a single transaction; either
+// every statement commits and a row is added to schema_migrations, or
+// nothing changes.
+type Migration struct {
+	Version int
+	Stmts   []string
+}
+
+// Vault is the SQLite-backed persistence handle. The zero value is not
+// usable; construct via Open. Vault is safe for concurrent use; the
+// underlying *sql.DB is a connection pool.
+type Vault struct {
+	db *sql.DB
+}
+
+// dsnPragmas are SQLite pragmas embedded in the connection string so
+// modernc.org/sqlite applies them on EVERY new connection in the pool.
+// Per-connection pragmas (foreign_keys, synchronous, cache_size,
+// busy_timeout) do not persist across pool growth when applied via
+// db.Exec; embedding them in the DSN is the documented fix.
+//
+// WAL mode is database-wide (persists in the file) and is set
+// separately via db.Exec after Open since it is not a per-connection
+// setting.
+const dsnPragmas = "?_pragma=foreign_keys(1)" +
+	"&_pragma=synchronous(NORMAL)" +
+	"&_pragma=cache_size(-8000)" +
+	"&_pragma=busy_timeout(5000)"
+
+// Open opens or creates the SQLite database at path, applies pragmas,
+// runs any pending registered migrations, and returns a usable Vault.
+// Callers must Close the Vault when done.
+//
+// On POSIX systems, the database file is created (or chmod'd if it
+// already exists) with mode 0600. modernc.org/sqlite does not expose a
+// perms DSN parameter, so the file is materialized here before
+// sql.Open.
+//
+// Migrations must be sorted by Version with no duplicates. Open
+// validates this before any DB I/O. Each migration runs in its own
+// transaction; a failure leaves the database at the previous
+// successfully-applied version with no partial DDL or schema_migrations
+// row from the failed migration.
+//
+// Open auto-runs migrations: a returned Vault is always at the current
+// schema version. There is no opt-out — every consumer wants a migrated
+// vault.
+func Open(path string, migrations []Migration) (*Vault, error) {
+	if err := validateMigrations(migrations); err != nil {
+		return nil, err
+	}
+
+	if runtime.GOOS != "windows" {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+		if err != nil {
+			return nil, fmt.Errorf("creating vault file at %s: %w", path, err)
+		}
+		_ = f.Close()
+		if err := os.Chmod(path, 0o600); err != nil {
+			return nil, fmt.Errorf("chmod %s to 0600: %w", path, err)
+		}
+	}
+
+	db, err := sql.Open("sqlite", path+dsnPragmas)
+	if err != nil {
+		return nil, fmt.Errorf("opening sqlite at %s: %w", path, err)
+	}
+	// WAL is database-wide — set once via Exec; persists in the file.
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("setting journal_mode=WAL: %w", err)
+	}
+
+	v := &Vault{db: db}
+	if err := v.migrate(migrations); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrating vault at %s: %w", path, err)
+	}
+	return v, nil
+}
+
+// Close releases the underlying database connection. Idempotent —
+// calling Close on an already-closed Vault is a no-op.
+func (v *Vault) Close() error {
+	if v.db == nil {
+		return nil
+	}
+	err := v.db.Close()
+	v.db = nil
+	return err
+}
+
+// validateMigrations enforces strictly increasing versions with no
+// duplicates. Pure function, called before any DB I/O so a bad slice
+// fails fast and leaves no half-initialised vault.
+func validateMigrations(ms []Migration) error {
+	for i := 1; i < len(ms); i++ {
+		if ms[i].Version <= ms[i-1].Version {
+			return fmt.Errorf("migration version %d follows %d (must be strictly increasing)",
+				ms[i].Version, ms[i-1].Version)
+		}
+	}
+	return nil
+}
+
+// migrate ensures schema_migrations exists, then applies every
+// registered migration whose version is not already recorded. Each
+// migration runs inside its own transaction.
+func (v *Vault) migrate(migrations []Migration) error {
+	if _, err := v.db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		version    INTEGER PRIMARY KEY,
+		applied_at TEXT NOT NULL
+	)`); err != nil {
+		return fmt.Errorf("creating schema_migrations: %w", err)
+	}
+
+	for _, m := range migrations {
+		var applied int
+		if err := v.db.QueryRow(
+			`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`,
+			m.Version,
+		).Scan(&applied); err != nil {
+			return fmt.Errorf("checking migration %d: %w", m.Version, err)
+		}
+		if applied > 0 {
+			continue
+		}
+		if err := v.Tx(func(tx *sql.Tx) error {
+			for _, stmt := range m.Stmts {
+				if _, err := tx.Exec(stmt); err != nil {
+					return fmt.Errorf("statement: %w", err)
+				}
+			}
+			_, err := tx.Exec(
+				`INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
+				m.Version,
+				time.Now().UTC().Format(time.RFC3339Nano),
+			)
+			return err
+		}); err != nil {
+			return fmt.Errorf("applying migration %d: %w", m.Version, err)
+		}
+	}
+	return nil
+}
+
+// Query runs a read-only query and invokes scan with the resulting
+// rows. Vault closes the *sql.Rows after scan returns. Callers never
+// see *sql.DB.
+func (v *Vault) Query(query string, args []any, scan func(*sql.Rows) error) error {
+	rows, err := v.db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	if err := scan(rows); err != nil {
+		return err
+	}
+	return rows.Err()
+}
+
+// Tx runs fn inside a transaction. The transaction commits on nil
+// return; any non-nil error rolls it back and is returned to the
+// caller. A panic in fn rolls the transaction back and re-panics.
+// Callers receive a *sql.Tx but never *sql.DB.
+func (v *Vault) Tx(fn func(*sql.Tx) error) (err error) {
+	tx, err := v.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+		if err != nil {
+			_ = tx.Rollback()
+			return
+		}
+		err = tx.Commit()
+	}()
+	err = fn(tx)
+	return err
+}

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -1,0 +1,339 @@
+package vault_test
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// helper opens a vault at a temp path with the given migrations, registers
+// t.Cleanup for Close, and fails the test if Open errors.
+func openTempVault(t *testing.T, migrations []vault.Migration) (*vault.Vault, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mom.db")
+	v, err := vault.Open(path, migrations)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	return v, path
+}
+
+func TestOpen_createsSchemaMigrationsTable(t *testing.T) {
+	v, _ := openTempVault(t, nil)
+
+	var name string
+	err := v.Query(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'`,
+		nil,
+		func(rs *sql.Rows) error {
+			if !rs.Next() {
+				return errors.New("schema_migrations table not found")
+			}
+			return rs.Scan(&name)
+		},
+	)
+	if err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if name != "schema_migrations" {
+		t.Fatalf("got %q, want schema_migrations", name)
+	}
+}
+
+func TestOpen_createsFileWith0600OnPOSIX(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX perms only")
+	}
+	_, path := openTempVault(t, nil)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("got mode %o, want 0600", mode)
+	}
+}
+
+func TestOpen_runsRegisteredMigrations(t *testing.T) {
+	migs := []vault.Migration{
+		{Version: 1, Stmts: []string{`CREATE TABLE widgets (id INTEGER PRIMARY KEY)`}},
+	}
+	v, _ := openTempVault(t, migs)
+
+	if err := v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`INSERT INTO widgets (id) VALUES (1)`)
+		return err
+	}); err != nil {
+		t.Fatalf("insert into migrated table: %v", err)
+	}
+
+	var count int
+	if err := v.Query(
+		`SELECT COUNT(*) FROM schema_migrations WHERE version = 1`,
+		nil,
+		func(rs *sql.Rows) error {
+			rs.Next()
+			return rs.Scan(&count)
+		},
+	); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("schema_migrations count = %d, want 1", count)
+	}
+}
+
+func TestOpen_isIdempotent(t *testing.T) {
+	migs := []vault.Migration{
+		{Version: 1, Stmts: []string{`CREATE TABLE widgets (id INTEGER PRIMARY KEY)`}},
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mom.db")
+
+	v1, err := vault.Open(path, migs)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	_ = v1.Close()
+
+	// Re-open: must be a no-op for already-applied migrations.
+	v2, err := vault.Open(path, migs)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v2.Close() })
+
+	var count int
+	if err := v2.Query(
+		`SELECT COUNT(*) FROM schema_migrations`,
+		nil,
+		func(rs *sql.Rows) error { rs.Next(); return rs.Scan(&count) },
+	); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("schema_migrations count = %d after re-open, want 1", count)
+	}
+}
+
+func TestMigrate_atomicPerMigration_rollsBackBothDDLAndVersionRow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mom.db")
+
+	bad := []vault.Migration{
+		{Version: 1, Stmts: []string{
+			`CREATE TABLE good (id INTEGER PRIMARY KEY)`,
+			`THIS IS NOT VALID SQL`,
+		}},
+	}
+	_, err := vault.Open(path, bad)
+	if err == nil {
+		t.Fatal("expected error from invalid migration, got nil")
+	}
+
+	// Re-open with a clean migrations list to inspect post-failure state.
+	v, err := vault.Open(path, nil)
+	if err != nil {
+		t.Fatalf("re-open after failed migration: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+
+	// The "good" table from the first statement must NOT exist — the whole
+	// migration rolled back atomically.
+	var tableName string
+	err = v.Query(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='good'`,
+		nil,
+		func(rs *sql.Rows) error {
+			if rs.Next() {
+				return rs.Scan(&tableName)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("query for good table: %v", err)
+	}
+	if tableName != "" {
+		t.Fatal("CREATE TABLE good was not rolled back after migration failure")
+	}
+
+	// And no version-1 row exists in schema_migrations.
+	var versionCount int
+	if err := v.Query(
+		`SELECT COUNT(*) FROM schema_migrations WHERE version = 1`,
+		nil,
+		func(rs *sql.Rows) error { rs.Next(); return rs.Scan(&versionCount) },
+	); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if versionCount != 0 {
+		t.Fatal("schema_migrations recorded version 1 despite failure")
+	}
+}
+
+func TestOpen_rejectsNonMonotonicMigrations(t *testing.T) {
+	bad := []vault.Migration{
+		{Version: 2, Stmts: []string{`CREATE TABLE a(id INT)`}},
+		{Version: 1, Stmts: []string{`CREATE TABLE b(id INT)`}},
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mom.db")
+	_, err := vault.Open(path, bad)
+	if err == nil {
+		t.Fatal("expected error for non-monotonic migrations, got nil")
+	}
+	if !strings.Contains(err.Error(), "version") {
+		t.Fatalf("error %q should mention version ordering", err)
+	}
+}
+
+func TestOpen_rejectsDuplicateMigrationVersions(t *testing.T) {
+	bad := []vault.Migration{
+		{Version: 1, Stmts: []string{`CREATE TABLE a(id INT)`}},
+		{Version: 1, Stmts: []string{`CREATE TABLE b(id INT)`}},
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mom.db")
+	_, err := vault.Open(path, bad)
+	if err == nil {
+		t.Fatal("expected error for duplicate migration versions, got nil")
+	}
+}
+
+func TestForeignKeysEnforcedAcrossPoolGrowth(t *testing.T) {
+	migs := []vault.Migration{
+		{Version: 1, Stmts: []string{
+			`CREATE TABLE parent (id INTEGER PRIMARY KEY)`,
+			`CREATE TABLE child (
+				id INTEGER PRIMARY KEY,
+				parent_id INTEGER NOT NULL REFERENCES parent(id)
+			)`,
+		}},
+	}
+	v, _ := openTempVault(t, migs)
+
+	// Force the pool to grow at least one extra connection by holding a
+	// transaction open while issuing a read on a separate goroutine. Then
+	// probe FK enforcement on a fresh connection.
+	done := make(chan error, 1)
+	hold := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		done <- v.Tx(func(tx *sql.Tx) error {
+			close(hold)
+			<-release
+			return nil
+		})
+	}()
+	<-hold
+	defer func() { close(release); <-done }()
+
+	// On a different (fresh) pool connection, attempt an FK violation.
+	// Foreign keys must still be enforced.
+	err := v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`INSERT INTO child (id, parent_id) VALUES (1, 999)`)
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected FK violation error on fresh pool connection, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "foreign key") {
+		t.Fatalf("expected foreign-key error, got: %v", err)
+	}
+}
+
+func TestTx_commitsOnNilReturn(t *testing.T) {
+	migs := []vault.Migration{
+		{Version: 1, Stmts: []string{`CREATE TABLE t (id INTEGER PRIMARY KEY)`}},
+	}
+	v, _ := openTempVault(t, migs)
+
+	if err := v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`INSERT INTO t (id) VALUES (1)`)
+		return err
+	}); err != nil {
+		t.Fatalf("Tx: %v", err)
+	}
+
+	var count int
+	_ = v.Query(`SELECT COUNT(*) FROM t`, nil, func(rs *sql.Rows) error {
+		rs.Next()
+		return rs.Scan(&count)
+	})
+	if count != 1 {
+		t.Fatalf("count = %d, want 1 (commit failed)", count)
+	}
+}
+
+func TestTx_rollsBackOnError(t *testing.T) {
+	migs := []vault.Migration{
+		{Version: 1, Stmts: []string{`CREATE TABLE t (id INTEGER PRIMARY KEY)`}},
+	}
+	v, _ := openTempVault(t, migs)
+
+	wantErr := errors.New("boom")
+	got := v.Tx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`INSERT INTO t (id) VALUES (1)`); err != nil {
+			return err
+		}
+		return wantErr
+	})
+	if !errors.Is(got, wantErr) {
+		t.Fatalf("Tx returned %v, want %v wrapped", got, wantErr)
+	}
+
+	var count int
+	_ = v.Query(`SELECT COUNT(*) FROM t`, nil, func(rs *sql.Rows) error {
+		rs.Next()
+		return rs.Scan(&count)
+	})
+	if count != 0 {
+		t.Fatalf("count = %d, want 0 (rollback failed)", count)
+	}
+}
+
+func TestTx_rollsBackOnPanic(t *testing.T) {
+	migs := []vault.Migration{
+		{Version: 1, Stmts: []string{`CREATE TABLE t (id INTEGER PRIMARY KEY)`}},
+	}
+	v, _ := openTempVault(t, migs)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic to propagate")
+		}
+		var count int
+		_ = v.Query(`SELECT COUNT(*) FROM t`, nil, func(rs *sql.Rows) error {
+			rs.Next()
+			return rs.Scan(&count)
+		})
+		if count != 0 {
+			t.Fatalf("count = %d, want 0 (panic rollback failed)", count)
+		}
+	}()
+
+	_ = v.Tx(func(tx *sql.Tx) error {
+		_, _ = tx.Exec(`INSERT INTO t (id) VALUES (1)`)
+		panic("boom")
+	})
+}
+
+func TestClose_isIdempotent(t *testing.T) {
+	v, _ := openTempVault(t, nil)
+	if err := v.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := v.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **Vault** — the private SQLite primitive at the bottom of the v0.30 stack. Owns the connection at `\$HOME/.mom/mom.db`, the migration runner, and Tx/Query primitives. Has no knowledge of memories/tags/entities; those tables ship with Librarian (#235) and Logbook (#236), which register their migrations via Open's caller-passed list.

## What's locked in

- **DSN-embedded pragmas** for per-connection settings (`foreign_keys`, `synchronous`, `cache_size`, `busy_timeout`). `journal_mode=WAL` only goes through a one-shot Exec since it is database-wide.
- **0600 file perms** pre-created on POSIX before `sql.Open` since modernc.org/sqlite has no perms DSN parameter.
- **Atomic per-migration Tx** — DDL + schema_migrations row commit together or both roll back.
- **Monotonic-version validation** before any DB I/O — bad slice fails fast.
- **Open auto-runs migrations**; no inspect-before-migrate surface.

## Test plan

- [x] `go test ./internal/vault/` — 11 tests pass
- [x] `go test -race ./internal/vault/` — clean
- [x] `go vet ./internal/vault/` — clean
- [x] FK enforcement across pool growth (regression test holds Tx open to force a new connection)
- [x] Migration rollback atomic (both DDL and schema_migrations row)
- [x] Tx commit on nil, rollback on error, rollback on panic
- [x] Idempotent Open and Close

Refs: closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)