### PR TITLE
schema: tighten migrations 2 + 3 — CHECKs, indexes, ON DELETE CASCADE (Theme D)

### DIFF
--- a/cli/internal/librarian/librarian.go
+++ b/cli/internal/librarian/librarian.go
@@ -214,6 +214,32 @@ type OperationalUpdate struct {
 	CentralityScore *float64
 }
 
+// Delete removes a memory by id. ON DELETE CASCADE on memory_tags
+// and memory_entities (per migration 2) cleans up edges
+// automatically; tag and entity rows themselves are untouched.
+//
+// Returns ErrNotFound if no memory matches. Substance is gone after
+// this call — there is no recovery.
+func (l *Librarian) Delete(id string) error {
+	if strings.TrimSpace(id) == "" {
+		return fmt.Errorf("Delete: id: %w", ErrEmptyArg)
+	}
+	return l.v.Tx(func(tx *sql.Tx) error {
+		res, err := tx.Exec(`DELETE FROM memories WHERE id = ?`, id)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
 // UpdateOperational mutates only the operational columns of a memory.
 // Substance columns are unreachable through this API. Empty patches
 // are a no-op success.

--- a/cli/internal/librarian/migrations.go
+++ b/cli/internal/librarian/migrations.go
@@ -30,9 +30,19 @@ func Migrations() []vault.Migration {
 		{
 			Version: 2,
 			Stmts: []string{
+				// type is locked to the Tulving typology (ADR 0012). The
+				// set is intentionally small — adding a fifth value is a
+				// deliberate ADR amendment, not a typo. Defense in depth:
+				// API rejects invalid types; schema rejects again.
+				//
+				// promotion_state is locked to the v0.30 lifecycle
+				// (ADR 0011). 'archived', 'deprecated', and any other
+				// future states need a deliberate schema change. Same
+				// defense.
 				`CREATE TABLE memories (
 					id                       TEXT PRIMARY KEY,
-					type                     TEXT NOT NULL DEFAULT 'untyped',
+					type                     TEXT NOT NULL DEFAULT 'untyped'
+					                         CHECK (type IN ('episodic','semantic','procedural','untyped')),
 					summary                  TEXT,
 					content                  TEXT NOT NULL CHECK (json_valid(content)),
 					created_at               TEXT NOT NULL,
@@ -40,10 +50,18 @@ func Migrations() []vault.Migration {
 					provenance_actor         TEXT,
 					provenance_source_type   TEXT,
 					provenance_trigger_event TEXT,
-					promotion_state          TEXT NOT NULL DEFAULT 'draft',
+					promotion_state          TEXT NOT NULL DEFAULT 'draft'
+					                         CHECK (promotion_state IN ('draft','curated')),
 					landmark                 INTEGER NOT NULL DEFAULT 0,
 					centrality_score         REAL
 				)`,
+				// session_id is the most-filtered dimension after id
+				// (PK). created_at is the natural sort key for tag /
+				// entity listings — composite (created_at DESC, id DESC)
+				// matches MemoriesByTag / MemoriesByEntity ORDER BY
+				// exactly.
+				`CREATE INDEX idx_memories_session ON memories(session_id)`,
+				`CREATE INDEX idx_memories_created ON memories(created_at DESC, id DESC)`,
 				`CREATE TABLE tags (
 					id         TEXT PRIMARY KEY,
 					name       TEXT NOT NULL UNIQUE,
@@ -56,12 +74,22 @@ func Migrations() []vault.Migration {
 					created_at   TEXT NOT NULL,
 					UNIQUE (type, display_name)
 				)`,
+				// ON DELETE CASCADE on memory_id columns: deleting a
+				// memory cleans up its edges automatically. The semantic
+				// of "delete the memory" includes its associations —
+				// they cease to exist when the memory does. Cartographer
+				// regen and Upgrade rollback rely on this.
+				//
+				// Tag/entity rows do NOT cascade — deleting a tag with
+				// edges should be an explicit MergeTags or a deliberate
+				// orphan cleanup, never a silent edge-wipe. Default
+				// RESTRICT is correct.
 				`CREATE TABLE memory_tags (
 					memory_id  TEXT NOT NULL,
 					tag_id     TEXT NOT NULL,
 					created_at TEXT NOT NULL,
 					PRIMARY KEY (memory_id, tag_id),
-					FOREIGN KEY (memory_id) REFERENCES memories(id),
+					FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE,
 					FOREIGN KEY (tag_id)    REFERENCES tags(id)
 				)`,
 				`CREATE TABLE memory_entities (
@@ -70,7 +98,7 @@ func Migrations() []vault.Migration {
 					relationship TEXT NOT NULL,
 					created_at   TEXT NOT NULL,
 					PRIMARY KEY (memory_id, entity_id, relationship),
-					FOREIGN KEY (memory_id) REFERENCES memories(id),
+					FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE,
 					FOREIGN KEY (entity_id) REFERENCES entities(id)
 				)`,
 				`CREATE TABLE filter_audit (
@@ -79,12 +107,12 @@ func Migrations() []vault.Migration {
 					last_fired_at   TEXT
 				)`,
 				// FTS5 over memories. content_text is extracted from the
-				// JSON content's $.text field by the sync triggers below.
-				// Per ADR 0007 the column weights apply at query time:
-				// bm25(memories_fts, 0, 2, 10) — zero on id (opaque UUID),
-				// light on summary, heavy on content. Tags are not in
-				// FTS5 in v0.30; tag-based recall uses SQL joins on
-				// memory_tags (ADR 0010).
+				// JSON content's $.text field by the sync triggers
+				// below. Per ADR 0007 the column weights apply at query
+				// time: bm25(memories_fts, 0, 2, 10) — zero on id
+				// (opaque UUID), light on summary, heavy on content.
+				// Tags are not in FTS5 in v0.30; tag-based recall uses
+				// SQL joins on memory_tags (ADR 0010).
 				`CREATE VIRTUAL TABLE memories_fts USING fts5(
 					id UNINDEXED,
 					summary,

--- a/cli/internal/librarian/schema_constraints_test.go
+++ b/cli/internal/librarian/schema_constraints_test.go
@@ -1,0 +1,133 @@
+package librarian_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/librarian"
+)
+
+// TestSchemaCHECK_RejectsInvalidType locks the ADR 0012 vocabulary at
+// the schema level. Even if Librarian's Insert ever stops validating
+// Type at the API layer, the schema CHECK is the second line of
+// defense — typos and unknown values fail fast.
+func TestSchemaCHECK_RejectsInvalidType(t *testing.T) {
+	l := openLib(t)
+
+	in := validInsert()
+	in.Type = "fictional-type"
+	_, err := l.Insert(in)
+	if err == nil {
+		t.Fatal("expected CHECK violation for invalid type, got nil")
+	}
+	if !strings.Contains(err.Error(), "CHECK") && !strings.Contains(err.Error(), "constraint") {
+		t.Fatalf("expected CHECK/constraint error, got: %v", err)
+	}
+}
+
+func TestSchemaCHECK_AcceptsAllADR0012Types(t *testing.T) {
+	for _, tt := range []string{"episodic", "semantic", "procedural", "untyped"} {
+		t.Run(tt, func(t *testing.T) {
+			l := openLib(t)
+			in := validInsert()
+			in.Type = tt
+			if _, err := l.Insert(in); err != nil {
+				t.Fatalf("type=%q rejected unexpectedly: %v", tt, err)
+			}
+		})
+	}
+}
+
+// TestSchemaCHECK_RejectsInvalidPromotionState locks the ADR 0011
+// vocabulary at the schema level. UpdateOperational doesn't validate
+// the value at the API today, so the schema CHECK is the only
+// enforcement — makes the contract honest.
+func TestSchemaCHECK_RejectsInvalidPromotionState(t *testing.T) {
+	l := openLib(t)
+	id, err := l.Insert(validInsert())
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	bad := "archived" // valid v0.X word, NOT in v0.30 vocabulary
+	err = l.UpdateOperational(id, librarian.OperationalUpdate{PromotionState: &bad})
+	if err == nil {
+		t.Fatal("expected CHECK violation for promotion_state=archived, got nil")
+	}
+	if !strings.Contains(err.Error(), "CHECK") && !strings.Contains(err.Error(), "constraint") {
+		t.Fatalf("expected CHECK/constraint error, got: %v", err)
+	}
+}
+
+func TestSchemaCHECK_AcceptsADR0011PromotionStates(t *testing.T) {
+	l := openLib(t)
+	for _, ps := range []string{"draft", "curated"} {
+		id, err := l.Insert(validInsert())
+		if err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+		state := ps
+		if err := l.UpdateOperational(id, librarian.OperationalUpdate{PromotionState: &state}); err != nil {
+			t.Errorf("promotion_state=%q rejected unexpectedly: %v", ps, err)
+		}
+	}
+}
+
+// TestDelete_CascadesEdges_ButLeavesTagAndEntityIntact locks the
+// ON DELETE CASCADE behavior on memory_tags and memory_entities.
+// Cartographer regen and Upgrade rollback rely on this. The cascade
+// must NOT touch the tag or entity rows themselves — those stay for
+// other memories that may still reference them.
+func TestDelete_CascadesEdges_ButLeavesTagAndEntityIntact(t *testing.T) {
+	l := openLib(t)
+
+	// Two memories share the same tag and entity — proves edges
+	// cascade per-memory, not by tag/entity-wide cleanup.
+	a, _ := l.Insert(validInsert())
+	b, _ := l.Insert(validInsert())
+	tid, _ := l.UpsertTag("recall")
+	eid, _ := l.UpsertEntity("user", "Alice")
+	_ = l.LinkTag(a, tid)
+	_ = l.LinkTag(b, tid)
+	_ = l.LinkEntity(a, eid, "created_by")
+	_ = l.LinkEntity(b, eid, "created_by")
+
+	// Delete only memory A.
+	if err := l.Delete(a); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// A's edges are gone; B's edges remain.
+	gotByTag, _ := l.MemoriesByTag("recall")
+	if len(gotByTag) != 1 || gotByTag[0] != b {
+		t.Errorf("post-delete MemoriesByTag = %v, want [%q]", gotByTag, b)
+	}
+	gotByEntity, _ := l.MemoriesByEntity("user", "Alice")
+	if len(gotByEntity) != 1 || gotByEntity[0] != b {
+		t.Errorf("post-delete MemoriesByEntity = %v, want [%q]", gotByEntity, b)
+	}
+
+	// Memory A is gone.
+	if _, err := l.Get(a); !errors.Is(err, librarian.ErrNotFound) {
+		t.Errorf("Get(a) after delete: err = %v, want ErrNotFound", err)
+	}
+	// Memory B still readable.
+	if _, err := l.Get(b); err != nil {
+		t.Errorf("Get(b) after delete of a: %v", err)
+	}
+}
+
+func TestDelete_RejectsEmptyID(t *testing.T) {
+	l := openLib(t)
+	if err := l.Delete(""); !errors.Is(err, librarian.ErrEmptyArg) {
+		t.Fatalf("err = %v, want ErrEmptyArg", err)
+	}
+}
+
+func TestDelete_NotFoundForUnknownID(t *testing.T) {
+	l := openLib(t)
+	if err := l.Delete("nope"); !errors.Is(err, librarian.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/cli/internal/logbook/migrations_v030.go
+++ b/cli/internal/logbook/migrations_v030.go
@@ -22,9 +22,16 @@ func Migrations() []librarian.Migration {
 					created_at  TEXT NOT NULL,
 					payload     TEXT
 				)`,
-				`CREATE INDEX idx_op_events_type    ON op_events(event_type)`,
-				`CREATE INDEX idx_op_events_session ON op_events(session_id)`,
-				`CREATE INDEX idx_op_events_created ON op_events(created_at)`,
+				// idx_op_events_type serves cross-session queries
+				// ("all events of type X"). idx_op_events_session_time
+				// is composite — its leading column matches "events
+				// for session X" alone, and the trailing created_at
+				// DESC matches "events for session X in last N hours,"
+				// the most common mom lens query. Single-column
+				// indexes on session_id and created_at would each be
+				// subsumed by this composite or rarely queried alone.
+				`CREATE INDEX idx_op_events_type         ON op_events(event_type)`,
+				`CREATE INDEX idx_op_events_session_time ON op_events(session_id, created_at DESC)`,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Theme D from the Phase 1 review pass. Five schema tightenings while we still can:

| # | Change | Why |
|---|---|---|
| 1 | `CHECK (type IN (...))` on `memories` | Locks ADR 0012 vocabulary at the schema |
| 2 | `CHECK (promotion_state IN (...))` on `memories` | Locks ADR 0011 lifecycle |
| 3 | `idx_memories_session` | Finder's session-narrowing stops scanning |
| 4 | `idx_memories_created` (composite, DESC) | Matches MemoriesByTag/Entity ORDER BY |
| 5 | `ON DELETE CASCADE` on `memory_tags(memory_id)` + `memory_entities(memory_id)` | Cartographer regen / Upgrade rollback semantics |
| 6 | Composite `idx_op_events_session_time` replaces single-column session/created indexes | Most common `mom lens` query |

## Bonus: `Librarian.Delete(id)`

Public API for memory deletion — needed to observe the cascade behavior, will be used by Cartographer regen and Upgrade rollback. Validates non-empty id, returns `ErrNotFound` on miss.

## Test plan

- [x] CHECK rejects invalid type / promotion_state
- [x] CHECK accepts every value in the ADR vocabularies (sub-tests)
- [x] Delete cascade: two memories share a tag + entity; deleting one wipes its edges; the other's edges survive; tag and entity rows themselves stay intact
- [x] Delete API boundary: empty id → ErrEmptyArg; unknown id → ErrNotFound
- [x] `go test ./...` — full repo green
- [x] `go test -race ./internal/librarian/ ./internal/logbook/ ./internal/finder/` — race-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)