### PR TITLE
refactor: lock stderr observability + Vault ErrClosed (Theme B)

### DIFF
--- a/cli/internal/herald/herald.go
+++ b/cli/internal/herald/herald.go
@@ -3,6 +3,7 @@ package herald
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 )
@@ -137,7 +138,11 @@ func (b *Bus) Publish(e Event) {
 func invoke(eventType EventType, event Event, h Handler) {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Fprintf(os.Stderr, "herald: handler for %q panicked: %v\n", eventType, r)
+			// Include the goroutine stack so a recovered panic is
+			// debuggable from a single log line. One-line panics are
+			// brittle when the failure mode is "which subscriber blew
+			// up and why."
+			fmt.Fprintf(os.Stderr, "herald: handler for %q panicked: %v\n%s\n", eventType, r, debug.Stack())
 		}
 	}()
 	h(event)

--- a/cli/internal/herald/stderr_capture_test.go
+++ b/cli/internal/herald/stderr_capture_test.go
@@ -1,0 +1,86 @@
+package herald
+
+import (
+	"io"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// captureStderr redirects os.Stderr to a pipe for the duration of fn,
+// then restores it and returns whatever was written. Used to lock the
+// "logs to stderr" contract for handler-panic recovery.
+//
+// The redirect mutates a process-global, so this helper assumes the
+// caller does not run in parallel with other code that writes to
+// stderr. Tests using it should not call t.Parallel().
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+// TestPublish_HandlerPanic_LogsToStderrWithStack locks the contract
+// that recovered panics are visible (line + stack), not just absorbed.
+// Without this test, a future refactor that drops the log line would
+// pass — TestPublish_HandlerPanicDoesNotBlockOthers only verifies
+// fan-out, not visibility.
+func TestPublish_HandlerPanic_LogsToStderrWithStack(t *testing.T) {
+	bus := NewBus()
+	var sentinel atomic.Int64
+	bus.Subscribe(Error, func(e Event) { panic("specific-panic-marker-x42") })
+	bus.Subscribe(Error, func(e Event) { sentinel.Add(1) })
+
+	captured := captureStderr(t, func() {
+		bus.Publish(Event{Type: Error, SessionID: "s"})
+	})
+
+	// Sibling handler still fires.
+	if got := sentinel.Load(); got != 1 {
+		t.Errorf("sibling handler fired %d times, want 1", got)
+	}
+
+	// Stderr contains the panic value, the event type, and a stack frame.
+	if !strings.Contains(captured, `herald: handler for "error" panicked`) {
+		t.Errorf("missing panic prefix in stderr:\n%s", captured)
+	}
+	if !strings.Contains(captured, "specific-panic-marker-x42") {
+		t.Errorf("missing panic value in stderr:\n%s", captured)
+	}
+	if !strings.Contains(captured, "goroutine ") {
+		t.Errorf("missing goroutine stack in stderr:\n%s", captured)
+	}
+}
+
+// TestPublish_NoPanic_NoStderr locks the inverse: a normal publish
+// produces zero stderr output. Catches a future bug where a debug log
+// is left in the hot path.
+func TestPublish_NoPanic_NoStderr(t *testing.T) {
+	bus := NewBus()
+	bus.Subscribe(SessionStart, func(e Event) {})
+
+	captured := captureStderr(t, func() {
+		bus.Publish(Event{Type: SessionStart, SessionID: "s"})
+	})
+
+	if captured != "" {
+		t.Errorf("expected no stderr output for normal publish, got:\n%s", captured)
+	}
+}

--- a/cli/internal/logbook/stderr_capture_test.go
+++ b/cli/internal/logbook/stderr_capture_test.go
@@ -1,0 +1,115 @@
+package logbook_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/momhq/mom/cli/internal/logbook"
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// captureStderr is the same pattern as herald's; duplicated per
+// package so the helper stays test-local. See herald/stderr_capture_test.go.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+// TestWorker_Subscribe_LogsToStderr_OnEmptySessionID locks the
+// contract that empty SessionID produces a stderr log, not a silent
+// drop. The original Logbook regression was silent loss of audit
+// data; visibility of the gap is the actual fix.
+func TestWorker_Subscribe_LogsToStderr_OnEmptySessionID(t *testing.T) {
+	w, _ := openWorker(t)
+	bus := herald.NewBus()
+	defer w.Subscribe(bus, "op.broken")()
+
+	captured := captureStderr(t, func() {
+		bus.Publish(herald.Event{
+			Type:    "op.broken",
+			Payload: map[string]any{"foo": "bar"},
+		})
+	})
+
+	if !strings.Contains(captured, "logbook: drop") {
+		t.Errorf("missing logbook drop log in stderr:\n%s", captured)
+	}
+	if !strings.Contains(captured, "op.broken") {
+		t.Errorf("missing event type in stderr:\n%s", captured)
+	}
+	if !strings.Contains(captured, "session_id") {
+		t.Errorf("stderr should mention the reason (empty session_id):\n%s", captured)
+	}
+}
+
+// TestWorker_Subscribe_LogsToStderr_OnPersistFailure locks the
+// contract that a Librarian write failure inside the subscriber is
+// reported to stderr, not swallowed. Forces failure by using a
+// Librarian whose underlying vault was closed BEFORE the publish.
+func TestWorker_Subscribe_LogsToStderr_OnPersistFailure(t *testing.T) {
+	dir := t.TempDir()
+	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	lib := librarian.New(v)
+	w := logbook.New(lib)
+
+	bus := herald.NewBus()
+	defer w.Subscribe(bus, "op.x")()
+
+	// Close the vault out from under the worker so the next persist
+	// fails. This simulates "vault unavailable" without manufacturing
+	// a fault-injection path.
+	if err := v.Close(); err != nil {
+		t.Fatalf("v.Close: %v", err)
+	}
+
+	captured := captureStderr(t, func() {
+		bus.Publish(herald.Event{Type: "op.x", SessionID: "s"})
+	})
+
+	if !strings.Contains(captured, "logbook: persist") {
+		t.Errorf("missing persist-failure log in stderr:\n%s", captured)
+	}
+	if !strings.Contains(captured, "op.x") {
+		t.Errorf("missing event type in stderr:\n%s", captured)
+	}
+}
+
+// TestWorker_Log_DirectErrorReturn ensures Worker.Log itself still
+// returns the error to direct callers — only the Subscribe path
+// converts errors to stderr (because the publisher has no return to
+// surface them on). Direct callers must still be able to handle
+// errors.Is(err, librarian.ErrEmptyArg) etc.
+func TestWorker_Log_DirectErrorReturn(t *testing.T) {
+	w, _ := openWorker(t)
+	err := w.Log("", "s", nil)
+	if !errors.Is(err, librarian.ErrEmptyArg) {
+		t.Fatalf("Worker.Log direct call: err = %v, want ErrEmptyArg", err)
+	}
+}

--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -12,6 +12,7 @@ package vault
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -19,6 +20,12 @@ import (
 
 	_ "modernc.org/sqlite"
 )
+
+// ErrClosed is returned by Tx and Query when called on a Vault whose
+// Close has already run. Defends against nil-pointer panics in the
+// underlying *sql.DB; callers that hold a stale Vault reference get a
+// clear error rather than a stack trace.
+var ErrClosed = errors.New("vault: closed")
 
 // Migration is one applied schema change identified by a strictly
 // increasing integer version. Stmts run as a single transaction; either
@@ -170,7 +177,12 @@ func (v *Vault) migrate(migrations []Migration) error {
 // Query runs a read-only query and invokes scan with the resulting
 // rows. Vault closes the *sql.Rows after scan returns. Callers never
 // see *sql.DB.
+//
+// Returns ErrClosed if Close has already run on the Vault.
 func (v *Vault) Query(query string, args []any, scan func(*sql.Rows) error) error {
+	if v.db == nil {
+		return ErrClosed
+	}
 	rows, err := v.db.Query(query, args...)
 	if err != nil {
 		return err
@@ -186,7 +198,12 @@ func (v *Vault) Query(query string, args []any, scan func(*sql.Rows) error) erro
 // return; any non-nil error rolls it back and is returned to the
 // caller. A panic in fn rolls the transaction back and re-panics.
 // Callers receive a *sql.Tx but never *sql.DB.
+//
+// Returns ErrClosed if Close has already run on the Vault.
 func (v *Vault) Tx(fn func(*sql.Tx) error) (err error) {
+	if v.db == nil {
+		return ErrClosed
+	}
 	tx, err := v.db.Begin()
 	if err != nil {
 		return err

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -337,3 +337,21 @@ func TestClose_isIdempotent(t *testing.T) {
 		t.Fatalf("second Close: %v", err)
 	}
 }
+
+// TestUseAfterClose_ReturnsErrClosedNotPanic locks the contract that
+// using a closed Vault returns vault.ErrClosed instead of nil-pointer
+// panicking through the underlying *sql.DB. Callers that hold a stale
+// Vault (e.g., via a Librarian) get a recoverable error.
+func TestUseAfterClose_ReturnsErrClosedNotPanic(t *testing.T) {
+	v, _ := openTempVault(t, nil)
+	if err := v.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := v.Tx(func(tx *sql.Tx) error { return nil }); !errors.Is(err, vault.ErrClosed) {
+		t.Errorf("Tx after Close: err = %v, want ErrClosed", err)
+	}
+	if err := v.Query(`SELECT 1`, nil, func(*sql.Rows) error { return nil }); !errors.Is(err, vault.ErrClosed) {
+		t.Errorf("Query after Close: err = %v, want ErrClosed", err)
+	}
+}


### PR DESCRIPTION
## Summary

Theme B from the Phase 1 review pass. Three tightening changes:

1. **Herald's recovered-panic log includes `debug.Stack()`.** One-line panic logs were brittle (PR #258 F3).

2. **Stderr contract is now locked by tests.** Capture `os.Stderr` via `os.Pipe`, assert line shape. Three contracts now tested:
   - Herald: panic-handler emits `"herald: handler for X panicked"` + goroutine stack
   - Logbook: empty SessionID emits `"logbook: drop X event with empty session_id"`
   - Logbook: persist failure emits `"logbook: persist X failed: ..."`
   - Inverse: normal publish emits no stderr (catches accidental debug logs)

3. **Vault gains `ErrClosed`.** `Tx` and `Query` on a closed Vault now return `vault.ErrClosed` instead of nil-pointer panicking through `*sql.DB`. Surfaced while writing the Logbook persist-failure test — the closed-vault scenario panicked through Herald's handler recovery, bypassing the err-return path that Worker.Subscribe needs to surface to stderr. Now: `Vault.Close → Tx returns ErrClosed → Worker.Log returns error → Subscribe logs to stderr.`

## Why this matters

Without these tests, a future refactor that drops a log line passes silently — exactly the silent-data-loss class of bug we fixed in Theme A. The contracts are documented; now they're enforced.

## Test plan

- [x] `go test ./...` — full repo green
- [x] `go test -race ./internal/vault/ ./internal/herald/ ./internal/logbook/` — race-clean
- [x] 6 new test cases (Herald: 2; Logbook: 3; Vault: 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)