### PR TITLE
test: close gaps where tests passed regardless of bug presence (Theme F)

### DIFF
--- a/cli/internal/finder/finder_test.go
+++ b/cli/internal/finder/finder_test.go
@@ -160,32 +160,95 @@ func TestRecall_PrefersCuratedWhenAvailable(t *testing.T) {
 // ── AND→OR relaxation ────────────────────────────────────────────────────────
 
 func TestRecall_ANDPassPrecisionMultiToken(t *testing.T) {
+	// Memory A contains both terms; B contains only one. The AND
+	// pass should match A and only A. Forcing thresholdLow=1 makes
+	// the AND pass satisfy on its own — without that, the OR pass
+	// runs too and B sneaks in, which would mask any AND-precision
+	// regression.
 	f, lib := openFinder(t)
-	// Memory A contains both terms; B contains only one. AND pass
-	// returns only A.
+	f = f.WithThresholdLow(1)
 	a := insertMemory(t, lib, "s", "deploy postgres canary")
-	_ = insertMemory(t, lib, "s", "deploy redis cluster")
+	b := insertMemory(t, lib, "s", "deploy redis cluster")
 
-	// Force IncludeDrafts so we can isolate the AND pass behavior.
-	got, _ := f.Recall(finder.Options{Query: "deploy postgres", IncludeDrafts: true, Limit: 10})
-	// AND first; if AND yields enough we shouldn't see only-deploy
-	// matches. Given thresholdLow=5 and only 1 matching row, the loop
-	// will continue to OR and pick up the other. The contract here:
-	// AND results come FIRST in the ordered chain; tier label
-	// distinguishes.
-	if len(got) == 0 {
-		t.Fatal("expected results, got none")
+	got, err := f.Recall(finder.Options{
+		Query:         "deploy postgres",
+		IncludeDrafts: true,
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
 	}
-	// At least the AND-only match must be present.
-	found := false
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one AND-precise match, got %d: %v", len(got), got)
+	}
+	if got[0].ID != a {
+		t.Fatalf("AND-precise match = %q, want %q (B=%q sneaked in via OR)", got[0].ID, a, b)
+	}
+	// Tier must be the AND tier, not the OR tier — proves the AND
+	// pass actually satisfied and we didn't fall through.
+	if got[0].Tier != "draft" {
+		t.Errorf("Tier = %q, want %q (AND pass for IncludeDrafts=true)", got[0].Tier, "draft")
+	}
+}
+
+// TestRecall_IncludeDraftsTrue_SkipsCuratedTier locks the contract
+// that IncludeDrafts=true bypasses the curated-only passes entirely.
+// Every result must carry a draft-tier label, never a curated one.
+func TestRecall_IncludeDraftsTrue_SkipsCuratedTier(t *testing.T) {
+	f, lib := openFinder(t)
+	curated := insertMemory(t, lib, "s", "deploy curated")
+	promote(t, lib, curated)
+	draft := insertMemory(t, lib, "s", "deploy draft")
+
+	got, err := f.Recall(finder.Options{
+		Query:         "deploy",
+		IncludeDrafts: true,
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
 	for _, r := range got {
-		if r.ID == a {
-			found = true
-			break
+		if r.Tier == "curated" || r.Tier == "curated-or" {
+			t.Errorf("IncludeDrafts=true must skip curated passes; got tier=%q on %q", r.Tier, r.ID)
 		}
 	}
-	if !found {
-		t.Fatalf("AND-precise match %q missing from results", a)
+	// Both rows still surface — the curated row is still a memory,
+	// just queried under the draft tier (no promotion-state filter).
+	ids := map[string]bool{}
+	for _, r := range got {
+		ids[r.ID] = true
+	}
+	if !ids[curated] || !ids[draft] {
+		t.Errorf("expected both rows, got %v", ids)
+	}
+}
+
+// TestRecall_WithThresholdLow_StopsEscalationEarlier locks the
+// configurable-threshold contract: at thresholdLow=1, a single
+// curated match satisfies the first pass and the loop stops; lower
+// tiers (drafts) are not searched.
+func TestRecall_WithThresholdLow_StopsEscalationEarlier(t *testing.T) {
+	f, lib := openFinder(t)
+	f = f.WithThresholdLow(1)
+
+	curated := insertMemory(t, lib, "s", "deploy curated")
+	promote(t, lib, curated)
+	draft := insertMemory(t, lib, "s", "deploy draft")
+
+	got, err := f.Recall(finder.Options{Query: "deploy"})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	// thresholdLow=1 → curated AND yields 1 → satisfies → stop.
+	// The draft row must NOT appear.
+	for _, r := range got {
+		if r.ID == draft {
+			t.Errorf("draft %q surfaced despite thresholdLow=1 satisfying curated", draft)
+		}
+		if r.Tier != "curated" {
+			t.Errorf("Tier = %q, want curated (early stop)", r.Tier)
+		}
 	}
 }
 

--- a/cli/internal/librarian/librarian_test.go
+++ b/cli/internal/librarian/librarian_test.go
@@ -3,6 +3,7 @@ package librarian_test
 import (
 	"errors"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -236,30 +237,49 @@ func TestUpdateOperational_RejectsEmptyID(t *testing.T) {
 
 // ── Substance immutability — locked by the API surface ────────────────────────
 
-// TestSubstanceImmutability documents which struct fields on
-// OperationalUpdate exist and which substance fields cannot be reached
-// through it. If a future maintainer adds a substance field to the
-// patch type (Content *string, SessionID *string, etc.), this test
-// fails — guarding the API contract from drift.
-func TestSubstanceImmutability_OperationalUpdateFieldsAreOperationalOnly(t *testing.T) {
-	// Reflection-free check: the public fields on OperationalUpdate
-	// must be exactly the operational-mutable set per ADR 0011.
+// TestSubstanceImmutability_OperationalUpdateShape uses reflect to
+// enforce that OperationalUpdate has EXACTLY the four operational-
+// mutable fields per ADR 0011 — Type, PromotionState, Landmark,
+// CentralityScore. Adding a substance field (Content, SessionID,
+// CreatedAt, Provenance*) to the struct then fails this test, even
+// if no caller uses the new field. This is the actual contract guard
+// — reflection over the type, not behaviour over an instance.
+func TestSubstanceImmutability_OperationalUpdateShape(t *testing.T) {
 	allowed := map[string]bool{
-		"Type": true, "PromotionState": true, "Landmark": true, "CentralityScore": true,
+		"Type":            true,
+		"PromotionState":  true,
+		"Landmark":        true,
+		"CentralityScore": true,
 	}
-	// Round-trip through Insert + Get to confirm substance fields are
-	// not re-write-able through any public path on Librarian. The only
-	// post-Insert mutator is UpdateOperational, which lacks the
-	// substance fields on its struct entirely. (See type definition.)
+	tt := reflect.TypeOf(librarian.OperationalUpdate{})
+	if tt.Kind() != reflect.Struct {
+		t.Fatalf("OperationalUpdate is %v, want struct", tt.Kind())
+	}
+	for i := 0; i < tt.NumField(); i++ {
+		f := tt.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		if !allowed[f.Name] {
+			t.Errorf("OperationalUpdate has unexpected field %q — substance field leaked into the patch type, violating ADR 0011", f.Name)
+		}
+		delete(allowed, f.Name)
+	}
+	for missing := range allowed {
+		t.Errorf("OperationalUpdate is missing the operational field %q", missing)
+	}
+}
+
+// TestSubstanceImmutability_RoundTripDoesNotMutateSubstance is the
+// behavioural complement to the shape test above: even with every
+// operational field exercised through UpdateOperational, the
+// substance columns on the row stay byte-identical.
+func TestSubstanceImmutability_RoundTripDoesNotMutateSubstance(t *testing.T) {
 	l := openLib(t)
 	id, _ := l.Insert(validInsert())
 	got1, _ := l.Get(id)
 
-	// Apply every legal operational field once to exercise the path.
-	t1 := "episodic"
-	st := "curated"
-	lm := true
-	sc := 1.0
+	t1, st, lm, sc := "episodic", "curated", true, 1.0
 	if err := l.UpdateOperational(id, librarian.OperationalUpdate{
 		Type: &t1, PromotionState: &st, Landmark: &lm, CentralityScore: &sc,
 	}); err != nil {
@@ -281,5 +301,4 @@ func TestSubstanceImmutability_OperationalUpdateFieldsAreOperationalOnly(t *test
 		got2.ProvenanceTriggerEvent != got1.ProvenanceTriggerEvent {
 		t.Error("Provenance changed despite only operational update")
 	}
-	_ = allowed // intentionally held in scope for documentation
 }

--- a/cli/internal/logbook/op_events_test.go
+++ b/cli/internal/logbook/op_events_test.go
@@ -165,17 +165,35 @@ func TestQueryOpEvents_FilterBySinceUntilWindow(t *testing.T) {
 
 func TestQueryOpEvents_DefaultLimit_100(t *testing.T) {
 	l := openLibWithLogbook(t)
+	// Insert 105 rows with ascending timestamps so ID order matches
+	// time order. The contract is "return the most recent 100 rows
+	// in DESC order" — len==100 alone doesn't lock that, an ASC
+	// regression would still pass len==100 but return the OLDEST
+	// 100 instead.
+	t0 := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	ids := make([]int64, 105)
 	for i := 0; i < 105; i++ {
-		_, err := l.InsertOpEvent(librarian.OpEvent{
-			EventType: "op.x", SessionID: "s",
+		id, err := l.InsertOpEvent(librarian.OpEvent{
+			EventType: "op.x",
+			SessionID: "s",
+			CreatedAt: t0.Add(time.Duration(i) * time.Second),
 		})
 		if err != nil {
 			t.Fatalf("Insert %d: %v", i, err)
 		}
+		ids[i] = id
 	}
 	rows, _ := l.QueryOpEvents(librarian.OpEventFilter{})
 	if len(rows) != 100 {
 		t.Fatalf("default limit: got %d rows, want 100", len(rows))
+	}
+	// Ordering: most recent first. rows[0] must be the row with the
+	// LAST id (= 105th insert); rows[99] must be the 6th insert.
+	if rows[0].ID != ids[104] {
+		t.Errorf("rows[0].ID = %d, want %d (most recent)", rows[0].ID, ids[104])
+	}
+	if rows[99].ID != ids[5] {
+		t.Errorf("rows[99].ID = %d, want %d (the 6th-oldest survives the limit)", rows[99].ID, ids[5])
 	}
 }
 

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -228,13 +228,45 @@ func TestServer_BusIsAccessibleAndDistinctPerInstance(t *testing.T) {
 	if a.Bus() == b.Bus() {
 		t.Fatal("two Servers share the same Bus pointer")
 	}
+	// Same-instance idempotence: Bus() must return the same pointer
+	// across calls. A future refactor that allocates a fresh bus per
+	// call silently breaks every subscribe/publish test that uses
+	// srv.Bus() then publishes via toolMomRecord.
+	if a.Bus() != a.Bus() {
+		t.Fatal("Server.Bus() not idempotent on same instance")
+	}
 }
 
 func TestServer_SetBusReplacesTheBus(t *testing.T) {
 	srv := New(t.TempDir())
+	old := srv.Bus()
+
+	// Subscribe on the OLD bus before swapping.
+	var oldBusFires atomic.Int64
+	old.Subscribe(MemoryRecordEventType, func(e herald.Event) { oldBusFires.Add(1) })
+
 	custom := herald.NewBus()
 	srv.SetBus(custom)
 	if srv.Bus() != custom {
 		t.Fatal("SetBus did not replace the bus")
+	}
+
+	// Subscribe on the NEW bus.
+	var newBusFires atomic.Int64
+	custom.Subscribe(MemoryRecordEventType, func(e herald.Event) { newBusFires.Add(1) })
+
+	// Publish via the handler — should hit ONLY the new bus.
+	if _, err := srv.toolMomRecord(map[string]any{
+		"session_id": "s",
+		"content":    map[string]any{"text": "x"},
+	}); err != nil {
+		t.Fatalf("toolMomRecord: %v", err)
+	}
+
+	if got := oldBusFires.Load(); got != 0 {
+		t.Errorf("old bus subscriber fired %d times after SetBus; want 0 (publish should not leak)", got)
+	}
+	if got := newBusFires.Load(); got != 1 {
+		t.Errorf("new bus subscriber fired %d times; want 1", got)
 	}
 }

--- a/cli/internal/vault/vault_test.go
+++ b/cli/internal/vault/vault_test.go
@@ -99,13 +99,24 @@ func TestOpen_isIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mom.db")
 
+	// First open: apply migration and write a row to the migrated
+	// table. The row + the table itself must survive close/re-open.
 	v1, err := vault.Open(path, migs)
 	if err != nil {
 		t.Fatalf("first Open: %v", err)
 	}
+	if err := v1.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`INSERT INTO widgets (id) VALUES (42)`)
+		return err
+	}); err != nil {
+		t.Fatalf("seed widgets: %v", err)
+	}
 	_ = v1.Close()
 
-	// Re-open: must be a no-op for already-applied migrations.
+	// Re-open: must be a no-op for already-applied migrations AND
+	// must leave the previously-written data untouched. Checking
+	// only schema_migrations would miss a regression where the
+	// re-open path accidentally drops user tables.
 	v2, err := vault.Open(path, migs)
 	if err != nil {
 		t.Fatalf("second Open: %v", err)
@@ -118,10 +129,23 @@ func TestOpen_isIdempotent(t *testing.T) {
 		nil,
 		func(rs *sql.Rows) error { rs.Next(); return rs.Scan(&count) },
 	); err != nil {
-		t.Fatalf("query: %v", err)
+		t.Fatalf("query schema_migrations: %v", err)
 	}
 	if count != 1 {
 		t.Fatalf("schema_migrations count = %d after re-open, want 1", count)
+	}
+
+	// DDL from migration 1 still present and queryable.
+	var widgetID int
+	if err := v2.Query(
+		`SELECT id FROM widgets`,
+		nil,
+		func(rs *sql.Rows) error { rs.Next(); return rs.Scan(&widgetID) },
+	); err != nil {
+		t.Fatalf("query widgets after re-open: %v", err)
+	}
+	if widgetID != 42 {
+		t.Fatalf("widgets row = %d, want 42 (re-open dropped data?)", widgetID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Theme F from the Phase 1 review pass. Seven tests claimed to lock contracts but were structured so they'd pass even when the contract was broken. False-confidence tests are worse than missing ones.

## Gaps closed

| # | Test | Was | Now |
|---|---|---|---|
| 1 | Vault `TestOpen_isIdempotent` | only checked `schema_migrations` count | seeds a row, asserts DDL + data survive re-open (PR #257 F8) |
| 2 | Librarian `TestSubstanceImmutability_*` | built an `allowed` set then ignored it | reflect-based shape check + separate behavioural test (PR #259 F4) |
| 3 | Logbook `TestQueryOpEvents_DefaultLimit_100` | only asserted `len==100` | asserts `rows[0]` is the latest ID and `rows[99]` is the 6th-oldest (PR #260 F8) |
| 4 | Finder `TestRecall_ANDPassPrecisionMultiToken` | OR pass also ran, masking AND-precision regressions | `WithThresholdLow(1)` so AND alone satisfies; asserts exactly one result with the AND-tier label (PR #261 F4) |
| 5 | Finder | `IncludeDrafts=true` and `WithThresholdLow` paths untested | two new tests, one per branch (PR #261 F5) |
| 6 | MCP `TestServer_BusIsAccessibleAndDistinctPerInstance` | didn't assert same-instance idempotence | one-line guard added (PR #262 F7) |
| 7 | MCP `TestServer_SetBusReplacesTheBus` | only checked the new pointer | subscribes on both, asserts old-bus stays at 0 firings post-replacement (PR #262 F8) |

## Test plan

- [x] `go test ./...` — full repo green
- [x] `go test -race ./internal/vault/ ./internal/librarian/ ./internal/logbook/ ./internal/finder/ ./internal/mcp/` — race-clean
- [x] Mental walkthrough: each strengthened test now FAILS for the bug it claims to guard against (verified by inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)