### PR TITLE
fix: critical correctness — UpsertTag race, Finder duplicate query, empty-tag rejection (Theme E)

### DIFF
--- a/cli/internal/finder/finder.go
+++ b/cli/internal/finder/finder.go
@@ -127,6 +127,14 @@ func (f *Finder) Recall(opts Options) ([]Result, error) {
 		}
 	}
 
+	// Track the most-recent (widest) results so we can return them on
+	// natural loop exit without re-running SearchMemories. The
+	// previous shape ran the last pass twice in the all-thin case —
+	// wasted query plus a race window between the two calls.
+	var (
+		lastHits []librarian.SearchedMemory
+		lastTier string
+	)
 	for _, p := range passes {
 		hits, err := f.lib.SearchMemories(librarian.SearchFilter{
 			FTSQuery:       p.ftsQ,
@@ -141,24 +149,11 @@ func (f *Finder) Recall(opts Options) ([]Result, error) {
 		if len(hits) >= f.thresholdLow || len(hits) >= limit {
 			return resultsFrom(hits, p.tier), nil
 		}
-		// Keep going — this pass yielded too few. Last pass returns
-		// whatever it has even if below threshold.
+		lastHits, lastTier = hits, p.tier
+		// Keep going — this pass yielded too few. The natural exit
+		// path returns these last (widest) results.
 	}
-
-	// All passes exhausted; return the last (widest) result, even if
-	// short of the threshold. (We keep its tier label.)
-	last := passes[len(passes)-1]
-	hits, err := f.lib.SearchMemories(librarian.SearchFilter{
-		FTSQuery:       last.ftsQ,
-		Tags:           opts.Tags,
-		SessionID:      opts.SessionID,
-		PromotionState: last.state,
-		Limit:          limit,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return resultsFrom(hits, last.tier), nil
+	return resultsFrom(lastHits, lastTier), nil
 }
 
 func resultsFrom(hits []librarian.SearchedMemory, tier string) []Result {

--- a/cli/internal/finder/finder_correctness_test.go
+++ b/cli/internal/finder/finder_correctness_test.go
@@ -1,0 +1,88 @@
+package finder_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/finder"
+	"github.com/momhq/mom/cli/internal/librarian"
+)
+
+// TestRecall_AllPassesThinReturnsLastTier locks the natural-loop-exit
+// path. The previous shape ran the last pass twice when no pass met
+// thresholdLow — wasted query plus a race window where the duplicate
+// could see different rows than the first call. The fix is that the
+// loop tracks the last pass's hits and returns them at exit, no
+// second SearchMemories call.
+//
+// Test: insert one draft (below default thresholdLow=5). Every pass
+// returns 1 row, none meet threshold, the loop exits naturally. The
+// returned tier must be the LAST pass's tier ("draft-or" for a
+// multi-token query, "draft" for single-token), and the returned
+// memory must be the inserted one.
+func TestRecall_AllPassesThinReturnsLastTier(t *testing.T) {
+	t.Run("multi-token", func(t *testing.T) {
+		f, lib := openFinder(t)
+		mid := insertMemory(t, lib, "s", "uniqueword anotherword")
+
+		got, err := f.Recall(finder.Options{
+			Query: "uniqueword anotherword",
+			// IncludeDrafts=false → curated AND, curated OR, draft AND,
+			// draft OR. Every pass returns the one matching draft, none
+			// hit thresholdLow=5.
+		})
+		if err != nil {
+			t.Fatalf("Recall: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != mid {
+			t.Fatalf("got %v, want [%q]", got, mid)
+		}
+		// Last pass is draft-or for multi-token + IncludeDrafts=false.
+		if got[0].Tier != "draft-or" {
+			t.Errorf("Tier = %q, want draft-or (last pass for multi-token)", got[0].Tier)
+		}
+	})
+
+	t.Run("single-token", func(t *testing.T) {
+		f, lib := openFinder(t)
+		mid := insertMemory(t, lib, "s", "uniqueword")
+
+		got, err := f.Recall(finder.Options{Query: "uniqueword"})
+		if err != nil {
+			t.Fatalf("Recall: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != mid {
+			t.Fatalf("got %v, want [%q]", got, mid)
+		}
+		// Single-token skips OR passes; last pass is "draft".
+		if got[0].Tier != "draft" {
+			t.Errorf("Tier = %q, want draft (last pass for single-token)", got[0].Tier)
+		}
+	})
+}
+
+// TestRecall_EmptyTagInTags_RejectedAtLibrarian locks the lesson:
+// previously, Tags=["deploy", ""] silently produced WHERE name IN
+// ("deploy", "") with COUNT(DISTINCT) = 2, returning zero rows with
+// no signal that the input was malformed. The fix rejects at the SQL
+// composer with ErrEmptyArg.
+func TestRecall_EmptyTagInTags_RejectedAtLibrarian(t *testing.T) {
+	f, lib := openFinder(t)
+	insertMemory(t, lib, "s", "deploy postgres", "deploy")
+
+	cases := [][]string{
+		{""},
+		{"deploy", ""},
+		{"  "},
+		{"deploy", " "},
+	}
+	for _, tags := range cases {
+		_, err := f.Recall(finder.Options{
+			Query: "deploy",
+			Tags:  tags,
+		})
+		if !errors.Is(err, librarian.ErrEmptyArg) {
+			t.Errorf("tags=%v: err = %v, want ErrEmptyArg", tags, err)
+		}
+	}
+}

--- a/cli/internal/librarian/graph.go
+++ b/cli/internal/librarian/graph.go
@@ -17,36 +17,34 @@ import (
 //
 // Comparison is case-sensitive at the storage layer; "MCP" and "mcp"
 // are different tags. Normalisation is a higher-level convention.
+//
+// The whole operation is one Tx with INSERT … ON CONFLICT(name) DO
+// NOTHING followed by SELECT id WHERE name = ?. Two concurrent calls
+// for the same name both succeed and both return the same id; neither
+// surfaces a UNIQUE constraint error. Atomicity is guaranteed by the
+// transaction, not by lookup-then-insert.
 func (l *Librarian) UpsertTag(name string) (string, error) {
 	if strings.TrimSpace(name) == "" {
 		return "", fmt.Errorf("UpsertTag: name: %w", ErrEmptyArg)
 	}
 	var id string
-	err := l.v.Query(
-		`SELECT id FROM tags WHERE name = ?`,
-		[]any{name},
-		func(rs *sql.Rows) error {
-			if rs.Next() {
-				return rs.Scan(&id)
-			}
-			return nil
-		},
-	)
+	err := l.v.Tx(func(tx *sql.Tx) error {
+		newID := uuid.NewString()
+		if _, err := tx.Exec(
+			`INSERT INTO tags (id, name, created_at) VALUES (?, ?, ?)
+			 ON CONFLICT(name) DO NOTHING`,
+			newID, name, formatTime(l.now()),
+		); err != nil {
+			return err
+		}
+		// Always SELECT — INSERT ON CONFLICT DO NOTHING does not
+		// reliably return last_insert_rowid for the conflict case,
+		// and either the just-inserted row or the pre-existing one
+		// is what we want.
+		return tx.QueryRow(`SELECT id FROM tags WHERE name = ?`, name).Scan(&id)
+	})
 	if err != nil {
-		return "", fmt.Errorf("UpsertTag lookup: %w", err)
-	}
-	if id != "" {
-		return id, nil
-	}
-	id = uuid.NewString()
-	if err := l.v.Tx(func(tx *sql.Tx) error {
-		_, err := tx.Exec(
-			`INSERT INTO tags (id, name, created_at) VALUES (?, ?, ?)`,
-			id, name, formatTime(l.now()),
-		)
-		return err
-	}); err != nil {
-		return "", fmt.Errorf("UpsertTag insert: %w", err)
+		return "", fmt.Errorf("UpsertTag: %w", err)
 	}
 	return id, nil
 }
@@ -179,6 +177,10 @@ func (l *Librarian) MergeTags(source, target string) error {
 // returns the id of an existing matching row. Both type and
 // display_name must be non-empty after trimming. The schema enforces
 // UNIQUE(type, display_name); the API enforces non-empty inputs.
+//
+// One Tx with INSERT … ON CONFLICT(type, display_name) DO NOTHING
+// followed by SELECT id. Concurrent calls for the same (type, name)
+// pair are safe — see UpsertTag for the atomicity rationale.
 func (l *Librarian) UpsertEntity(entityType, displayName string) (string, error) {
 	if strings.TrimSpace(entityType) == "" {
 		return "", fmt.Errorf("UpsertEntity: type: %w", ErrEmptyArg)
@@ -187,32 +189,23 @@ func (l *Librarian) UpsertEntity(entityType, displayName string) (string, error)
 		return "", fmt.Errorf("UpsertEntity: display_name: %w", ErrEmptyArg)
 	}
 	var id string
-	err := l.v.Query(
-		`SELECT id FROM entities WHERE type = ? AND display_name = ?`,
-		[]any{entityType, displayName},
-		func(rs *sql.Rows) error {
-			if rs.Next() {
-				return rs.Scan(&id)
-			}
-			return nil
-		},
-	)
-	if err != nil {
-		return "", fmt.Errorf("UpsertEntity lookup: %w", err)
-	}
-	if id != "" {
-		return id, nil
-	}
-	id = uuid.NewString()
-	if err := l.v.Tx(func(tx *sql.Tx) error {
-		_, err := tx.Exec(
+	err := l.v.Tx(func(tx *sql.Tx) error {
+		newID := uuid.NewString()
+		if _, err := tx.Exec(
 			`INSERT INTO entities (id, type, display_name, created_at)
-			 VALUES (?, ?, ?, ?)`,
-			id, entityType, displayName, formatTime(l.now()),
-		)
-		return err
-	}); err != nil {
-		return "", fmt.Errorf("UpsertEntity insert: %w", err)
+			 VALUES (?, ?, ?, ?)
+			 ON CONFLICT(type, display_name) DO NOTHING`,
+			newID, entityType, displayName, formatTime(l.now()),
+		); err != nil {
+			return err
+		}
+		return tx.QueryRow(
+			`SELECT id FROM entities WHERE type = ? AND display_name = ?`,
+			entityType, displayName,
+		).Scan(&id)
+	})
+	if err != nil {
+		return "", fmt.Errorf("UpsertEntity: %w", err)
 	}
 	return id, nil
 }

--- a/cli/internal/librarian/search.go
+++ b/cli/internal/librarian/search.go
@@ -41,7 +41,17 @@ type SearchedMemory struct {
 // SearchMemories runs the filtered query and returns matching rows. It
 // is the SQL composition primitive for Finder; Finder layers
 // relaxation (AND→OR) and tier escalation (curated→draft) on top.
+//
+// Empty/whitespace tag names in f.Tags are rejected with ErrEmptyArg
+// — the previous behaviour silently produced WHERE name IN (..., '')
+// with COUNT(DISTINCT) = N+1, which always returned zero rows and
+// gave callers no signal that their input was malformed.
 func (l *Librarian) SearchMemories(f SearchFilter) ([]SearchedMemory, error) {
+	for i, t := range f.Tags {
+		if strings.TrimSpace(t) == "" {
+			return nil, fmt.Errorf("SearchMemories: tags[%d] (%q): %w", i, t, ErrEmptyArg)
+		}
+	}
 	limit := f.Limit
 	if limit <= 0 {
 		limit = 100

--- a/cli/internal/librarian/upsert_concurrency_test.go
+++ b/cli/internal/librarian/upsert_concurrency_test.go
@@ -1,0 +1,107 @@
+package librarian_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/librarian"
+)
+
+// TestUpsertTag_ConcurrentSameNameProducesOneRow locks the lesson the
+// previous attempt missed: lookup-then-insert was not atomic, so two
+// concurrent UpsertTag("recall") calls both passed the SELECT, both
+// INSERTed, and the second hit UNIQUE(name). Drafter will run this
+// path under load when capture events arrive close together — the
+// race is not theoretical.
+//
+// The fixed contract: N concurrent calls for the same name produce
+// exactly one tag row, and every caller sees the same id.
+func TestUpsertTag_ConcurrentSameNameProducesOneRow(t *testing.T) {
+	l := openLib(t)
+
+	const N = 50
+	var wg sync.WaitGroup
+	ids := make([]string, N)
+	errs := make([]error, N)
+
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			id, err := l.UpsertTag("recall")
+			ids[i] = id
+			errs[i] = err
+		}()
+	}
+	wg.Wait()
+
+	// No goroutine surfaced an error.
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: UpsertTag returned %v", i, err)
+		}
+	}
+
+	// Every goroutine saw the same id.
+	first := ids[0]
+	if first == "" {
+		t.Fatal("first goroutine got empty id")
+	}
+	for i := 1; i < N; i++ {
+		if ids[i] != first {
+			t.Errorf("goroutine %d saw id %q, want %q (race produced multiple tag rows)", i, ids[i], first)
+		}
+	}
+
+	// Sanity: subsequent UpsertTag yields the same id (idempotent).
+	again, err := l.UpsertTag("recall")
+	if err != nil {
+		t.Fatalf("post-race UpsertTag: %v", err)
+	}
+	if again != first {
+		t.Errorf("post-race id = %q, want %q", again, first)
+	}
+}
+
+func TestUpsertEntity_ConcurrentSamePairProducesOneRow(t *testing.T) {
+	l := openLib(t)
+
+	const N = 50
+	var wg sync.WaitGroup
+	ids := make([]string, N)
+	errs := make([]error, N)
+
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			id, err := l.UpsertEntity("user", "Alice")
+			ids[i] = id
+			errs[i] = err
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: UpsertEntity returned %v", i, err)
+		}
+	}
+
+	first := ids[0]
+	if first == "" {
+		t.Fatal("first goroutine got empty id")
+	}
+	for i := 1; i < N; i++ {
+		if ids[i] != first {
+			t.Errorf("goroutine %d saw id %q, want %q", i, ids[i], first)
+		}
+	}
+}
+
+// Idempotent + correct-result: existing tests in graph_test.go
+// (TestUpsertTag_Idempotent, TestUpsertEntity_Idempotent) cover the
+// single-caller case. This file adds the concurrent contract on top.
+var _ = librarian.NormalizeTagName // keep the librarian import non-test-only


### PR DESCRIPTION
## Summary

Theme E from the Phase 1 review pass. Three real correctness bugs.

## Bug 1 — UpsertTag / UpsertEntity SELECT-then-INSERT race

Two concurrent calls for the same name both passed the lookup, both INSERTed, second hit `UNIQUE(name)` and surfaced a raw SQLite error. Drafter under load will trigger this regularly.

**Fix:** one `Tx` with `INSERT … ON CONFLICT(name) DO NOTHING` followed by `SELECT id`. Atomic by transaction, not by lookup-then-insert. Same shape for `UpsertEntity` over `UNIQUE(type, display_name)`.

## Bug 2 — Finder ran the last pass twice

When no pass met `thresholdLow`, the natural loop exit fell through to a post-loop block that called `SearchMemories` again with identical parameters. Wasted query + race window.

**Fix:** track `lastHits` / `lastTier` inside the loop and return them at exit. No second call.

## Bug 3 — `librarian.SearchMemories` silently accepted empty tags

`Tags=["deploy",""]` produced `WHERE name IN ("deploy","")` with `COUNT(DISTINCT)=2`, always returned zero rows, no signal.

**Fix:** reject at the SQL composer with `ErrEmptyArg`.

## Test plan

- [x] `TestUpsertTag_ConcurrentSameNameProducesOneRow` — 50 goroutines, all see the same id, one row in `tags`. **Verified under `-race`.**
- [x] `TestUpsertEntity_ConcurrentSamePairProducesOneRow` — same shape.
- [x] `TestRecall_AllPassesThinReturnsLastTier` (multi-token + single-token) — natural-loop-exit path returns correct memory with correct last-pass tier label.
- [x] `TestRecall_EmptyTagInTags_RejectedAtLibrarian` — four flavours of empty/whitespace input.
- [x] `go test ./...` — full repo green
- [x] `go test -race ./internal/librarian/ ./internal/finder/`

## Findings retired

- **Librarian PR #259 F1** (HIGH) — race
- **Finder PR #261 F1** — duplicate query
- **Finder PR #261 F2** — empty-tag silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)