### PR TITLE
feat(logbook): operational event stream worker — Herald subscriber + ops table (#236)

### DIFF
--- a/cli/internal/librarian/migrations.go
+++ b/cli/internal/librarian/migrations.go
@@ -2,6 +2,12 @@ package librarian
 
 import "github.com/momhq/mom/cli/internal/vault"
 
+// Migration is a re-export of vault.Migration so other v0.30 packages
+// (Logbook, future Cartographer state) can register their schema
+// changes through Librarian without importing Vault directly. Only
+// Librarian touches Vault — this alias keeps the rule auditable.
+type Migration = vault.Migration
+
 // Migrations returns the schema migrations Librarian owns. Callers pass
 // these to vault.Open so the runner applies them at version boundaries.
 //

--- a/cli/internal/librarian/op_events.go
+++ b/cli/internal/librarian/op_events.go
@@ -1,0 +1,151 @@
+package librarian
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// OpEvent is one row in Logbook's operational stream. It is the
+// substance for `mom lens` activity timelines and the "what MOM did"
+// audit surface.
+//
+// CreatedAt is stored using the fixed-width nanosecond format Librarian
+// uses for every owned timestamp; reads tolerate RFC3339Nano for
+// forward-compat with legacy import paths.
+type OpEvent struct {
+	ID        int64
+	EventType string
+	SessionID string
+	CreatedAt time.Time
+	Payload   map[string]any
+}
+
+// OpEventFilter narrows a QueryOpEvents call. Zero values mean "no
+// filter on that dimension". Limit defaults to 100 if zero. Until is
+// exclusive; Since is inclusive.
+type OpEventFilter struct {
+	EventType string
+	SessionID string
+	Since     time.Time
+	Until     time.Time
+	Limit     int
+}
+
+// InsertOpEvent appends a row to the operational stream. EventType and
+// SessionID are required end-to-end (NOT NULL at the schema, rejected
+// at the API). Synthetic session IDs (`mom-<uuid>`) are valid for
+// MOM-internal runs (cartographer, import); empty is always a
+// programming error.
+//
+// Payload normalisation: nil and empty map both serialise to JSON
+// "null". On read, json.Unmarshal of "null" into a map sets the target
+// to nil, so round-trip is symmetrical and no special-case guard is
+// required.
+func (l *Librarian) InsertOpEvent(e OpEvent) (int64, error) {
+	if strings.TrimSpace(e.EventType) == "" {
+		return 0, fmt.Errorf("InsertOpEvent: event_type: %w", ErrEmptyArg)
+	}
+	if strings.TrimSpace(e.SessionID) == "" {
+		return 0, fmt.Errorf("InsertOpEvent: session_id: %w", ErrEmptyArg)
+	}
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = l.now()
+	}
+	// nil and empty map both serialize to "null".
+	var payload map[string]any
+	if len(e.Payload) > 0 {
+		payload = e.Payload
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return 0, fmt.Errorf("InsertOpEvent marshal: %w", err)
+	}
+
+	var id int64
+	err = l.v.Tx(func(tx *sql.Tx) error {
+		res, execErr := tx.Exec(
+			`INSERT INTO op_events (event_type, session_id, created_at, payload)
+			 VALUES (?, ?, ?, ?)`,
+			e.EventType,
+			e.SessionID,
+			formatTime(e.CreatedAt),
+			string(payloadJSON),
+		)
+		if execErr != nil {
+			return execErr
+		}
+		id, execErr = res.LastInsertId()
+		return execErr
+	})
+	if err != nil {
+		return 0, fmt.Errorf("InsertOpEvent: %w", err)
+	}
+	return id, nil
+}
+
+// QueryOpEvents returns rows matching the filter, ordered by created_at
+// descending (most recent first), then id descending as a tiebreaker.
+// Limit defaults to 100.
+func (l *Librarian) QueryOpEvents(f OpEventFilter) ([]OpEvent, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	var (
+		sb   strings.Builder
+		args []any
+	)
+	sb.WriteString(`SELECT id, event_type, session_id, created_at, payload
+		FROM op_events WHERE 1=1`)
+	if f.EventType != "" {
+		sb.WriteString(` AND event_type = ?`)
+		args = append(args, f.EventType)
+	}
+	if f.SessionID != "" {
+		sb.WriteString(` AND session_id = ?`)
+		args = append(args, f.SessionID)
+	}
+	if !f.Since.IsZero() {
+		sb.WriteString(` AND created_at >= ?`)
+		args = append(args, formatTime(f.Since))
+	}
+	if !f.Until.IsZero() {
+		sb.WriteString(` AND created_at < ?`)
+		args = append(args, formatTime(f.Until))
+	}
+	sb.WriteString(` ORDER BY created_at DESC, id DESC LIMIT ?`)
+	args = append(args, limit)
+
+	out := []OpEvent{}
+	err := l.v.Query(sb.String(), args, func(rs *sql.Rows) error {
+		for rs.Next() {
+			var (
+				e            OpEvent
+				createdAtStr string
+				payloadStr   sql.NullString
+			)
+			if err := rs.Scan(&e.ID, &e.EventType, &e.SessionID, &createdAtStr, &payloadStr); err != nil {
+				return err
+			}
+			t, err := parseTime(createdAtStr)
+			if err != nil {
+				return fmt.Errorf("parse created_at %q: %w", createdAtStr, err)
+			}
+			e.CreatedAt = t
+			if payloadStr.Valid && payloadStr.String != "" {
+				if err := json.Unmarshal([]byte(payloadStr.String), &e.Payload); err != nil {
+					return fmt.Errorf("unmarshal payload: %w", err)
+				}
+			}
+			out = append(out, e)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("QueryOpEvents: %w", err)
+	}
+	return out, nil
+}

--- a/cli/internal/logbook/migrations_v030.go
+++ b/cli/internal/logbook/migrations_v030.go
@@ -1,0 +1,31 @@
+package logbook
+
+import "github.com/momhq/mom/cli/internal/librarian"
+
+// Migrations returns the schema migrations Logbook owns. Callers
+// concatenate these with Librarian's migrations and pass the combined
+// list to vault.Open. The list is exposed via librarian.Migration to
+// keep "only Librarian imports vault" auditable.
+//
+// Migration 3 creates the operational stream table. There is NO
+// separate `event_log` table; this is the single source of truth for
+// "what MOM did" and what `mom lens` reads.
+func Migrations() []librarian.Migration {
+	return []librarian.Migration{
+		{
+			Version: 3,
+			Stmts: []string{
+				`CREATE TABLE op_events (
+					id          INTEGER PRIMARY KEY AUTOINCREMENT,
+					event_type  TEXT NOT NULL,
+					session_id  TEXT NOT NULL,
+					created_at  TEXT NOT NULL,
+					payload     TEXT
+				)`,
+				`CREATE INDEX idx_op_events_type    ON op_events(event_type)`,
+				`CREATE INDEX idx_op_events_session ON op_events(session_id)`,
+				`CREATE INDEX idx_op_events_created ON op_events(created_at)`,
+			},
+		},
+	}
+}

--- a/cli/internal/logbook/op_events_test.go
+++ b/cli/internal/logbook/op_events_test.go
@@ -1,0 +1,237 @@
+package logbook_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/momhq/mom/cli/internal/logbook"
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// openLibWithLogbook opens a vault with both Librarian's and Logbook's
+// migrations applied. Used by tests that exercise the op_events table.
+func openLibWithLogbook(t *testing.T) *librarian.Librarian {
+	t.Helper()
+	dir := t.TempDir()
+	migrations := append(librarian.Migrations(), logbook.Migrations()...)
+	v, err := vault.Open(filepath.Join(dir, "mom.db"), migrations)
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	return librarian.New(v)
+}
+
+func TestInsertOpEvent_RoundTrip(t *testing.T) {
+	l := openLibWithLogbook(t)
+	id, err := l.InsertOpEvent(librarian.OpEvent{
+		EventType: "op.recall.queried",
+		SessionID: "s-test-1",
+		Payload:   map[string]any{"query": "deploy", "max_results": 10},
+	})
+	if err != nil {
+		t.Fatalf("InsertOpEvent: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("InsertOpEvent returned id %d, want > 0", id)
+	}
+
+	rows, err := l.QueryOpEvents(librarian.OpEventFilter{})
+	if err != nil {
+		t.Fatalf("QueryOpEvents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ID != id {
+		t.Errorf("ID = %d, want %d", got.ID, id)
+	}
+	if got.EventType != "op.recall.queried" {
+		t.Errorf("EventType = %q", got.EventType)
+	}
+	if got.SessionID != "s-test-1" {
+		t.Errorf("SessionID = %q", got.SessionID)
+	}
+	if got.Payload["query"] != "deploy" {
+		t.Errorf("payload.query = %v", got.Payload["query"])
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("CreatedAt should default to now, got zero")
+	}
+}
+
+func TestInsertOpEvent_RejectsEmptyEventType(t *testing.T) {
+	l := openLibWithLogbook(t)
+	_, err := l.InsertOpEvent(librarian.OpEvent{SessionID: "s"})
+	if !errors.Is(err, librarian.ErrEmptyArg) {
+		t.Fatalf("err = %v, want ErrEmptyArg", err)
+	}
+}
+
+func TestInsertOpEvent_RejectsEmptySessionID(t *testing.T) {
+	l := openLibWithLogbook(t)
+	_, err := l.InsertOpEvent(librarian.OpEvent{EventType: "op.x"})
+	if !errors.Is(err, librarian.ErrEmptyArg) {
+		t.Fatalf("err = %v, want ErrEmptyArg", err)
+	}
+}
+
+func TestInsertOpEvent_NilAndEmptyPayload_RoundTripIdentically(t *testing.T) {
+	l := openLibWithLogbook(t)
+
+	// Insert with nil payload.
+	if _, err := l.InsertOpEvent(librarian.OpEvent{
+		EventType: "op.x",
+		SessionID: "s-nil",
+		Payload:   nil,
+	}); err != nil {
+		t.Fatalf("Insert nil: %v", err)
+	}
+	// Insert with empty (non-nil) map payload.
+	if _, err := l.InsertOpEvent(librarian.OpEvent{
+		EventType: "op.x",
+		SessionID: "s-empty",
+		Payload:   map[string]any{},
+	}); err != nil {
+		t.Fatalf("Insert empty: %v", err)
+	}
+
+	rows, _ := l.QueryOpEvents(librarian.OpEventFilter{EventType: "op.x"})
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	for _, r := range rows {
+		if r.Payload != nil {
+			t.Errorf("session %q: payload = %v, want nil (round-trip from null)", r.SessionID, r.Payload)
+		}
+	}
+}
+
+func TestQueryOpEvents_FilterByEventType(t *testing.T) {
+	l := openLibWithLogbook(t)
+	_, _ = l.InsertOpEvent(librarian.OpEvent{EventType: "op.a", SessionID: "s"})
+	_, _ = l.InsertOpEvent(librarian.OpEvent{EventType: "op.b", SessionID: "s"})
+
+	rows, _ := l.QueryOpEvents(librarian.OpEventFilter{EventType: "op.a"})
+	if len(rows) != 1 || rows[0].EventType != "op.a" {
+		t.Fatalf("filter by event_type: got %v, want [op.a]", rows)
+	}
+}
+
+func TestQueryOpEvents_FilterBySession(t *testing.T) {
+	l := openLibWithLogbook(t)
+	_, _ = l.InsertOpEvent(librarian.OpEvent{EventType: "op.x", SessionID: "s-1"})
+	_, _ = l.InsertOpEvent(librarian.OpEvent{EventType: "op.x", SessionID: "s-2"})
+
+	rows, _ := l.QueryOpEvents(librarian.OpEventFilter{SessionID: "s-1"})
+	if len(rows) != 1 || rows[0].SessionID != "s-1" {
+		t.Fatalf("filter by session: got %v, want [s-1]", rows)
+	}
+}
+
+func TestQueryOpEvents_FilterBySinceUntilWindow(t *testing.T) {
+	l := openLibWithLogbook(t)
+	t0 := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+
+	for i, dt := range []time.Duration{
+		0,                  // 10:00
+		1 * time.Hour,      // 11:00
+		2 * time.Hour,      // 12:00
+		3 * time.Hour,      // 13:00
+	} {
+		_, err := l.InsertOpEvent(librarian.OpEvent{
+			EventType: "op.x",
+			SessionID: "s",
+			CreatedAt: t0.Add(dt),
+			Payload:   map[string]any{"i": i},
+		})
+		if err != nil {
+			t.Fatalf("Insert %d: %v", i, err)
+		}
+	}
+
+	rows, _ := l.QueryOpEvents(librarian.OpEventFilter{
+		Since: t0.Add(1 * time.Hour),    // inclusive
+		Until: t0.Add(3 * time.Hour),    // exclusive
+	})
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows in [11:00, 13:00), got %d", len(rows))
+	}
+}
+
+func TestQueryOpEvents_DefaultLimit_100(t *testing.T) {
+	l := openLibWithLogbook(t)
+	for i := 0; i < 105; i++ {
+		_, err := l.InsertOpEvent(librarian.OpEvent{
+			EventType: "op.x", SessionID: "s",
+		})
+		if err != nil {
+			t.Fatalf("Insert %d: %v", i, err)
+		}
+	}
+	rows, _ := l.QueryOpEvents(librarian.OpEventFilter{})
+	if len(rows) != 100 {
+		t.Fatalf("default limit: got %d rows, want 100", len(rows))
+	}
+}
+
+func TestQueryOpEvents_OrderingIsMostRecentFirst(t *testing.T) {
+	l := openLibWithLogbook(t)
+	t0 := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	earlier, _ := l.InsertOpEvent(librarian.OpEvent{
+		EventType: "op.x", SessionID: "s", CreatedAt: t0,
+	})
+	later, _ := l.InsertOpEvent(librarian.OpEvent{
+		EventType: "op.x", SessionID: "s", CreatedAt: t0.Add(time.Hour),
+	})
+
+	rows, _ := l.QueryOpEvents(librarian.OpEventFilter{})
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	if rows[0].ID != later || rows[1].ID != earlier {
+		t.Fatalf("order: got [%d, %d], want [%d (later), %d (earlier)]",
+			rows[0].ID, rows[1].ID, later, earlier)
+	}
+}
+
+// TestQueryOpEvents_MixedPrecisionLexicalOrdering locks the lesson from
+// the previous attempt: timestamps with different fractional-second
+// precision must lexically sort consistently with their actual time
+// ordering. RFC3339Nano breaks this because it trims trailing zeros and
+// "." < "Z" in ASCII. The fixed-width nanosecond format keeps sort
+// correct.
+func TestQueryOpEvents_MixedPrecisionLexicalOrdering(t *testing.T) {
+	l := openLibWithLogbook(t)
+	// One row at exactly 10:00:05Z (zero fractional part) and one at
+	// 10:00:05.5Z (half-second past). Under RFC3339Nano the strings
+	// would be "...:05Z" and "...:05.5Z"; "." (0x2E) sorts before "Z"
+	// (0x5A), so the half-second-LATER row would sort BEFORE the
+	// even-second row — wrong. The fixed-width format always emits
+	// nine fractional digits ("...:05.000000000Z" vs
+	// "...:05.500000000Z") so lexical sort matches time ordering.
+	tBase := time.Date(2026, 5, 4, 10, 0, 5, 0, time.UTC)
+	tHalf := tBase.Add(500 * time.Millisecond)
+
+	earlierID, _ := l.InsertOpEvent(librarian.OpEvent{
+		EventType: "op.x", SessionID: "s", CreatedAt: tBase,
+	})
+	laterID, _ := l.InsertOpEvent(librarian.OpEvent{
+		EventType: "op.x", SessionID: "s", CreatedAt: tHalf,
+	})
+
+	rows, _ := l.QueryOpEvents(librarian.OpEventFilter{})
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	// Most recent first: tHalf (later) must appear before tBase
+	// (earlier) — both purely from the lexical ordering of created_at.
+	if rows[0].ID != laterID || rows[1].ID != earlierID {
+		t.Fatalf("lexical order broken: got [%d, %d], want [later=%d, earlier=%d]",
+			rows[0].ID, rows[1].ID, laterID, earlierID)
+	}
+}

--- a/cli/internal/logbook/worker.go
+++ b/cli/internal/logbook/worker.go
@@ -1,0 +1,91 @@
+// File worker.go contains Logbook's v0.30 surface: a worker that
+// subscribes to operational events on Herald and persists them through
+// Librarian into the op_events table. The legacy transcript-parsing
+// surface in this package (logbook.go and friends) is a separate
+// concern used by lens, watcher, and cmd; the two coexist while v1
+// callers migrate.
+package logbook
+
+import (
+	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/librarian"
+)
+
+// Worker subscribes to operational events on Herald and persists them
+// through Librarian. Worker does NOT touch the Vault directly (that
+// rule is owned by Librarian); the package-level architecture test
+// asserts the import graph.
+type Worker struct {
+	lib *librarian.Librarian
+}
+
+// New returns a Worker backed by the given Librarian. Callers wire it
+// to a Herald bus by calling Subscribe for each event type they want
+// recorded.
+func New(lib *librarian.Librarian) *Worker {
+	return &Worker{lib: lib}
+}
+
+// Log writes an operational event directly through Librarian, without
+// going via Herald. Useful for tests, for synchronous-write call paths
+// (e.g., upgrade), and as the implementation hook used by Subscribe.
+//
+// EventType and SessionID are required; empty inputs are rejected at
+// the API boundary by Librarian.
+func (w *Worker) Log(eventType, sessionID string, payload map[string]any) error {
+	_, err := w.lib.InsertOpEvent(librarian.OpEvent{
+		EventType: eventType,
+		SessionID: sessionID,
+		Payload:   payload,
+	})
+	return err
+}
+
+// Subscribe registers a handler on the bus that persists every matching
+// event. Returns the unsubscribe func from Herald — callers may detach
+// the worker without retaining the Bus reference.
+//
+// The handler reads session_id from event.Payload["session_id"] when
+// present; if missing, the row is skipped (the API requires non-empty
+// session_id and a programming-error event without one should not
+// silently land in the stream).
+func (w *Worker) Subscribe(bus *herald.Bus, eventType herald.EventType) func() {
+	return bus.Subscribe(eventType, func(e herald.Event) {
+		sessionID := stringField(e.Payload, "session_id")
+		if sessionID == "" {
+			return
+		}
+		_ = w.Log(string(e.Type), sessionID, e.Payload)
+	})
+}
+
+// SubscribeAll wires the worker to every listed event type and returns
+// a single unsubscribe that detaches them all.
+func (w *Worker) SubscribeAll(bus *herald.Bus, eventTypes ...herald.EventType) func() {
+	unsubs := make([]func(), 0, len(eventTypes))
+	for _, t := range eventTypes {
+		unsubs = append(unsubs, w.Subscribe(bus, t))
+	}
+	return func() {
+		for _, u := range unsubs {
+			u()
+		}
+	}
+}
+
+// Query reads back rows from the operational stream through Librarian.
+func (w *Worker) Query(filter librarian.OpEventFilter) ([]librarian.OpEvent, error) {
+	return w.lib.QueryOpEvents(filter)
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}

--- a/cli/internal/logbook/worker_test.go
+++ b/cli/internal/logbook/worker_test.go
@@ -1,0 +1,185 @@
+package logbook_test
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/momhq/mom/cli/internal/logbook"
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// openWorker opens a Vault with Librarian + Logbook migrations and
+// returns a Logbook Worker plus the underlying Librarian for read-back.
+func openWorker(t *testing.T) (*logbook.Worker, *librarian.Librarian) {
+	t.Helper()
+	dir := t.TempDir()
+	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	lib := librarian.New(v)
+	return logbook.New(lib), lib
+}
+
+func TestWorker_Log_PersistsThroughLibrarian(t *testing.T) {
+	w, lib := openWorker(t)
+	if err := w.Log("op.session.started", "s-1", map[string]any{"runtime": "claude-code"}); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{})
+	if err != nil {
+		t.Fatalf("QueryOpEvents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].EventType != "op.session.started" {
+		t.Errorf("EventType = %q", rows[0].EventType)
+	}
+}
+
+func TestWorker_Log_RejectsEmptyEventType(t *testing.T) {
+	w, _ := openWorker(t)
+	err := w.Log("", "s", nil)
+	if !errors.Is(err, librarian.ErrEmptyArg) {
+		t.Fatalf("err = %v, want ErrEmptyArg", err)
+	}
+}
+
+func TestWorker_Log_RejectsEmptySessionID(t *testing.T) {
+	w, _ := openWorker(t)
+	err := w.Log("op.x", "", nil)
+	if !errors.Is(err, librarian.ErrEmptyArg) {
+		t.Fatalf("err = %v, want ErrEmptyArg", err)
+	}
+}
+
+func TestWorker_Subscribe_PersistsPublishedEvents(t *testing.T) {
+	w, lib := openWorker(t)
+	bus := herald.NewBus()
+	unsub := w.Subscribe(bus, "op.recall.queried")
+	defer unsub()
+
+	bus.Publish("op.recall.queried", map[string]any{
+		"session_id":  "s-test",
+		"query":       "deploy",
+		"max_results": 10,
+	})
+
+	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "op.recall.queried"})
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].SessionID != "s-test" {
+		t.Errorf("SessionID = %q, want s-test", rows[0].SessionID)
+	}
+	if rows[0].Payload["query"] != "deploy" {
+		t.Errorf("payload.query = %v", rows[0].Payload["query"])
+	}
+}
+
+func TestWorker_Subscribe_SkipsEventsWithoutSessionID(t *testing.T) {
+	// Events without a session_id field violate the API contract. Rather
+	// than letting the row land with empty session_id (which is also
+	// rejected at the API), the subscriber drops the event silently.
+	// This matches the lesson: empty session_id is always a programming
+	// error and should never appear in the stream.
+	w, lib := openWorker(t)
+	bus := herald.NewBus()
+	defer w.Subscribe(bus, "op.broken")()
+
+	bus.Publish("op.broken", map[string]any{"foo": "bar"})
+
+	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{})
+	if len(rows) != 0 {
+		t.Fatalf("got %d rows, want 0 (event without session_id should be skipped)", len(rows))
+	}
+}
+
+func TestWorker_Unsubscribe_StopsRecording(t *testing.T) {
+	w, lib := openWorker(t)
+	bus := herald.NewBus()
+	unsub := w.Subscribe(bus, "op.x")
+
+	bus.Publish("op.x", map[string]any{"session_id": "s"})
+	unsub()
+	bus.Publish("op.x", map[string]any{"session_id": "s"})
+
+	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{})
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows after unsubscribe, want 1 (the pre-unsub event)", len(rows))
+	}
+}
+
+func TestWorker_SubscribeAll_AndCombinedUnsubscribe(t *testing.T) {
+	w, lib := openWorker(t)
+	bus := herald.NewBus()
+	stop := w.SubscribeAll(bus, "op.a", "op.b", "op.c")
+
+	bus.Publish("op.a", map[string]any{"session_id": "s"})
+	bus.Publish("op.b", map[string]any{"session_id": "s"})
+	bus.Publish("op.c", map[string]any{"session_id": "s"})
+	bus.Publish("op.d", map[string]any{"session_id": "s"}) // not subscribed
+
+	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{})
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3 (only a/b/c subscribed)", len(rows))
+	}
+
+	stop()
+	bus.Publish("op.a", map[string]any{"session_id": "s"})
+	rows, _ = lib.QueryOpEvents(librarian.OpEventFilter{})
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows after combined unsub, want still 3", len(rows))
+	}
+}
+
+// TestWorker_Subscribe_FanOutWithOtherSubscribers ensures Logbook does
+// not interfere with other handlers on the same Herald event type.
+func TestWorker_Subscribe_FanOutWithOtherSubscribers(t *testing.T) {
+	w, _ := openWorker(t)
+	bus := herald.NewBus()
+	defer w.Subscribe(bus, "op.x")()
+
+	var sibling atomic.Int64
+	bus.Subscribe("op.x", func(e herald.Event) { sibling.Add(1) })
+
+	bus.Publish("op.x", map[string]any{"session_id": "s"})
+
+	if got := sibling.Load(); got != 1 {
+		t.Errorf("sibling handler fired %d times, want 1", got)
+	}
+}
+
+// TestLogbook_DoesNotImportVault enforces the architectural rule:
+// Logbook is a worker that goes through Librarian; only Librarian
+// touches the Vault package.
+//
+// `go list` without `-deps` returns the package's DIRECT imports only;
+// vault appearing here would mean logbook reaches around librarian
+// instead of through it. Transitive imports (logbook → librarian →
+// vault) are expected and not flagged.
+func TestLogbook_DoesNotImportVault(t *testing.T) {
+	cmd := exec.Command("go", "list",
+		"-f", "{{range .Imports}}{{.}}\n{{end}}",
+		"github.com/momhq/mom/cli/internal/logbook")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list failed: %v\n%s", err, out)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "github.com/momhq/mom/cli/internal/vault" {
+			t.Errorf("logbook imports vault directly; must go through librarian")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements **Logbook**'s v0.30 surface: a worker that subscribes to operational events on Herald and persists them through Librarian into a single `op_events` table. **No** parallel `event_log` table — the duplicate stream from the previous attempt is dropped.

## Architecture

```
producer ── Publish on Herald ──► Logbook.Worker ──► Librarian.InsertOpEvent ──► Vault
```

Worker is a thin Herald subscriber that calls Librarian. Logbook does not import Vault directly — locked by a `go list` test that allows transitive imports through Librarian but rejects direct ones.

## Locked contracts

- **Fixed-width nanosecond timestamps** on every Librarian-owned column. Mixed-precision lexical ordering test (`:05Z` vs `:05.5Z`) prevents RFC3339Nano-style regressions.
- **Payload normalization**: nil and empty-map round-trip identically as `"null" → nil`.
- **session_id required end-to-end**: schema `NOT NULL`, API `ErrEmptyArg`. Subscribe drops events whose payload lacks `session_id`.
- **Single ops stream**, owned by Logbook, queried by `mom lens`.
- **Migration registration via `librarian.Migration` type alias** so Logbook never imports Vault.

## Test plan

- [x] 16 tests covering the contracts above
- [x] `go test ./internal/logbook/ ./internal/librarian/` — green
- [x] `go test -race ./internal/logbook/ ./internal/librarian/`
- [x] `go test ./...` — full repo green
- [x] Architectural rule: Logbook has no direct vault import (locked test)

Refs: closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)