### PR TITLE
feat(mcp): mom_record tool — explicit-write path via Herald (#239)

### DIFF
--- a/cli/internal/mcp/mom_record.go
+++ b/cli/internal/mcp/mom_record.go
@@ -1,0 +1,179 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/librarian"
+)
+
+// MemoryRecordEventType is the v0.30 Herald event type the mom_record
+// MCP handler publishes. Drafter subscribes to this type, applies the
+// explicit-write filter bypass (per ADR 0014), stamps provenance, and
+// persists the memory through Librarian.
+//
+// Producers other than mom_record SHOULD NOT publish this type — it
+// represents the "user intentionally saved" path that bypasses
+// content-shaped filters. Watcher-driven captures use a different type.
+const MemoryRecordEventType herald.EventType = "memory.record"
+
+// MemoryRecordPayload is the canonical payload shape for memory.record
+// events. Drafter reads these fields verbatim; nothing else inspects
+// the payload, so the contract is defined here.
+//
+// Provenance is filled in by the handler:
+//   - ProvenanceTriggerEvent = "record"
+//   - ProvenanceSourceType   = "manual-draft"
+//   - ProvenanceActor        = ActorAgent (claude-code, codex, …) or
+//                              "mcp" when the caller did not announce.
+//
+// Tags are normalised via librarian.NormalizeTagName before publish;
+// every entry in Tags is the canonical form. If any input tag
+// normalised to empty the handler rejects the WHOLE request before
+// publishing — mirroring the lesson that prevented the orphan-row bug
+// in the previous attempt.
+type MemoryRecordPayload struct {
+	SessionID              string
+	Summary                string
+	Tags                   []string
+	Content                map[string]any
+	ProvenanceActor        string
+	ProvenanceSourceType   string
+	ProvenanceTriggerEvent string
+}
+
+// toolMomRecord is the MCP handler. It validates inputs, normalises
+// tags, then publishes the record event on the v0.30 bus. It does NOT
+// call Librarian directly — Drafter is the worker that subscribes to
+// memory.record and persists.
+//
+// Validation rules (locked):
+//   - content is required, must be an object/map (not empty).
+//   - session_id is required.
+//   - summary is optional.
+//   - tags is optional. Each tag is normalised; if any normalises to
+//     empty, the entire request is rejected with a clear error and no
+//     event is published (no orphan rows downstream).
+func (s *Server) toolMomRecord(args map[string]any) (toolCallResult, error) {
+	content, err := requireMapArg(args, "content")
+	if err != nil {
+		return toolCallResult{}, err
+	}
+	sessionID := stringArg(args, "session_id")
+	if strings.TrimSpace(sessionID) == "" {
+		return toolCallResult{}, errors.New("session_id is required")
+	}
+	summary := stringArg(args, "summary")
+
+	rawTags, err := optionalStringSliceArg(args, "tags")
+	if err != nil {
+		return toolCallResult{}, err
+	}
+	normalisedTags, err := normaliseTagsOrReject(rawTags)
+	if err != nil {
+		return toolCallResult{}, err
+	}
+
+	actor := stringArg(args, "actor")
+	if strings.TrimSpace(actor) == "" {
+		actor = "mcp"
+	}
+
+	payload := MemoryRecordPayload{
+		SessionID:              sessionID,
+		Summary:                summary,
+		Tags:                   normalisedTags,
+		Content:                content,
+		ProvenanceActor:        actor,
+		ProvenanceSourceType:   "manual-draft",
+		ProvenanceTriggerEvent: "record",
+	}
+
+	s.bus.Publish(MemoryRecordEventType, payloadAsMap(payload))
+
+	return toolCallResult{
+		Content: []toolContent{{
+			Type: "text",
+			Text: fmt.Sprintf("recorded: session=%s tags=%v summary=%q", sessionID, normalisedTags, summary),
+		}},
+	}, nil
+}
+
+// normaliseTagsOrReject applies librarian.NormalizeTagName to every
+// input tag. If any tag normalises to empty (e.g., "!!!", "  "), the
+// whole slice is rejected with an error — the previous attempt's
+// orphan-row bug came from publishing the memory then failing later on
+// a per-tag UpsertTag("").
+func normaliseTagsOrReject(raw []string) ([]string, error) {
+	out := make([]string, 0, len(raw))
+	for i, t := range raw {
+		n := librarian.NormalizeTagName(t)
+		if n == "" {
+			return nil, fmt.Errorf("tag %d (%q) normalises to empty; reject the request rather than persist a partial memory", i, t)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+// requireMapArg returns the named argument as a map[string]any. Empty
+// or missing maps are rejected.
+func requireMapArg(args map[string]any, key string) (map[string]any, error) {
+	v, ok := args[key]
+	if !ok {
+		return nil, fmt.Errorf("%s is required", key)
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an object", key)
+	}
+	if len(m) == 0 {
+		return nil, fmt.Errorf("%s is required", key)
+	}
+	return m, nil
+}
+
+// optionalStringSliceArg returns the named argument as []string. Absent
+// or nil arg yields nil, nil. Mixed-type arrays are rejected.
+func optionalStringSliceArg(args map[string]any, key string) ([]string, error) {
+	v, ok := args[key]
+	if !ok || v == nil {
+		return nil, nil
+	}
+	raw, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array of strings", key)
+	}
+	out := make([]string, 0, len(raw))
+	for i, x := range raw {
+		s, ok := x.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be a string", key, i)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// payloadAsMap converts a MemoryRecordPayload to a map for Herald
+// transport. Each Herald event payload is map[string]any per the
+// v1+v0.30 Bus contract; using a typed struct internally keeps the
+// handler readable while the Bus stays type-agnostic.
+func payloadAsMap(p MemoryRecordPayload) map[string]any {
+	m := map[string]any{
+		"session_id":               p.SessionID,
+		"content":                  p.Content,
+		"provenance_actor":         p.ProvenanceActor,
+		"provenance_source_type":   p.ProvenanceSourceType,
+		"provenance_trigger_event": p.ProvenanceTriggerEvent,
+	}
+	if p.Summary != "" {
+		m["summary"] = p.Summary
+	}
+	if len(p.Tags) > 0 {
+		m["tags"] = p.Tags
+	}
+	return m
+}

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -1,0 +1,237 @@
+package mcp
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/herald"
+)
+
+// recordingSubscriber attaches to the bus, captures the single event
+// it sees (if any), and returns it. Tests use it to assert the
+// handler's published event shape.
+type recordingSubscriber struct {
+	captured atomic.Value // herald.Event
+	count    atomic.Int64
+}
+
+func (rs *recordingSubscriber) attach(bus *herald.Bus) func() {
+	return bus.Subscribe(MemoryRecordEventType, func(e herald.Event) {
+		rs.captured.Store(e)
+		rs.count.Add(1)
+	})
+}
+
+func (rs *recordingSubscriber) get() (herald.Event, bool) {
+	v := rs.captured.Load()
+	if v == nil {
+		return herald.Event{}, false
+	}
+	return v.(herald.Event), true
+}
+
+func newSrvWithSubscriber(t *testing.T) (*Server, *recordingSubscriber) {
+	t.Helper()
+	srv := New(t.TempDir())
+	rs := &recordingSubscriber{}
+	t.Cleanup(rs.attach(srv.Bus()))
+	return srv, rs
+}
+
+// ── happy path ────────────────────────────────────────────────────────────────
+
+func TestMomRecord_PublishesEventWithNormalizedTags(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+
+	res, err := srv.toolMomRecord(map[string]any{
+		"session_id": "s-1",
+		"summary":    "deploy notes",
+		"content":    map[string]any{"text": "deploy postgres canary"},
+		"tags":       []any{"v0.30", "MCP"},
+		"actor":      "claude-code",
+	})
+	if err != nil {
+		t.Fatalf("toolMomRecord: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("got IsError=true: %+v", res)
+	}
+
+	got, ok := rs.get()
+	if !ok {
+		t.Fatal("no event published")
+	}
+	if got.Type != MemoryRecordEventType {
+		t.Errorf("event type = %q, want %q", got.Type, MemoryRecordEventType)
+	}
+	if got.Payload["session_id"] != "s-1" {
+		t.Errorf("session_id = %v", got.Payload["session_id"])
+	}
+	tags, _ := got.Payload["tags"].([]string)
+	want := []string{"v0-30", "mcp"} // normalised
+	if len(tags) != len(want) {
+		t.Fatalf("tags = %v, want %v", tags, want)
+	}
+	for i := range want {
+		if tags[i] != want[i] {
+			t.Errorf("tags[%d] = %q, want %q", i, tags[i], want[i])
+		}
+	}
+
+	// Provenance stamps locked.
+	if got.Payload["provenance_trigger_event"] != "record" {
+		t.Errorf("trigger_event = %v", got.Payload["provenance_trigger_event"])
+	}
+	if got.Payload["provenance_source_type"] != "manual-draft" {
+		t.Errorf("source_type = %v", got.Payload["provenance_source_type"])
+	}
+	if got.Payload["provenance_actor"] != "claude-code" {
+		t.Errorf("actor = %v", got.Payload["provenance_actor"])
+	}
+}
+
+func TestMomRecord_DefaultsActorToMCP(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	_, err := srv.toolMomRecord(map[string]any{
+		"session_id": "s",
+		"content":    map[string]any{"text": "hi"},
+	})
+	if err != nil {
+		t.Fatalf("toolMomRecord: %v", err)
+	}
+	got, _ := rs.get()
+	if got.Payload["provenance_actor"] != "mcp" {
+		t.Errorf("default actor = %v, want mcp", got.Payload["provenance_actor"])
+	}
+}
+
+// ── validation ────────────────────────────────────────────────────────────────
+
+func TestMomRecord_RejectsEmptySessionID(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	_, err := srv.toolMomRecord(map[string]any{
+		"session_id": "",
+		"content":    map[string]any{"text": "x"},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty session_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "session_id") {
+		t.Errorf("error %q should mention session_id", err)
+	}
+	// No event published.
+	if rs.count.Load() != 0 {
+		t.Errorf("event count = %d, want 0 (validation rejected before publish)", rs.count.Load())
+	}
+}
+
+func TestMomRecord_RejectsMissingContent(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	_, err := srv.toolMomRecord(map[string]any{
+		"session_id": "s",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing content")
+	}
+	if rs.count.Load() != 0 {
+		t.Errorf("event count = %d, want 0", rs.count.Load())
+	}
+}
+
+func TestMomRecord_RejectsEmptyContent(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	_, err := srv.toolMomRecord(map[string]any{
+		"session_id": "s",
+		"content":    map[string]any{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty content")
+	}
+	if rs.count.Load() != 0 {
+		t.Errorf("event count = %d, want 0", rs.count.Load())
+	}
+}
+
+func TestMomRecord_RejectsNonObjectContent(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	_, err := srv.toolMomRecord(map[string]any{
+		"session_id": "s",
+		"content":    "this is a string, not an object",
+	})
+	if err == nil {
+		t.Fatal("expected error for string content")
+	}
+	if rs.count.Load() != 0 {
+		t.Errorf("event count = %d, want 0", rs.count.Load())
+	}
+}
+
+// TestMomRecord_RejectsTagsThatNormaliseToEmpty locks the lesson from
+// the previous attempt: a memory + entity edge was persisted and THEN
+// UpsertTag("") failed downstream, leaving an orphan memory. The fix
+// is to validate post-normalisation tag emptiness BEFORE publishing.
+func TestMomRecord_RejectsTagsThatNormaliseToEmpty(t *testing.T) {
+	cases := []struct {
+		name string
+		tags []any
+	}{
+		{"all-punctuation", []any{"!!!"}},
+		{"all-whitespace", []any{"   "}},
+		{"mixed-some-empty", []any{"deploy", "  ", "ok"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv, rs := newSrvWithSubscriber(t)
+			_, err := srv.toolMomRecord(map[string]any{
+				"session_id": "s",
+				"content":    map[string]any{"text": "x"},
+				"tags":       c.tags,
+			})
+			if err == nil {
+				t.Fatal("expected error for normalise-empty tag")
+			}
+			if !strings.Contains(err.Error(), "normalises to empty") {
+				t.Errorf("error %q should mention normalisation", err)
+			}
+			// CRITICAL: NO event must have been published.
+			if rs.count.Load() != 0 {
+				t.Errorf("event count = %d, want 0 — orphan-row regression", rs.count.Load())
+			}
+		})
+	}
+}
+
+func TestMomRecord_RejectsMixedTypeTags(t *testing.T) {
+	srv, _ := newSrvWithSubscriber(t)
+	_, err := srv.toolMomRecord(map[string]any{
+		"session_id": "s",
+		"content":    map[string]any{"text": "x"},
+		"tags":       []any{"deploy", 42},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-string tag element")
+	}
+}
+
+// ── architectural / integration ──────────────────────────────────────────────
+
+func TestServer_BusIsAccessibleAndDistinctPerInstance(t *testing.T) {
+	a := New(t.TempDir())
+	b := New(t.TempDir())
+	if a.Bus() == nil || b.Bus() == nil {
+		t.Fatal("Server.Bus() returned nil")
+	}
+	if a.Bus() == b.Bus() {
+		t.Fatal("two Servers share the same Bus pointer")
+	}
+}
+
+func TestServer_SetBusReplacesTheBus(t *testing.T) {
+	srv := New(t.TempDir())
+	custom := herald.NewBus()
+	srv.SetBus(custom)
+	if srv.Bus() != custom {
+		t.Fatal("SetBus did not replace the bus")
+	}
+}

--- a/cli/internal/mcp/server.go
+++ b/cli/internal/mcp/server.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/momhq/mom/cli/internal/adapters/storage"
+	"github.com/momhq/mom/cli/internal/herald"
 	"github.com/momhq/mom/cli/internal/recall"
 	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/ux"
@@ -62,10 +63,14 @@ type Server struct {
 	momDir string
 	idx    *storage.IndexedAdapter
 	engine *recall.Engine
+	bus    *herald.Bus
 }
 
 // New creates a new Server rooted at the given .mom/ directory.
-// It builds the recall Engine from the scope chain discovered at momDir.
+// It builds the recall Engine from the scope chain discovered at momDir
+// and attaches a fresh v0.30 Herald bus for write tools (mom_record) to
+// publish on. Callers who want their own bus (e.g., to wire a Drafter
+// subscriber) can replace it via SetBus before Serve.
 func New(momDir string) *Server {
 	idx := storage.NewIndexedAdapter(momDir)
 
@@ -82,8 +87,19 @@ func New(momDir string) *Server {
 		momDir: momDir,
 		idx:    idx,
 		engine: recall.NewEngine(chain),
+		bus:    herald.NewBus(),
 	}
 }
+
+// Bus returns the v0.30 Herald bus this Server publishes on. Callers
+// that need to attach subscribers (e.g., Drafter for memory.record
+// events, Logbook for op.* events) take this reference before Serve.
+func (s *Server) Bus() *herald.Bus { return s.bus }
+
+// SetBus replaces the Server's bus with the given one. Useful when the
+// application root constructs a single shared bus across MCP +
+// watcher + Drafter; never call after Serve has started.
+func (s *Server) SetBus(b *herald.Bus) { s.bus = b }
 
 // Serve runs the JSON-RPC 2.0 stdio loop. It reads newline-delimited requests
 // from in and writes responses to out. Blocks until in is closed or returns an

--- a/cli/internal/mcp/server_test.go
+++ b/cli/internal/mcp/server_test.go
@@ -182,8 +182,8 @@ func TestToolsList(t *testing.T) {
 	if !ok {
 		t.Fatalf("tools not an array: %v", result["tools"])
 	}
-	if len(tools) != 7 {
-		t.Errorf("expected 7 tools, got %d", len(tools))
+	if len(tools) != 8 {
+		t.Errorf("expected 8 tools, got %d", len(tools))
 	}
 
 	names := make(map[string]bool)
@@ -195,7 +195,7 @@ func TestToolsList(t *testing.T) {
 		name, _ := tool["name"].(string)
 		names[name] = true
 	}
-	expected := []string{"get_memory", "list_scopes", "create_memory_draft", "list_landmarks", "mom_status", "mom_record_turn", "mom_recall"}
+	expected := []string{"get_memory", "list_scopes", "create_memory_draft", "list_landmarks", "mom_status", "mom_record_turn", "mom_recall", "mom_record"}
 	for _, n := range expected {
 		if !names[n] {
 			t.Errorf("tool %q missing from tools/list", n)

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -99,6 +99,21 @@ func allTools() []toolDef {
 			},
 		},
 		{
+			Name:        "mom_record",
+			Description: "Explicit-write path: intentionally save a memory mid-session. Bypasses Drafter's content filters (the user override) and stamps trigger_event='record', source_type='manual-draft'. Required: session_id, content. Optional: summary, tags, actor.",
+			InputSchema: map[string]any{
+				"type":     "object",
+				"required": []string{"session_id", "content"},
+				"properties": map[string]any{
+					"session_id": map[string]any{"type": "string", "description": "Session ID this memory belongs to"},
+					"summary":    map[string]any{"type": "string", "description": "One-line summary"},
+					"tags":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Tag names (will be normalised; empty after normalisation rejects the request)"},
+					"content":    map[string]any{"type": "object", "description": "Memory content (must include $.text for FTS)"},
+					"actor":      map[string]any{"type": "string", "description": "Calling agent (claude-code, codex, …); defaults to 'mcp'"},
+				},
+			},
+		},
+		{
 			Name:        "mom_recall",
 			Description: "Search your memory for relevant context. Uses progressive scope escalation (repo→org→user) with AND→OR query relaxation and curated-first, draft-fallback quality tiers.",
 			InputSchema: map[string]any{
@@ -155,6 +170,8 @@ func (s *Server) handleToolsCall(params json.RawMessage) (any, *rpcError) {
 		result, err = s.toolMomStatus()
 	case "mom_record_turn":
 		result, err = s.toolRecordTurn(req.Arguments)
+	case "mom_record":
+		result, err = s.toolMomRecord(req.Arguments)
 	case "mom_recall":
 		result, err = s.toolMomRecall(req.Arguments)
 	default:


### PR DESCRIPTION
## Summary

Adds the `mom_record` MCP tool with the corrected v0.30 architecture: the handler validates inputs, normalises tags, and **publishes on Herald** rather than calling Librarian directly. Drafter (lands in #240) subscribes to `memory.record` and persists with the filter bypass per ADR 0014.

## Locked contracts

- `mcp.MemoryRecordEventType = "memory.record"` and `mcp.MemoryRecordPayload` define the stable contract Drafter implements against.
- **Validate-before-publish**: empty `session_id`, missing/empty/non-object `content`, mixed-type tag arrays, and tags that normalise to empty all reject the request with no event published. Locked by sub-test matrix.
- **Tag normalisation** reuses `librarian.NormalizeTagName` so canonical form is consistent across mom_record, Drafter, and Wrap-up.
- **Provenance stamps** locked: `trigger_event="record"`, `source_type="manual-draft"`, `actor=<arg or "mcp">`.
- `Server.Bus()` / `Server.SetBus(b)` give the application root one bus to wire across MCP + watcher + Drafter.

## Out of scope (intentional)

- Drafter subscriber that consumes the published events. The contract is locked here; the worker lands in #240.
- Removal of pre-0.30 `create_memory_draft` and `mom_record_turn` (still have v1 callers; delete when v1 paths migrate).
- `vault.Open` at MCP startup (lands with Drafter wiring; cobra's error path already honours the stderr-not-stdout rule).

## Test plan

- [x] 10 mom_record tests covering happy path, all validation rejections, the orphan-row regression test (sub-cases for normalise-empty tags), and Bus accessor surface
- [x] Existing `TestToolsList` updated for the new 8-tool catalog
- [x] `go test ./internal/mcp/` — green
- [x] `go test -race ./internal/mcp/`
- [x] `go test ./...` — full repo green

Refs: closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)