### PR TITLE
refactor: shared archtest helper for import-graph rules (Theme C)

### DIFF
--- a/cli/internal/archtest/archtest.go
+++ b/cli/internal/archtest/archtest.go
@@ -1,0 +1,88 @@
+// Package archtest provides shared helpers for in-process
+// architectural rule tests. It avoids the `exec.Command("go", "list",
+// ...)` pattern so tests don't depend on the go toolchain being on
+// $PATH at test time.
+//
+// The helpers parse a package's .go files (production sources only —
+// _test.go files are excluded so test imports don't trip arch rules)
+// and return the import set declared by `import (...)` clauses.
+//
+// Only direct imports are reported. The v0.30 architecture rules are
+// shaped as direct-import constraints: "X must not import Y," where
+// "import" means the textual import declaration. Transitive deps are
+// not in scope — callers wanting that should iterate.
+package archtest
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// DirectImports returns the union of all imports declared by .go files
+// in pkgDir, excluding _test.go files. Paths are unquoted ("foo/bar",
+// not `"foo/bar"`) and deduplicated.
+//
+// pkgDir is a filesystem path (typically obtained via a relative
+// path like "../herald" from the test file's location, or from
+// os.Getwd() + "/.." + sibling).
+func DirectImports(t *testing.T, pkgDir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		t.Fatalf("archtest: read %s: %v", pkgDir, err)
+	}
+
+	seen := map[string]struct{}{}
+	fset := token.NewFileSet()
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(pkgDir, name)
+		f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("archtest: parse %s: %v", path, err)
+		}
+		for _, imp := range f.Imports {
+			p, err := strconv.Unquote(imp.Path.Value)
+			if err != nil {
+				t.Fatalf("archtest: unquote %s in %s: %v", imp.Path.Value, path, err)
+			}
+			seen[p] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	return out
+}
+
+// AssertNoDirectImport fails t if pkgDir's direct imports contain any
+// of forbidden. It is the canonical shape for v0.30 architectural
+// rules: "package X must not directly import Y."
+//
+// Use one call per arch rule per package. If the same package has
+// multiple distinct rules, multiple calls keep failure messages
+// targeted.
+func AssertNoDirectImport(t *testing.T, pkgDir string, forbidden ...string) {
+	t.Helper()
+	imports := DirectImports(t, pkgDir)
+	bad := map[string]struct{}{}
+	for _, f := range forbidden {
+		bad[f] = struct{}{}
+	}
+	for _, imp := range imports {
+		if _, ok := bad[imp]; ok {
+			t.Errorf("forbidden direct import %q in %s", imp, pkgDir)
+		}
+	}
+}

--- a/cli/internal/archtest/archtest_test.go
+++ b/cli/internal/archtest/archtest_test.go
@@ -1,0 +1,73 @@
+package archtest_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/archtest"
+)
+
+// fixtureDir writes a tiny package with a known import set into a
+// fresh temp dir and returns the dir path.
+func fixtureDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func TestDirectImports_ReportsAllProductionFileImports(t *testing.T) {
+	dir := fixtureDir(t, map[string]string{
+		"a.go": `package fx; import "fmt"; var _ = fmt.Sprint`,
+		"b.go": `package fx; import "errors"; var _ = errors.New`,
+	})
+
+	got := archtest.DirectImports(t, dir)
+	if !slices.Contains(got, "fmt") || !slices.Contains(got, "errors") {
+		t.Errorf("got %v, want fmt and errors", got)
+	}
+}
+
+// TestDirectImports_ExcludesTestFiles is the contract that lets us
+// import "testing" from _test.go files without tripping arch rules
+// against production sources.
+func TestDirectImports_ExcludesTestFiles(t *testing.T) {
+	dir := fixtureDir(t, map[string]string{
+		"a.go":      `package fx; import "fmt"; var _ = fmt.Sprint`,
+		"a_test.go": `package fx; import "testing"; func TestX(t *testing.T) {}`,
+	})
+
+	got := archtest.DirectImports(t, dir)
+	if slices.Contains(got, "testing") {
+		t.Errorf("testing should be excluded (it lives only in _test.go); got %v", got)
+	}
+	if !slices.Contains(got, "fmt") {
+		t.Errorf("fmt should be present (production source); got %v", got)
+	}
+}
+
+// TestDirectImports_DeduplicatesAcrossFiles ensures the same import
+// in two files surfaces once.
+func TestDirectImports_DeduplicatesAcrossFiles(t *testing.T) {
+	dir := fixtureDir(t, map[string]string{
+		"a.go": `package fx; import "fmt"; var _ = fmt.Sprint`,
+		"b.go": `package fx; import "fmt"; var _ = fmt.Println`,
+	})
+
+	got := archtest.DirectImports(t, dir)
+	count := 0
+	for _, p := range got {
+		if p == "fmt" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("fmt appeared %d times, want 1 (dedupe failed)", count)
+	}
+}

--- a/cli/internal/finder/finder_test.go
+++ b/cli/internal/finder/finder_test.go
@@ -2,11 +2,11 @@ package finder_test
 
 import (
 	"errors"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/momhq/mom/cli/internal/archtest"
 	"github.com/momhq/mom/cli/internal/finder"
 	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/logbook"
@@ -282,16 +282,7 @@ func TestRecall_BM25HeavierOnContentThanSummary(t *testing.T) {
 // Librarian." Direct-import only — transitive through Librarian is
 // expected.
 func TestFinder_DoesNotImportVault(t *testing.T) {
-	cmd := exec.Command("go", "list",
-		"-f", "{{range .Imports}}{{.}}\n{{end}}",
-		"github.com/momhq/mom/cli/internal/finder")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("go list failed: %v\n%s", err, out)
-	}
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line == "github.com/momhq/mom/cli/internal/vault" {
-			t.Errorf("finder imports vault directly; must go through librarian")
-		}
-	}
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/cli/internal/vault",
+	)
 }

--- a/cli/internal/herald/bus_v030_test.go
+++ b/cli/internal/herald/bus_v030_test.go
@@ -1,11 +1,11 @@
 package herald
 
 import (
-	"os/exec"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/momhq/mom/cli/internal/archtest"
 )
 
 // These tests lock the v0.30 Herald contract on top of the existing v1
@@ -146,29 +146,13 @@ func TestSubscribe_ConcurrentUnsubscribeIsRaceFree(t *testing.T) {
 	wg.Wait()
 }
 
-// TestHerald_NoVaultOrLibrarianDependency enforces the architectural rule
-// (PRD 0003): Herald is a pure pub/sub bus and must NEVER import the Vault
-// or Librarian packages. The dep is checked via `go list` so the test fails
-// fast when a future change introduces a forbidden import.
+// TestHerald_NoVaultOrLibrarianDependency enforces PRD 0003: Herald
+// is a pure pub/sub bus and must not import Vault or Librarian.
+// Herald's only imports are stdlib, so a direct-import check is
+// sufficient — there's no transitive path in production code.
 func TestHerald_NoVaultOrLibrarianDependency(t *testing.T) {
-	cmd := exec.Command("go", "list", "-deps",
-		"-f", "{{.ImportPath}}",
-		"github.com/momhq/mom/cli/internal/herald")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("go list failed: %v\n%s", err, out)
-	}
-
-	forbidden := []string{
+	archtest.AssertNoDirectImport(t, ".",
 		"github.com/momhq/mom/cli/internal/vault",
 		"github.com/momhq/mom/cli/internal/librarian",
-	}
-
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		for _, f := range forbidden {
-			if line == f {
-				t.Errorf("herald imports forbidden package: %s", f)
-			}
-		}
-	}
+	)
 }

--- a/cli/internal/logbook/worker_test.go
+++ b/cli/internal/logbook/worker_test.go
@@ -2,12 +2,11 @@ package logbook_test
 
 import (
 	"errors"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/momhq/mom/cli/internal/archtest"
 	"github.com/momhq/mom/cli/internal/herald"
 	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/logbook"
@@ -165,24 +164,10 @@ func TestWorker_Subscribe_FanOutWithOtherSubscribers(t *testing.T) {
 
 // TestLogbook_DoesNotImportVault enforces the architectural rule:
 // Logbook is a worker that goes through Librarian; only Librarian
-// touches the Vault package.
-//
-// `go list` without `-deps` returns the package's DIRECT imports only;
-// vault appearing here would mean logbook reaches around librarian
-// instead of through it. Transitive imports (logbook → librarian →
-// vault) are expected and not flagged.
+// touches Vault. Direct-import only — transitive (logbook → librarian
+// → vault) is expected.
 func TestLogbook_DoesNotImportVault(t *testing.T) {
-	cmd := exec.Command("go", "list",
-		"-f", "{{range .Imports}}{{.}}\n{{end}}",
-		"github.com/momhq/mom/cli/internal/logbook")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("go list failed: %v\n%s", err, out)
-	}
-
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line == "github.com/momhq/mom/cli/internal/vault" {
-			t.Errorf("logbook imports vault directly; must go through librarian")
-		}
-	}
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/cli/internal/vault",
+	)
 }


### PR DESCRIPTION
## Summary

Theme C from the Phase 1 review pass. Three packages had near-identical `exec.Command("go", "list", ...)` tests enforcing architectural rules; consolidates them into `cli/internal/archtest/`.

## Rationale

- **Removed go-toolchain dependency at test time.** Stdlib-only (`go/parser`).
- **Reduced per-package boilerplate from 15–25 lines to 1–2.**
- **Established the pattern before #240.** Drafter will need its own arch rule ("must not import Finder", etc.); now it's a one-liner instead of another copy-paste.
- **Self-tested.** The helper's own contract has tests — without them, archtest could silently become a no-op (worst kind of arch test).

## What's in the helper

- `DirectImports(t, pkgDir) []string` — parses production .go files (excludes `_test.go`), returns deduplicated import set.
- `AssertNoDirectImport(t, pkgDir, forbidden...)` — canonical rule shape.

## Why direct-only (not transitive)

- Herald is a leaf in production code (stdlib only) → direct-import check suffices for its "no vault/librarian" rule.
- Logbook and Finder always wanted direct-only — transitive through Librarian is the intended path.
- If a future rule needs transitive enforcement, archtest extends.

## Test plan

- [x] 3 self-tests on archtest (multi-file aggregation, _test.go exclusion, dedupe)
- [x] All 3 existing arch tests still pass with the new helper
- [x] `go test ./...` — full repo green
- [x] `go test -race ./internal/archtest/ ./internal/herald/ ./internal/logbook/ ./internal/finder/` — race-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)