### PR TITLE
refactor(herald): lift session_id onto Event envelope; tighten Logbook

### DIFF
--- a/cli/internal/herald/bus_v030_test.go
+++ b/cli/internal/herald/bus_v030_test.go
@@ -19,9 +19,9 @@ func TestPublish_TypeOnlyRouting(t *testing.T) {
 	bus.Subscribe(SessionStart, func(e Event) { aCount.Add(1) })
 	bus.Subscribe(SessionEnd, func(e Event) { bCount.Add(1) })
 
-	bus.Publish(SessionStart, nil)
-	bus.Publish(SessionStart, nil)
-	bus.Publish(SessionEnd, nil)
+	bus.Publish(Event{Type: SessionStart})
+	bus.Publish(Event{Type: SessionStart})
+	bus.Publish(Event{Type: SessionEnd})
 
 	if got := aCount.Load(); got != 2 {
 		t.Errorf("SessionStart handler got %d events, want 2", got)
@@ -37,14 +37,14 @@ func TestSubscribe_ReturnsUnsubscribe_StopsDelivery(t *testing.T) {
 
 	unsub := bus.Subscribe(MemoryCreated, func(e Event) { count.Add(1) })
 
-	bus.Publish(MemoryCreated, nil)
+	bus.Publish(Event{Type: MemoryCreated})
 	if got := count.Load(); got != 1 {
 		t.Fatalf("got %d, want 1 (before unsubscribe)", got)
 	}
 
 	unsub()
 
-	bus.Publish(MemoryCreated, nil)
+	bus.Publish(Event{Type: MemoryCreated})
 	if got := count.Load(); got != 1 {
 		t.Errorf("got %d, want 1 (handler should not fire after unsubscribe)", got)
 	}
@@ -63,7 +63,7 @@ func TestUnsubscribe_IsIdempotent(t *testing.T) {
 	unsub()
 	unsub() // second call is a no-op
 
-	bus.Publish(ToolUse, nil)
+	bus.Publish(Event{Type: ToolUse})
 	if got := count.Load(); got != 10 {
 		t.Errorf("got %d, want 10 (only the still-subscribed handler should fire)", got)
 	}
@@ -77,7 +77,7 @@ func TestUnsubscribe_OnlyAffectsTheReturnedHandler(t *testing.T) {
 	bus.Subscribe(MemoryPromoted, func(e Event) { bCount.Add(1) })
 
 	unsubA()
-	bus.Publish(MemoryPromoted, nil)
+	bus.Publish(Event{Type: MemoryPromoted})
 
 	if a := aCount.Load(); a != 0 {
 		t.Errorf("unsubscribed handler fired %d times", a)
@@ -97,7 +97,7 @@ func TestPublish_HandlerPanicDoesNotBlockOthers(t *testing.T) {
 
 	// Publish must not propagate the panic and must call handlers
 	// registered after the panicking one.
-	bus.Publish(Error, map[string]any{"msg": "test"})
+	bus.Publish(Event{Type: Error, Payload: map[string]any{"msg": "test"}})
 
 	if got := beforeCount.Load(); got != 1 {
 		t.Errorf("before-panic handler got %d, want 1", got)
@@ -118,7 +118,7 @@ func TestPublish_HandlerPanicAcrossMultiplePublishes(t *testing.T) {
 	})
 
 	for i := 0; i < 5; i++ {
-		bus.Publish(ConfigChanged, nil)
+		bus.Publish(Event{Type: ConfigChanged})
 	}
 
 	if got := fireCount.Load(); got != 5 {
@@ -140,7 +140,7 @@ func TestSubscribe_ConcurrentUnsubscribeIsRaceFree(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			bus.Publish(TurnComplete, nil)
+			bus.Publish(Event{Type: TurnComplete})
 		}()
 	}
 	wg.Wait()

--- a/cli/internal/herald/herald.go
+++ b/cli/internal/herald/herald.go
@@ -27,8 +27,25 @@ const (
 )
 
 // Event is a single message on the bus.
+//
+// Type and SessionID are first-class envelope fields — producers set
+// them explicitly, consumers read them directly. SessionID is required
+// for any event a worker (Logbook, Drafter) will persist; programming-
+// error empty values are caught at the worker boundary, not buried
+// inside the payload.
+//
+// Timestamp is set by Publish (not by producers) using wall-clock UTC.
+// Any value a caller assigns is overwritten — the bus is the only
+// authority for "when this event happened on the wire." Historical
+// times for replay or import belong on the persisted row, not on the
+// envelope.
+//
+// Payload carries per-event-type fields. The bus is type-agnostic; the
+// payload contract is defined by each producer/consumer pair (see
+// e.g. mcp.MemoryRecordPayload).
 type Event struct {
 	Type      EventType
+	SessionID string
 	Timestamp time.Time
 	Payload   map[string]any
 }
@@ -85,16 +102,20 @@ func (b *Bus) Subscribe(eventType EventType, handler Handler) func() {
 	}
 }
 
-// Publish dispatches an event of eventType with the given payload to
-// all registered handlers. Handlers fire synchronously in registration
-// order. A panic in one handler is recovered and logged to stderr; the
-// remaining handlers still fire. The panicking handler stays registered.
+// Publish dispatches the event to all handlers registered for its
+// type. Handlers fire synchronously in registration order. A panic in
+// one handler is recovered and logged to stderr; the remaining
+// handlers still fire. The panicking handler stays registered.
+//
+// Publish always stamps Timestamp with wall-clock UTC, overwriting any
+// value the caller may have set. The bus is the sole authority for
+// event timing.
 //
 // stdout is reserved for JSON-RPC output by the MCP server, so all
 // recovered-panic logging goes to stderr.
-func (b *Bus) Publish(eventType EventType, payload map[string]any) {
+func (b *Bus) Publish(e Event) {
 	b.mu.RLock()
-	hs := b.entries[eventType]
+	hs := b.entries[e.Type]
 	if len(hs) == 0 {
 		b.mu.RUnlock()
 		return
@@ -106,14 +127,10 @@ func (b *Bus) Publish(eventType EventType, payload map[string]any) {
 	}
 	b.mu.RUnlock()
 
-	event := Event{
-		Type:      eventType,
-		Timestamp: time.Now().UTC(),
-		Payload:   payload,
-	}
+	e.Timestamp = time.Now().UTC()
 
 	for _, h := range handlers {
-		invoke(eventType, event, h)
+		invoke(e.Type, e, h)
 	}
 }
 

--- a/cli/internal/herald/herald_test.go
+++ b/cli/internal/herald/herald_test.go
@@ -91,8 +91,7 @@ func TestPublish_DeliversToHandler(t *testing.T) {
 		received = append(received, e)
 	})
 
-	payload := map[string]any{"session_id": "s-123"}
-	bus.Publish(SessionStart, payload)
+	bus.Publish(Event{Type: SessionStart, SessionID: "s-123"})
 
 	if len(received) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(received))
@@ -101,8 +100,8 @@ func TestPublish_DeliversToHandler(t *testing.T) {
 	if ev.Type != SessionStart {
 		t.Errorf("expected type %q, got %q", SessionStart, ev.Type)
 	}
-	if ev.Payload["session_id"] != "s-123" {
-		t.Errorf("expected session_id %q, got %v", "s-123", ev.Payload["session_id"])
+	if ev.SessionID != "s-123" {
+		t.Errorf("expected session_id %q, got %q", "s-123", ev.SessionID)
 	}
 	if ev.Timestamp.IsZero() {
 		t.Error("expected non-zero timestamp")
@@ -122,7 +121,7 @@ func TestPublish_MultipleSubscribersReceiveSameEvent(t *testing.T) {
 		})
 	}
 
-	bus.Publish(MemoryCreated, map[string]any{"id": "m-001"})
+	bus.Publish(Event{Type: MemoryCreated, Payload: map[string]any{"id": "m-001"}})
 
 	if count != 3 {
 		t.Errorf("expected 3 handler calls, got %d", count)
@@ -133,7 +132,7 @@ func TestPublish_UnsubscribedEventType_NoOp(t *testing.T) {
 	bus := NewBus()
 	// No subscribers registered.
 	// Must not panic, must not error.
-	bus.Publish(ConfigChanged, map[string]any{"key": "telemetry"})
+	bus.Publish(Event{Type: ConfigChanged, Payload: map[string]any{"key": "telemetry"}})
 }
 
 func TestPublish_SetsTimestampUTC(t *testing.T) {
@@ -142,7 +141,7 @@ func TestPublish_SetsTimestampUTC(t *testing.T) {
 	bus.Subscribe(TurnComplete, func(e Event) { ev = e })
 
 	before := time.Now().UTC()
-	bus.Publish(TurnComplete, nil)
+	bus.Publish(Event{Type: TurnComplete})
 	after := time.Now().UTC()
 
 	if ev.Timestamp.Before(before) || ev.Timestamp.After(after) {
@@ -157,7 +156,7 @@ func TestPublish_NilPayload_NoOp(t *testing.T) {
 	bus := NewBus()
 	var received Event
 	bus.Subscribe(Error, func(e Event) { received = e })
-	bus.Publish(Error, nil)
+	bus.Publish(Event{Type: Error})
 	if received.Payload != nil {
 		t.Errorf("expected nil payload, got %v", received.Payload)
 	}
@@ -179,7 +178,7 @@ func TestPublish_ConcurrentSafety(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			bus.Publish(ToolUse, map[string]any{"tool": "read"})
+			bus.Publish(Event{Type: ToolUse, Payload: map[string]any{"tool": "read"}})
 		}()
 	}
 	wg.Wait()
@@ -203,7 +202,7 @@ func TestSubscribe_ConcurrentWithPublish(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			bus.Publish(MemorySearched, nil)
+			bus.Publish(Event{Type: MemorySearched})
 		}()
 	}
 	wg.Wait()
@@ -218,9 +217,10 @@ func TestTelemetrySubscriber_WritesJSONLOnEvent(t *testing.T) {
 	ts.Register(bus)
 
 	// Publish a known event; TelemetrySubscriber should write it.
-	bus.Publish(SessionStart, map[string]any{
-		"session_id": "s-test",
-		"runtime":    "claude-code",
+	bus.Publish(Event{
+		Type:      SessionStart,
+		SessionID: "s-test",
+		Payload:   map[string]any{"runtime": "claude-code"},
 	})
 
 	// Read back — there should be at least one JSONL file.
@@ -250,7 +250,7 @@ func TestTelemetrySubscriber_DisabledWritesNothing(t *testing.T) {
 	ts := NewTelemetrySubscriber(momDir, false)
 	ts.Register(bus)
 
-	bus.Publish(SessionEnd, map[string]any{"session_id": "s-off"})
+	bus.Publish(Event{Type: SessionEnd, SessionID: "s-off"})
 
 	telDir := momDir + "/telemetry"
 	entries, _ := readDir(telDir)

--- a/cli/internal/logbook/worker.go
+++ b/cli/internal/logbook/worker.go
@@ -7,6 +7,9 @@
 package logbook
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/momhq/mom/cli/internal/herald"
 	"github.com/momhq/mom/cli/internal/librarian"
 )
@@ -45,17 +48,21 @@ func (w *Worker) Log(eventType, sessionID string, payload map[string]any) error 
 // event. Returns the unsubscribe func from Herald — callers may detach
 // the worker without retaining the Bus reference.
 //
-// The handler reads session_id from event.Payload["session_id"] when
-// present; if missing, the row is skipped (the API requires non-empty
-// session_id and a programming-error event without one should not
-// silently land in the stream).
+// SessionID comes from the Event envelope (e.SessionID), set by the
+// producer. An empty SessionID is a programming-error event and is
+// skipped with a stderr log — the schema NOT NULL constraint would
+// reject it anyway, but losing it silently in the audit substrate is
+// the bigger sin. A persistence failure (closed vault, FK error, disk
+// full) is also logged to stderr; we do not silently drop audit data.
 func (w *Worker) Subscribe(bus *herald.Bus, eventType herald.EventType) func() {
 	return bus.Subscribe(eventType, func(e herald.Event) {
-		sessionID := stringField(e.Payload, "session_id")
-		if sessionID == "" {
+		if e.SessionID == "" {
+			fmt.Fprintf(os.Stderr, "logbook: drop %q event with empty session_id\n", e.Type)
 			return
 		}
-		_ = w.Log(string(e.Type), sessionID, e.Payload)
+		if err := w.Log(string(e.Type), e.SessionID, e.Payload); err != nil {
+			fmt.Fprintf(os.Stderr, "logbook: persist %q failed: %v\n", e.Type, err)
+		}
 	})
 }
 
@@ -76,16 +83,4 @@ func (w *Worker) SubscribeAll(bus *herald.Bus, eventTypes ...herald.EventType) f
 // Query reads back rows from the operational stream through Librarian.
 func (w *Worker) Query(filter librarian.OpEventFilter) ([]librarian.OpEvent, error) {
 	return w.lib.QueryOpEvents(filter)
-}
-
-func stringField(m map[string]any, key string) string {
-	if m == nil {
-		return ""
-	}
-	if v, ok := m[key]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
-	}
-	return ""
 }

--- a/cli/internal/logbook/worker_test.go
+++ b/cli/internal/logbook/worker_test.go
@@ -69,10 +69,10 @@ func TestWorker_Subscribe_PersistsPublishedEvents(t *testing.T) {
 	unsub := w.Subscribe(bus, "op.recall.queried")
 	defer unsub()
 
-	bus.Publish("op.recall.queried", map[string]any{
-		"session_id":  "s-test",
-		"query":       "deploy",
-		"max_results": 10,
+	bus.Publish(herald.Event{
+		Type:      "op.recall.queried",
+		SessionID: "s-test",
+		Payload:   map[string]any{"query": "deploy", "max_results": 10},
 	})
 
 	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "op.recall.queried"})
@@ -88,16 +88,19 @@ func TestWorker_Subscribe_PersistsPublishedEvents(t *testing.T) {
 }
 
 func TestWorker_Subscribe_SkipsEventsWithoutSessionID(t *testing.T) {
-	// Events without a session_id field violate the API contract. Rather
-	// than letting the row land with empty session_id (which is also
-	// rejected at the API), the subscriber drops the event silently.
-	// This matches the lesson: empty session_id is always a programming
-	// error and should never appear in the stream.
+	// Events without an envelope SessionID violate the API contract.
+	// Rather than letting the row land with empty session_id (which is
+	// also rejected at the API), the subscriber drops the event and
+	// logs to stderr — empty session_id is always a programming error
+	// and should never appear in the stream.
 	w, lib := openWorker(t)
 	bus := herald.NewBus()
 	defer w.Subscribe(bus, "op.broken")()
 
-	bus.Publish("op.broken", map[string]any{"foo": "bar"})
+	bus.Publish(herald.Event{
+		Type:    "op.broken",
+		Payload: map[string]any{"foo": "bar"},
+	})
 
 	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{})
 	if len(rows) != 0 {
@@ -110,9 +113,9 @@ func TestWorker_Unsubscribe_StopsRecording(t *testing.T) {
 	bus := herald.NewBus()
 	unsub := w.Subscribe(bus, "op.x")
 
-	bus.Publish("op.x", map[string]any{"session_id": "s"})
+	bus.Publish(herald.Event{Type: "op.x", SessionID: "s"})
 	unsub()
-	bus.Publish("op.x", map[string]any{"session_id": "s"})
+	bus.Publish(herald.Event{Type: "op.x", SessionID: "s"})
 
 	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{})
 	if len(rows) != 1 {
@@ -125,10 +128,10 @@ func TestWorker_SubscribeAll_AndCombinedUnsubscribe(t *testing.T) {
 	bus := herald.NewBus()
 	stop := w.SubscribeAll(bus, "op.a", "op.b", "op.c")
 
-	bus.Publish("op.a", map[string]any{"session_id": "s"})
-	bus.Publish("op.b", map[string]any{"session_id": "s"})
-	bus.Publish("op.c", map[string]any{"session_id": "s"})
-	bus.Publish("op.d", map[string]any{"session_id": "s"}) // not subscribed
+	bus.Publish(herald.Event{Type: "op.a", SessionID: "s"})
+	bus.Publish(herald.Event{Type: "op.b", SessionID: "s"})
+	bus.Publish(herald.Event{Type: "op.c", SessionID: "s"})
+	bus.Publish(herald.Event{Type: "op.d", SessionID: "s"}) // not subscribed
 
 	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{})
 	if len(rows) != 3 {
@@ -136,7 +139,7 @@ func TestWorker_SubscribeAll_AndCombinedUnsubscribe(t *testing.T) {
 	}
 
 	stop()
-	bus.Publish("op.a", map[string]any{"session_id": "s"})
+	bus.Publish(herald.Event{Type: "op.a", SessionID: "s"})
 	rows, _ = lib.QueryOpEvents(librarian.OpEventFilter{})
 	if len(rows) != 3 {
 		t.Fatalf("got %d rows after combined unsub, want still 3", len(rows))
@@ -153,7 +156,7 @@ func TestWorker_Subscribe_FanOutWithOtherSubscribers(t *testing.T) {
 	var sibling atomic.Int64
 	bus.Subscribe("op.x", func(e herald.Event) { sibling.Add(1) })
 
-	bus.Publish("op.x", map[string]any{"session_id": "s"})
+	bus.Publish(herald.Event{Type: "op.x", SessionID: "s"})
 
 	if got := sibling.Load(); got != 1 {
 		t.Errorf("sibling handler fired %d times, want 1", got)

--- a/cli/internal/mcp/mom_record.go
+++ b/cli/internal/mcp/mom_record.go
@@ -91,7 +91,11 @@ func (s *Server) toolMomRecord(args map[string]any) (toolCallResult, error) {
 		ProvenanceTriggerEvent: "record",
 	}
 
-	s.bus.Publish(MemoryRecordEventType, payloadAsMap(payload))
+	s.bus.Publish(herald.Event{
+		Type:      MemoryRecordEventType,
+		SessionID: payload.SessionID,
+		Payload:   payloadAsMap(payload),
+	})
 
 	return toolCallResult{
 		Content: []toolContent{{
@@ -157,13 +161,13 @@ func optionalStringSliceArg(args map[string]any, key string) ([]string, error) {
 	return out, nil
 }
 
-// payloadAsMap converts a MemoryRecordPayload to a map for Herald
-// transport. Each Herald event payload is map[string]any per the
-// v1+v0.30 Bus contract; using a typed struct internally keeps the
-// handler readable while the Bus stays type-agnostic.
+// payloadAsMap converts a MemoryRecordPayload to a map for the Herald
+// payload bag. SessionID is NOT included — it lives on the envelope
+// (herald.Event.SessionID), not in the bag. Including it here would
+// duplicate the contract and re-introduce the silent-drop class of
+// bug Theme A retired.
 func payloadAsMap(p MemoryRecordPayload) map[string]any {
 	m := map[string]any{
-		"session_id":               p.SessionID,
 		"content":                  p.Content,
 		"provenance_actor":         p.ProvenanceActor,
 		"provenance_source_type":   p.ProvenanceSourceType,

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -65,8 +65,11 @@ func TestMomRecord_PublishesEventWithNormalizedTags(t *testing.T) {
 	if got.Type != MemoryRecordEventType {
 		t.Errorf("event type = %q, want %q", got.Type, MemoryRecordEventType)
 	}
-	if got.Payload["session_id"] != "s-1" {
-		t.Errorf("session_id = %v", got.Payload["session_id"])
+	if got.SessionID != "s-1" {
+		t.Errorf("session_id = %q, want s-1", got.SessionID)
+	}
+	if _, dup := got.Payload["session_id"]; dup {
+		t.Error("session_id was duplicated into payload bag; should live only on the envelope")
 	}
 	tags, _ := got.Payload["tags"].([]string)
 	want := []string{"v0-30", "mcp"} // normalised

--- a/cli/internal/watcher/watcher.go
+++ b/cli/internal/watcher/watcher.go
@@ -419,12 +419,15 @@ func (w *Watcher) ingestFile(path string) int {
 
 	// Publish to Herald so downstream processors (Logbook, Drafter) run.
 	if len(entries) > 0 && w.cfg.Bus != nil {
-		w.cfg.Bus.Publish(herald.RecordAppended, map[string]any{
-			"transcript_path": path,
-			"session_id":      sessionID,
-			"count":           len(entries),
-			"mom_dir":         w.cfg.MomDir,
-			"runtime":         w.adapterForPath(path).Name(),
+		w.cfg.Bus.Publish(herald.Event{
+			Type:      herald.RecordAppended,
+			SessionID: sessionID,
+			Payload: map[string]any{
+				"transcript_path": path,
+				"count":           len(entries),
+				"mom_dir":         w.cfg.MomDir,
+				"runtime":         w.adapterForPath(path).Name(),
+			},
 		})
 	}
 


### PR DESCRIPTION
## Summary

Theme A from the Phase 1 review pass. Resolves Herald PR #258 F2, Logbook PR #260 F1+F2, and mom_record PR #262 F2 in one change.

## What changes

- **`herald.Event` gains a first-class `SessionID` field.** Producers set it on the envelope; consumers read it from the envelope.
- **`herald.Bus.Publish(eventType, payload)` → `herald.Bus.Publish(Event)`**. Producers construct the full envelope; the bus stamps `Timestamp` (and only the bus stamps it — never overridable, no replay/import override).
- **`mom_record` no longer duplicates `session_id` into the payload bag.** Lives only on the envelope.
- **Logbook's `Worker.Subscribe` reads `e.SessionID` directly.** `stringField` helper deleted.
- **Logbook stops swallowing errors silently.** Empty `SessionID` and DB write failures both log to stderr now — the audit substrate honestly reports its own gaps instead of pretending nothing happened.
- **`watcher` publishes the new envelope shape** with session_id lifted out of the bag.

## Why no backwards-compat shim

Pre-alpha + on-prem; two production call sites (watcher, mom_record); both updated here. Keeping the old signature alongside would just hedge against a problem we don't have.

## Test plan

- [x] `go test ./...` — full repo green
- [x] `go test -race ./internal/herald/ ./internal/logbook/ ./internal/mcp/` — race-clean
- [x] mom_record test asserts session_id is on the envelope AND NOT duplicated into the payload bag
- [x] Logbook's "skip events without session_id" test exercises the envelope-empty case
- [x] All existing tests updated to the new `Publish(Event)` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)