### PR TITLE
feat(watcher,logbook): turn.observed event + Logbook metadata projection (#240 PR 1)

### DIFF
--- a/cli/internal/cmd/watch.go
+++ b/cli/internal/cmd/watch.go
@@ -17,9 +17,11 @@ import (
 	"github.com/momhq/mom/cli/internal/daemon"
 	"github.com/momhq/mom/cli/internal/drafter"
 	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/logbook"
 	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/ux"
+	"github.com/momhq/mom/cli/internal/vault"
 	"github.com/momhq/mom/cli/internal/watcher"
 	"github.com/spf13/cobra"
 )
@@ -219,8 +221,22 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 // newProjectBus creates a Herald event bus with Logbook and Drafter subscribers
 // wired for a given momDir. Used by both single-project and global watch modes.
 // adapters maps Harness name → Adapter for Harness-specific logbook parsing.
+//
+// Two wiring tiers:
+//
+//  1. Legacy v1 path: v1 logbook.ParseTranscript + v1 drafter.Process,
+//     subscribed to RecordAppended. Writes session-*.json + draft
+//     memory files under momDir. Stays operational through #240.
+//  2. v0.30 path: v0.30 logbook.Worker subscribed to TurnObserved,
+//     persisting metadata projections through Librarian into the
+//     central vault at $HOME/.mom/mom.db. Drafter on the v0.30 side
+//     is wired in #240 PR 2.
+//
+// Failures opening the central vault log to stderr and degrade
+// gracefully — the legacy path keeps working.
 func newProjectBus(momDir string, adapters map[string]watcher.Adapter) *herald.Bus {
 	bus := herald.NewBus()
+	wireV030LogbookSubscriber(bus)
 
 	// Logbook: parse transcript → write session metrics to .mom/logs/.
 	bus.Subscribe(herald.RecordAppended, func(e herald.Event) {
@@ -515,4 +531,40 @@ func runWatchStatus(momDir string) error {
 		p.Chevron(fmt.Sprintf("%s: %s bytes", c.sid, c.offset))
 	}
 	return nil
+}
+
+// wireV030LogbookSubscriber attaches a v0.30 Logbook worker to the
+// given bus, persisting turn.observed events as op_events rows in the
+// central vault.
+//
+// Errors are logged to stderr and the bus is left without a v0.30
+// subscriber — the legacy path keeps working. Cobra's RunE flow
+// already routes runtime errors to stderr; this helper preserves the
+// "stdout is reserved for JSON-RPC and human output, stderr is for
+// operational signal" rule from PR #262 F6.
+func wireV030LogbookSubscriber(bus *herald.Bus) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "watch: cannot resolve $HOME for v0.30 vault: %v — Logbook subscriber not wired\n", err)
+		return
+	}
+	momHome := filepath.Join(home, ".mom")
+	if err := os.MkdirAll(momHome, 0o700); err != nil {
+		fmt.Fprintf(os.Stderr, "watch: cannot create %s: %v — Logbook subscriber not wired\n", momHome, err)
+		return
+	}
+	dbPath := filepath.Join(momHome, "mom.db")
+	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	v, err := vault.Open(dbPath, migs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "watch: vault.Open %s: %v — Logbook subscriber not wired\n", dbPath, err)
+		return
+	}
+	lib := librarian.New(v)
+	w := logbook.New(lib)
+	w.SubscribeTurnObserved(bus)
+	// Vault stays open for the duration of the process. The watcher's
+	// lifecycle owns it; on shutdown the OS reclaims the handle. A
+	// future refactor should plumb a Close path through, but for
+	// alpha this is acceptable.
 }

--- a/cli/internal/cmd/watch.go
+++ b/cli/internal/cmd/watch.go
@@ -111,6 +111,10 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 
 	projectDir := filepath.Dir(momDir)
 
+	// Open the central vault once for this watch process. Worker is
+	// shared across the per-project buses below.
+	centralLogbook := openCentralLogbook()
+
 	// Build watcher sources: if --harness is explicitly set, use single source;
 	// otherwise read config and watch all enabled harnesses.
 	var sources []watcher.Source
@@ -158,7 +162,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		for _, src := range sources {
 			adapterMap[src.Harness] = src.Adapter
 		}
-		bus := newProjectBus(momDir, adapterMap)
+		bus := newProjectBus(momDir, adapterMap, centralLogbook)
 		w, err := watcher.New(watcher.Config{
 			ProjectDir: projectDir,
 			MomDir:     momDir,
@@ -186,7 +190,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	for _, src := range sources {
 		adapterMap[src.Harness] = src.Adapter
 	}
-	bus := newProjectBus(momDir, adapterMap)
+	bus := newProjectBus(momDir, adapterMap, centralLogbook)
 
 	w, err := watcher.New(watcher.Config{
 		ProjectDir: projectDir,
@@ -218,25 +222,30 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// newProjectBus creates a Herald event bus with Logbook and Drafter subscribers
-// wired for a given momDir. Used by both single-project and global watch modes.
-// adapters maps Harness name → Adapter for Harness-specific logbook parsing.
+// newProjectBus creates a Herald event bus with Logbook and Drafter
+// subscribers wired for a given momDir. Used by both single-project
+// and global watch modes. adapters maps Harness name → Adapter for
+// Harness-specific logbook parsing.
 //
-// Two wiring tiers:
+// `lb` is the central-vault Logbook worker (one per process); if
+// non-nil, it is subscribed to TurnObserved events on this bus. nil
+// means the central vault could not be opened — the bus still
+// functions for the legacy RecordAppended subscribers below.
 //
-//  1. Legacy v1 path: v1 logbook.ParseTranscript + v1 drafter.Process,
+// Two wiring tiers coexist while #240 is in flight:
+//
+//  1. Legacy path: v1 logbook.ParseTranscript + v1 drafter.Process,
 //     subscribed to RecordAppended. Writes session-*.json + draft
 //     memory files under momDir. Stays operational through #240.
-//  2. v0.30 path: v0.30 logbook.Worker subscribed to TurnObserved,
+//  2. New path: logbook.Worker subscribed to TurnObserved,
 //     persisting metadata projections through Librarian into the
-//     central vault at $HOME/.mom/mom.db. Drafter on the v0.30 side
-//     is wired in #240 PR 2.
-//
-// Failures opening the central vault log to stderr and degrade
-// gracefully — the legacy path keeps working.
-func newProjectBus(momDir string, adapters map[string]watcher.Adapter) *herald.Bus {
+//     central vault at $HOME/.mom/mom.db. Drafter joins this path
+//     in #240 PR 2.
+func newProjectBus(momDir string, adapters map[string]watcher.Adapter, lb *logbook.Worker) *herald.Bus {
 	bus := herald.NewBus()
-	wireV030LogbookSubscriber(bus)
+	if lb != nil {
+		lb.SubscribeTurnObserved(bus)
+	}
 
 	// Logbook: parse transcript → write session metrics to .mom/logs/.
 	bus.Subscribe(herald.RecordAppended, func(e herald.Event) {
@@ -308,6 +317,11 @@ func runWatchGlobal(sweepOnly bool) error {
 		return fmt.Errorf("loading registry: %w", err)
 	}
 
+	// Open the central vault ONCE for the entire global daemon. The
+	// same Logbook worker is shared across every per-project bus
+	// below — no N-vault-handle leak in multi-project mode.
+	centralLogbook := openCentralLogbook()
+
 	if sweepOnly {
 		p := ux.NewPrinter(os.Stderr)
 		totalSessions, totalTurns := 0, 0
@@ -326,7 +340,7 @@ func runWatchGlobal(sweepOnly bool) error {
 			for _, src := range sources {
 				adapterMap[src.Harness] = src.Adapter
 			}
-			bus := newProjectBus(entry.MomDir, adapterMap)
+			bus := newProjectBus(entry.MomDir, adapterMap, centralLogbook)
 			w, err := watcher.New(watcher.Config{
 				ProjectDir: projDir,
 				MomDir:     entry.MomDir,
@@ -378,7 +392,7 @@ func runWatchGlobal(sweepOnly bool) error {
 		for _, src := range sources {
 			adapterMap[src.Harness] = src.Adapter
 		}
-		bus := newProjectBus(entry.MomDir, adapterMap)
+		bus := newProjectBus(entry.MomDir, adapterMap, centralLogbook)
 		w, err := watcher.New(watcher.Config{
 			ProjectDir: projDir,
 			MomDir:     entry.MomDir,
@@ -533,38 +547,38 @@ func runWatchStatus(momDir string) error {
 	return nil
 }
 
-// wireV030LogbookSubscriber attaches a v0.30 Logbook worker to the
-// given bus, persisting turn.observed events as op_events rows in the
-// central vault.
+// openCentralLogbook opens the central vault at $HOME/.mom/mom.db,
+// runs migrations, and constructs a Logbook worker bound to it.
+// Returns nil + logs to stderr on any failure (HOME resolution,
+// MkdirAll, vault.Open) — the caller can still use the bus for
+// legacy subscribers.
 //
-// Errors are logged to stderr and the bus is left without a v0.30
-// subscriber — the legacy path keeps working. Cobra's RunE flow
-// already routes runtime errors to stderr; this helper preserves the
-// "stdout is reserved for JSON-RPC and human output, stderr is for
-// operational signal" rule from PR #262 F6.
-func wireV030LogbookSubscriber(bus *herald.Bus) {
+// Called once per process, NOT per project. The same worker is
+// subscribed to every project's bus by newProjectBus; SQLite WAL +
+// the librarian/vault concurrency contract keep this safe across
+// goroutines.
+//
+// The vault stays open for the process's lifetime. The runtime owns
+// the lifecycle; on shutdown the OS reclaims the handle. A future
+// refactor should plumb an explicit Close, but for alpha this is
+// acceptable.
+func openCentralLogbook() *logbook.Worker {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "watch: cannot resolve $HOME for v0.30 vault: %v — Logbook subscriber not wired\n", err)
-		return
+		fmt.Fprintf(os.Stderr, "watch: cannot resolve $HOME: %v — central Logbook not wired\n", err)
+		return nil
 	}
 	momHome := filepath.Join(home, ".mom")
 	if err := os.MkdirAll(momHome, 0o700); err != nil {
-		fmt.Fprintf(os.Stderr, "watch: cannot create %s: %v — Logbook subscriber not wired\n", momHome, err)
-		return
+		fmt.Fprintf(os.Stderr, "watch: cannot create %s: %v — central Logbook not wired\n", momHome, err)
+		return nil
 	}
 	dbPath := filepath.Join(momHome, "mom.db")
 	migs := append(librarian.Migrations(), logbook.Migrations()...)
 	v, err := vault.Open(dbPath, migs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "watch: vault.Open %s: %v — Logbook subscriber not wired\n", dbPath, err)
-		return
+		fmt.Fprintf(os.Stderr, "watch: vault.Open %s: %v — central Logbook not wired\n", dbPath, err)
+		return nil
 	}
-	lib := librarian.New(v)
-	w := logbook.New(lib)
-	w.SubscribeTurnObserved(bus)
-	// Vault stays open for the duration of the process. The watcher's
-	// lifecycle owns it; on shutdown the OS reclaims the handle. A
-	// future refactor should plumb a Close path through, but for
-	// alpha this is acceptable.
+	return logbook.New(librarian.New(v))
 }

--- a/cli/internal/cmd/watch_helpers.go
+++ b/cli/internal/cmd/watch_helpers.go
@@ -155,7 +155,10 @@ func sweepTranscripts(momDir string) {
 	for _, src := range sources {
 		adapterMap[src.Harness] = src.Adapter
 	}
-	bus := newProjectBus(momDir, adapterMap)
+	// Best-effort sweep — open the central vault on the spot. The
+	// helper is short-lived so leaving the vault uncloned is fine
+	// for this one-shot path.
+	bus := newProjectBus(momDir, adapterMap, openCentralLogbook())
 	w, err := watcher.New(watcher.Config{
 		ProjectDir: projectDir,
 		MomDir:     momDir,

--- a/cli/internal/herald/herald.go
+++ b/cli/internal/herald/herald.go
@@ -25,6 +25,15 @@ const (
 	RecordAppended   EventType = "record-appended"
 	ConfigChanged    EventType = "config-changed"
 	Error            EventType = "error"
+
+	// TurnObserved is the v0.30 source-of-truth event published by the
+	// watcher for every parsed turn. Carries the full structured turn
+	// (role, text, tool_calls with input, usage, model, provider) on
+	// the bus only — never persisted in raw form. Drafter consumes it
+	// for filter decisions; Logbook consumes it and persists a
+	// metadata-only projection (no text, no tool inputs) per ADR
+	// 0014's privacy contract.
+	TurnObserved EventType = "turn.observed"
 )
 
 // Event is a single message on the bus.

--- a/cli/internal/logbook/turn_observed_test.go
+++ b/cli/internal/logbook/turn_observed_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/momhq/mom/cli/internal/herald"
 	"github.com/momhq/mom/cli/internal/librarian"
@@ -33,14 +34,17 @@ func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
 	bus := herald.NewBus()
 	defer w.SubscribeTurnObserved(bus)()
 
+	turnedAt := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+
 	// Publish a turn that contains raw text AND a tool input with a
 	// secret-shaped string that Drafter would normally redact.
 	bus.Publish(herald.Event{
 		Type:      herald.TurnObserved,
 		SessionID: "s-test",
 		Payload: map[string]any{
-			"role": "assistant",
-			"text": "I'll deploy now using AKIA1234567890ABCDEF",
+			"role":       "assistant",
+			"created_at": turnedAt,
+			"text":       "I'll deploy now using AKIA1234567890ABCDEF",
 			"tool_calls": []map[string]any{
 				{
 					"name":     "Read",
@@ -64,6 +68,7 @@ func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
 			},
 			"model":    "claude-sonnet-4-6",
 			"provider": "anthropic",
+			"harness":  "claude-code",
 		},
 	})
 
@@ -88,6 +93,20 @@ func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
 	}
 	if got, _ := row.Payload["provider"].(string); got != "anthropic" {
 		t.Errorf("provider = %v", row.Payload["provider"])
+	}
+	if got, _ := row.Payload["harness"].(string); got != "claude-code" {
+		t.Errorf("harness = %v, want claude-code", row.Payload["harness"])
+	}
+
+	// CreatedAt: the persisted row's created_at must reflect the
+	// turn-occurred time, not the bus publish time.
+	gap := row.CreatedAt.Sub(turnedAt)
+	if gap < -time.Second || gap > time.Second {
+		t.Errorf("row.CreatedAt = %v, want close to %v (turn-occurred)", row.CreatedAt, turnedAt)
+	}
+	// created_at must NOT appear in the persisted payload.
+	if _, present := row.Payload["created_at"]; present {
+		t.Error("created_at leaked into the persisted payload; should be on OpEvent.CreatedAt only")
 	}
 	cats, _ := row.Payload["tool_categories"].([]any)
 	if len(cats) != 2 {

--- a/cli/internal/logbook/turn_observed_test.go
+++ b/cli/internal/logbook/turn_observed_test.go
@@ -1,0 +1,189 @@
+package logbook_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/momhq/mom/cli/internal/logbook"
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+// TestSubscribeTurnObserved_PersistsMetadataProjection locks the
+// privacy contract: when a turn.observed event arrives with raw text
+// and tool inputs in the payload, the persisted op_events row contains
+// ONLY role, tool_categories, usage, model, provider. No text. No
+// tool_call inputs. No tool_call names.
+//
+// This is the most important test in PR 1 — it's the lock that
+// prevents Drafter's redaction promise from being undone by the
+// audit substrate.
+func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
+	dir := t.TempDir()
+	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	lib := librarian.New(v)
+	w := logbook.New(lib)
+	bus := herald.NewBus()
+	defer w.SubscribeTurnObserved(bus)()
+
+	// Publish a turn that contains raw text AND a tool input with a
+	// secret-shaped string that Drafter would normally redact.
+	bus.Publish(herald.Event{
+		Type:      herald.TurnObserved,
+		SessionID: "s-test",
+		Payload: map[string]any{
+			"role": "assistant",
+			"text": "I'll deploy now using AKIA1234567890ABCDEF",
+			"tool_calls": []map[string]any{
+				{
+					"name":     "Read",
+					"category": "codebase_read",
+					"input":    map[string]any{"file_path": "/Users/x/secrets.env"},
+				},
+				{
+					"name":     "Bash",
+					"category": "system",
+					"input":    map[string]any{"command": "echo AKIA1234567890ABCDEF"},
+				},
+			},
+			"usage": map[string]any{
+				"input_tokens":       1234,
+				"output_tokens":      56,
+				"cache_read_tokens":  200,
+				"cache_write_tokens": 100,
+				"total_tokens":       1290,
+				"cost_usd":           0.0185,
+				"stop_reason":        "end_turn",
+			},
+			"model":    "claude-sonnet-4-6",
+			"provider": "anthropic",
+		},
+	})
+
+	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "turn.observed"})
+	if err != nil {
+		t.Fatalf("QueryOpEvents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	row := rows[0]
+
+	// Required projection fields.
+	if row.SessionID != "s-test" {
+		t.Errorf("SessionID = %q", row.SessionID)
+	}
+	if got, _ := row.Payload["role"].(string); got != "assistant" {
+		t.Errorf("role = %v", row.Payload["role"])
+	}
+	if got, _ := row.Payload["model"].(string); got != "claude-sonnet-4-6" {
+		t.Errorf("model = %v", row.Payload["model"])
+	}
+	if got, _ := row.Payload["provider"].(string); got != "anthropic" {
+		t.Errorf("provider = %v", row.Payload["provider"])
+	}
+	cats, _ := row.Payload["tool_categories"].([]any)
+	if len(cats) != 2 {
+		t.Errorf("tool_categories len = %d, want 2 (one per tool_call)", len(cats))
+	}
+	for i, want := range []string{"codebase_read", "system"} {
+		if i < len(cats) {
+			got, _ := cats[i].(string)
+			if got != want {
+				t.Errorf("tool_categories[%d] = %v, want %q", i, cats[i], want)
+			}
+		}
+	}
+
+	// CRITICAL: privacy contract — content / tool_input must NOT be
+	// in the persisted payload. Walk the entire payload as a string
+	// blob and assert the secret never appears.
+	dump := dumpPayload(row.Payload)
+	if strings.Contains(dump, "AKIA") {
+		t.Errorf("payload leaked the AWS-key sentinel:\n%s", dump)
+	}
+	if strings.Contains(dump, "secrets.env") {
+		t.Errorf("payload leaked the file path:\n%s", dump)
+	}
+	if strings.Contains(dump, "deploy now") {
+		t.Errorf("payload leaked the assistant text:\n%s", dump)
+	}
+	if strings.Contains(dump, "echo ") {
+		t.Errorf("payload leaked the Bash command:\n%s", dump)
+	}
+
+	// tool_calls and tool_call NAMES should NOT survive the projection.
+	if _, present := row.Payload["tool_calls"]; present {
+		t.Error("tool_calls should not appear in the projection")
+	}
+	if _, present := row.Payload["text"]; present {
+		t.Error("text should not appear in the projection")
+	}
+}
+
+// dumpPayload renders the payload back to a deterministic string for
+// substring assertions. We don't care about JSON validity — only
+// "is this string anywhere in the persisted payload."
+func dumpPayload(p map[string]any) string {
+	var b strings.Builder
+	walk(p, &b)
+	return b.String()
+}
+
+func walk(v any, b *strings.Builder) {
+	switch x := v.(type) {
+	case map[string]any:
+		for k, vv := range x {
+			b.WriteString(k)
+			b.WriteString("=")
+			walk(vv, b)
+			b.WriteString(";")
+		}
+	case []any:
+		for _, item := range x {
+			walk(item, b)
+			b.WriteString(",")
+		}
+	default:
+		b.WriteString(toString(x))
+	}
+}
+
+func toString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func TestSubscribeTurnObserved_DropsEventsWithoutSessionID(t *testing.T) {
+	dir := t.TempDir()
+	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	v, _ := vault.Open(filepath.Join(dir, "mom.db"), migs)
+	t.Cleanup(func() { _ = v.Close() })
+	lib := librarian.New(v)
+	w := logbook.New(lib)
+	bus := herald.NewBus()
+	defer w.SubscribeTurnObserved(bus)()
+
+	// Empty SessionID — should be dropped (programming-error state).
+	bus.Publish(herald.Event{
+		Type: herald.TurnObserved,
+		Payload: map[string]any{
+			"role":  "assistant",
+			"model": "claude-sonnet-4-6",
+		},
+	})
+
+	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{})
+	if len(rows) != 0 {
+		t.Errorf("got %d rows, want 0 (empty session_id should drop)", len(rows))
+	}
+}

--- a/cli/internal/logbook/worker.go
+++ b/cli/internal/logbook/worker.go
@@ -9,6 +9,7 @@ package logbook
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/momhq/mom/cli/internal/herald"
 	"github.com/momhq/mom/cli/internal/librarian"
@@ -74,11 +75,17 @@ func (w *Worker) Subscribe(bus *herald.Bus, eventType herald.EventType) func() {
 //	role             ("user" | "assistant")
 //	tool_categories  ([]string, derived from tool_calls[].category)
 //	usage            (token counts only, no text)
-//	model, provider
+//	model, provider, harness
 //
 // Raw text and tool inputs from the bus event are NEVER persisted.
 // Drafter is responsible for capturing redacted memories from the
 // same bus event; Logbook only records the audit trail.
+//
+// The persisted row's `created_at` reflects when the turn HAPPENED,
+// not when the watcher saw it. The watcher parses the source
+// timestamp into the bus payload's `created_at` key; Logbook lifts
+// it onto the OpEvent.CreatedAt field so Lens timelines match the
+// transcript even when ingestion runs in catch-up sweep mode.
 //
 // Empty SessionID drops the event with a stderr log (programming-
 // error state). Persistence failures also log to stderr.
@@ -88,19 +95,26 @@ func (w *Worker) SubscribeTurnObserved(bus *herald.Bus) func() {
 			fmt.Fprintf(os.Stderr, "logbook: drop %q event with empty session_id\n", e.Type)
 			return
 		}
-		projected := projectTurnObserved(e.Payload)
-		if err := w.Log(string(e.Type), e.SessionID, projected); err != nil {
+		projected, createdAt := projectTurnObserved(e.Payload)
+		if _, err := w.lib.InsertOpEvent(librarian.OpEvent{
+			EventType: string(e.Type),
+			SessionID: e.SessionID,
+			CreatedAt: createdAt, // zero falls through to InsertOpEvent's now() default
+			Payload:   projected,
+		}); err != nil {
 			fmt.Fprintf(os.Stderr, "logbook: persist %q failed: %v\n", e.Type, err)
 		}
 	})
 }
 
 // projectTurnObserved drops content (text, tool inputs) and keeps
-// only what Lens renders. Public for test access; the projection
-// shape is the contract op_events.payload follows.
-func projectTurnObserved(payload map[string]any) map[string]any {
+// only what Lens renders. Returns the projection map and the
+// turn-occurred timestamp (zero if absent). The caller lifts the
+// timestamp onto OpEvent.CreatedAt so the persisted row reflects
+// when the turn happened, not when the watcher published the event.
+func projectTurnObserved(payload map[string]any) (map[string]any, time.Time) {
 	if payload == nil {
-		return nil
+		return nil, time.Time{}
 	}
 	out := map[string]any{}
 	if role, _ := payload["role"].(string); role != "" {
@@ -111,6 +125,9 @@ func projectTurnObserved(payload map[string]any) map[string]any {
 	}
 	if provider, _ := payload["provider"].(string); provider != "" {
 		out["provider"] = provider
+	}
+	if harness, _ := payload["harness"].(string); harness != "" {
+		out["harness"] = harness
 	}
 
 	// tool_calls is []map[string]any in turn.ToPayload's output;
@@ -123,7 +140,16 @@ func projectTurnObserved(payload map[string]any) map[string]any {
 	if usage, ok := payload["usage"].(map[string]any); ok && usage != nil {
 		out["usage"] = projectUsage(usage)
 	}
-	return out
+
+	// created_at is consumed by the caller (lifted onto
+	// OpEvent.CreatedAt); it does NOT appear in the persisted payload.
+	var createdAt time.Time
+	if v, ok := payload["created_at"]; ok {
+		if t, ok := v.(time.Time); ok {
+			createdAt = t
+		}
+	}
+	return out, createdAt
 }
 
 func extractToolCategories(v any) []string {

--- a/cli/internal/logbook/worker.go
+++ b/cli/internal/logbook/worker.go
@@ -66,6 +66,114 @@ func (w *Worker) Subscribe(bus *herald.Bus, eventType herald.EventType) func() {
 	})
 }
 
+// SubscribeTurnObserved wires the worker to the watcher's
+// `turn.observed` source-of-truth events. Unlike Subscribe (which
+// persists the full payload), this method projects the payload to a
+// metadata-only shape before persisting:
+//
+//	role             ("user" | "assistant")
+//	tool_categories  ([]string, derived from tool_calls[].category)
+//	usage            (token counts only, no text)
+//	model, provider
+//
+// Raw text and tool inputs from the bus event are NEVER persisted.
+// Drafter is responsible for capturing redacted memories from the
+// same bus event; Logbook only records the audit trail.
+//
+// Empty SessionID drops the event with a stderr log (programming-
+// error state). Persistence failures also log to stderr.
+func (w *Worker) SubscribeTurnObserved(bus *herald.Bus) func() {
+	return bus.Subscribe(herald.TurnObserved, func(e herald.Event) {
+		if e.SessionID == "" {
+			fmt.Fprintf(os.Stderr, "logbook: drop %q event with empty session_id\n", e.Type)
+			return
+		}
+		projected := projectTurnObserved(e.Payload)
+		if err := w.Log(string(e.Type), e.SessionID, projected); err != nil {
+			fmt.Fprintf(os.Stderr, "logbook: persist %q failed: %v\n", e.Type, err)
+		}
+	})
+}
+
+// projectTurnObserved drops content (text, tool inputs) and keeps
+// only what Lens renders. Public for test access; the projection
+// shape is the contract op_events.payload follows.
+func projectTurnObserved(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+	out := map[string]any{}
+	if role, _ := payload["role"].(string); role != "" {
+		out["role"] = role
+	}
+	if model, _ := payload["model"].(string); model != "" {
+		out["model"] = model
+	}
+	if provider, _ := payload["provider"].(string); provider != "" {
+		out["provider"] = provider
+	}
+
+	// tool_calls is []map[string]any in turn.ToPayload's output;
+	// tolerate []any too in case the value round-tripped through JSON.
+	if cats := extractToolCategories(payload["tool_calls"]); len(cats) > 0 {
+		out["tool_categories"] = cats
+	}
+
+	// Usage map: keep numeric fields only.
+	if usage, ok := payload["usage"].(map[string]any); ok && usage != nil {
+		out["usage"] = projectUsage(usage)
+	}
+	return out
+}
+
+func extractToolCategories(v any) []string {
+	switch tcs := v.(type) {
+	case []map[string]any:
+		out := make([]string, 0, len(tcs))
+		for _, tc := range tcs {
+			if cat, _ := tc["category"].(string); cat != "" {
+				out = append(out, cat)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(tcs))
+		for _, item := range tcs {
+			tc, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cat, _ := tc["category"].(string); cat != "" {
+				out = append(out, cat)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// projectUsage retains only numeric token-accounting fields and the
+// stop_reason string. Unknown keys are dropped.
+func projectUsage(usage map[string]any) map[string]any {
+	out := map[string]any{}
+	for _, key := range []string{
+		"input_tokens",
+		"output_tokens",
+		"cache_read_tokens",
+		"cache_write_tokens",
+		"total_tokens",
+		"cost_usd",
+	} {
+		if v, ok := usage[key]; ok {
+			out[key] = v
+		}
+	}
+	if reason, _ := usage["stop_reason"].(string); reason != "" {
+		out["stop_reason"] = reason
+	}
+	return out
+}
+
 // SubscribeAll wires the worker to every listed event type and returns
 // a single unsubscribe that detaches them all.
 func (w *Worker) SubscribeAll(bus *herald.Bus, eventTypes ...herald.EventType) func() {

--- a/cli/internal/watcher/adapter.go
+++ b/cli/internal/watcher/adapter.go
@@ -17,7 +17,23 @@ type Adapter interface {
 	// ParseLine parses a single JSONL line from a transcript file.
 	// Returns (entry, true) if the line yields a recordable entry,
 	// (zero, false) if the line should be skipped (tool_use, metadata, etc.).
+	//
+	// Used by the legacy .mom/raw/ writer path; will retire alongside
+	// the raw writer in a follow-up cleanup once Drafter consumes
+	// turn.observed events.
 	ParseLine(line []byte, sessionID string) (recorder.RawEntry, bool)
+
+	// ExtractTurn parses a single JSONL line and returns the rich
+	// per-turn shape consumed by Drafter (filter pipeline) and
+	// Logbook (metadata projection). Returns (zero, false) for lines
+	// that do not produce a meaningful turn (tool_result, system
+	// messages, sidechain entries, malformed JSON).
+	//
+	// The returned Turn carries raw text and tool inputs. Drafter
+	// applies the redaction pipeline; Logbook projects to a
+	// privacy-safe metadata shape (no text, no inputs) before
+	// persisting. The full Turn never lands on disk.
+	ExtractTurn(line []byte, sessionID string) (Turn, bool)
 }
 
 // SessionParser is optionally implemented by adapters that provide

--- a/cli/internal/watcher/adapter_claude.go
+++ b/cli/internal/watcher/adapter_claude.go
@@ -41,9 +41,11 @@ type claudeTranscriptLine struct {
 }
 
 type claudeMessage struct {
-	Role    string `json:"role"`
-	Content any    `json:"content"` // string or []claudeContentItem
-	Usage   *claudeUsage `json:"usage,omitempty"`
+	Role       string       `json:"role"`
+	Model      string       `json:"model,omitempty"`
+	Content    any          `json:"content"` // string or []claudeContentItem
+	Usage      *claudeUsage `json:"usage,omitempty"`
+	StopReason string       `json:"stop_reason,omitempty"`
 }
 
 type claudeUsage struct {
@@ -137,6 +139,123 @@ func extractClaudeContent(content any) string {
 	}
 
 	return strings.Join(parts, "\n")
+}
+
+// ExtractTurn implements Adapter for v0.30. Returns the rich per-turn
+// shape Drafter and Logbook consume from `turn.observed` events. The
+// raw text and tool inputs ride on the bus only — Drafter applies
+// the redaction pipeline before persisting; Logbook strips them
+// before the metadata projection lands in op_events.
+func (a *ClaudeAdapter) ExtractTurn(line []byte, sessionID string) (Turn, bool) {
+	line = trimLine(line)
+	if len(line) == 0 {
+		return Turn{}, false
+	}
+	var tl claudeTranscriptLine
+	if err := json.Unmarshal(line, &tl); err != nil {
+		return Turn{}, false
+	}
+	if tl.Type != "user" && tl.Type != "assistant" {
+		return Turn{}, false
+	}
+	if tl.IsSidechain {
+		return Turn{}, false
+	}
+
+	turn := Turn{
+		SessionID: tl.SessionID,
+		Role:      tl.Type,
+		Model:     tl.Message.Model,
+		Provider:  "anthropic",
+	}
+	if turn.SessionID == "" {
+		turn.SessionID = sessionID
+	}
+
+	// Timestamp: prefer line's, fall back to now.
+	if tl.Timestamp != "" {
+		if t, err := time.Parse(time.RFC3339Nano, tl.Timestamp); err == nil {
+			turn.Timestamp = t
+		} else if t, err := time.Parse(time.RFC3339, tl.Timestamp); err == nil {
+			turn.Timestamp = t
+		}
+	}
+	if turn.Timestamp.IsZero() {
+		turn.Timestamp = time.Now().UTC()
+	}
+
+	// Text + tool calls: walk the structured content blocks.
+	turn.Text, turn.ToolCalls = walkClaudeContent(tl.Message.Content)
+
+	// Usage: lift from message.usage if present.
+	if tl.Message.Usage != nil {
+		u := &Usage{
+			InputTokens:      tl.Message.Usage.InputTokens,
+			OutputTokens:     tl.Message.Usage.OutputTokens,
+			CacheReadTokens:  tl.Message.Usage.CacheReadInputTokens,
+			CacheWriteTokens: tl.Message.Usage.CacheCreationInputTokens,
+			StopReason:       tl.Message.StopReason,
+		}
+		u.TotalTokens = u.InputTokens + u.OutputTokens
+		turn.Usage = u
+	}
+
+	// Drop turns with no text and no tool calls (e.g. tool_result-only
+	// blocks). They carry no signal for either Drafter or Logbook.
+	if turn.Text == "" && len(turn.ToolCalls) == 0 {
+		return Turn{}, false
+	}
+
+	return turn, true
+}
+
+// walkClaudeContent traverses message.content (string or array of
+// blocks) and returns:
+//   - the concatenated text from text-typed blocks
+//   - the tool calls extracted from tool_use-typed blocks (with
+//     pre-computed Category)
+//
+// Other block types (tool_result, image, etc.) are ignored.
+func walkClaudeContent(content any) (string, []ToolCall) {
+	if content == nil {
+		return "", nil
+	}
+	if s, ok := content.(string); ok {
+		return strings.TrimSpace(s), nil
+	}
+	items, ok := content.([]any)
+	if !ok {
+		return "", nil
+	}
+	var (
+		textParts []string
+		tcs       []ToolCall
+	)
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		t, _ := m["type"].(string)
+		switch t {
+		case "text":
+			if text, _ := m["text"].(string); text != "" {
+				textParts = append(textParts, text)
+			}
+		case "tool_use":
+			name, _ := m["name"].(string)
+			if name == "" {
+				continue
+			}
+			input, _ := m["input"].(map[string]any)
+			tcs = append(tcs, ToolCall{
+				Name:     name,
+				Input:    input,
+				Category: CategorizeToolCall(name),
+			})
+		}
+	}
+	return strings.Join(textParts, "\n"), tcs
 }
 
 // trimLine removes leading/trailing whitespace from a byte slice.

--- a/cli/internal/watcher/adapter_claude.go
+++ b/cli/internal/watcher/adapter_claude.go
@@ -167,6 +167,7 @@ func (a *ClaudeAdapter) ExtractTurn(line []byte, sessionID string) (Turn, bool) 
 		Role:      tl.Type,
 		Model:     tl.Message.Model,
 		Provider:  "anthropic",
+		Harness:   "claude-code",
 	}
 	if turn.SessionID == "" {
 		turn.SessionID = sessionID

--- a/cli/internal/watcher/adapter_claude_extract_test.go
+++ b/cli/internal/watcher/adapter_claude_extract_test.go
@@ -1,0 +1,167 @@
+package watcher
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Test fixtures: representative Claude Code transcript JSONL lines.
+
+// Real transcripts are single-line JSON per record (JSONL). Fixtures
+// follow that shape so they round-trip through the watcher's
+// line-by-line reader correctly.
+const claudeUserTurn = `{"type":"user","sessionId":"s-test","timestamp":"2026-05-05T12:00:00.000Z","isSidechain":false,"message":{"role":"user","content":"deploy postgres canary"}}`
+
+const claudeAssistantTextTurn = `{"type":"assistant","sessionId":"s-test","timestamp":"2026-05-05T12:00:01.000Z","isSidechain":false,"message":{"id":"msg_abc","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"Sure, deploying now."}],"stop_reason":"end_turn","usage":{"input_tokens":1234,"output_tokens":56,"cache_creation_input_tokens":100,"cache_read_input_tokens":200}}}`
+
+const claudeAssistantToolUseTurn = `{"type":"assistant","sessionId":"s-test","timestamp":"2026-05-05T12:00:02.000Z","isSidechain":false,"message":{"id":"msg_def","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"Reading the file."},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/Users/x/secrets.env"}},{"type":"tool_use","id":"toolu_2","name":"Bash","input":{"command":"echo AKIA1234567890ABCDEF"}}],"stop_reason":"tool_use","usage":{"input_tokens":500,"output_tokens":80}}}`
+
+const claudeSidechainTurn = `{"type":"assistant","sessionId":"s-test","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"subagent"}]}}`
+
+const claudeToolResultTurn = `{"type":"user","sessionId":"s-test","isSidechain":false,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"file content"}]}}`
+
+func TestClaudeAdapter_ExtractTurn_UserText(t *testing.T) {
+	a := NewClaudeAdapter()
+	turn, ok := a.ExtractTurn([]byte(claudeUserTurn), "s-fallback")
+	if !ok {
+		t.Fatal("expected ok=true for user turn")
+	}
+	if turn.SessionID != "s-test" {
+		t.Errorf("SessionID = %q, want s-test (from line)", turn.SessionID)
+	}
+	if turn.Role != "user" {
+		t.Errorf("Role = %q, want user", turn.Role)
+	}
+	if turn.Text != "deploy postgres canary" {
+		t.Errorf("Text = %q", turn.Text)
+	}
+	if len(turn.ToolCalls) != 0 {
+		t.Errorf("user turn should have no tool calls, got %v", turn.ToolCalls)
+	}
+	if turn.Usage != nil {
+		t.Errorf("user turn should have no usage, got %+v", turn.Usage)
+	}
+	if turn.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want anthropic", turn.Provider)
+	}
+}
+
+func TestClaudeAdapter_ExtractTurn_AssistantTextWithUsage(t *testing.T) {
+	a := NewClaudeAdapter()
+	turn, ok := a.ExtractTurn([]byte(claudeAssistantTextTurn), "s-fallback")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if turn.Role != "assistant" {
+		t.Errorf("Role = %q, want assistant", turn.Role)
+	}
+	if turn.Text != "Sure, deploying now." {
+		t.Errorf("Text = %q", turn.Text)
+	}
+	if turn.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q", turn.Model)
+	}
+	if turn.Usage == nil {
+		t.Fatal("Usage should be non-nil for assistant turn with usage block")
+	}
+	if turn.Usage.InputTokens != 1234 {
+		t.Errorf("InputTokens = %d, want 1234", turn.Usage.InputTokens)
+	}
+	if turn.Usage.OutputTokens != 56 {
+		t.Errorf("OutputTokens = %d, want 56", turn.Usage.OutputTokens)
+	}
+	if turn.Usage.CacheReadTokens != 200 {
+		t.Errorf("CacheReadTokens = %d, want 200", turn.Usage.CacheReadTokens)
+	}
+	if turn.Usage.CacheWriteTokens != 100 {
+		t.Errorf("CacheWriteTokens = %d, want 100", turn.Usage.CacheWriteTokens)
+	}
+	if turn.Usage.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q", turn.Usage.StopReason)
+	}
+}
+
+func TestClaudeAdapter_ExtractTurn_AssistantWithToolCalls(t *testing.T) {
+	a := NewClaudeAdapter()
+	turn, ok := a.ExtractTurn([]byte(claudeAssistantToolUseTurn), "s-fallback")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if turn.Text != "Reading the file." {
+		t.Errorf("Text = %q (text-typed blocks should be concatenated, tool_use blocks excluded)", turn.Text)
+	}
+	if len(turn.ToolCalls) != 2 {
+		t.Fatalf("got %d tool calls, want 2", len(turn.ToolCalls))
+	}
+	read := turn.ToolCalls[0]
+	if read.Name != "Read" {
+		t.Errorf("ToolCalls[0].Name = %q, want Read", read.Name)
+	}
+	if read.Category != "codebase_read" {
+		t.Errorf("ToolCalls[0].Category = %q, want codebase_read", read.Category)
+	}
+	if got, _ := read.Input["file_path"].(string); got != "/Users/x/secrets.env" {
+		t.Errorf("Read.Input.file_path = %q (full input must be preserved for Drafter's filter)", got)
+	}
+	bash := turn.ToolCalls[1]
+	if bash.Name != "Bash" {
+		t.Errorf("ToolCalls[1].Name = %q, want Bash", bash.Name)
+	}
+	if bash.Category != "system" {
+		t.Errorf("ToolCalls[1].Category = %q, want system", bash.Category)
+	}
+	if got, _ := bash.Input["command"].(string); got != "echo AKIA1234567890ABCDEF" {
+		t.Errorf("Bash.Input.command should preserve raw text; got %q", got)
+	}
+}
+
+func TestClaudeAdapter_ExtractTurn_SkipsSidechain(t *testing.T) {
+	a := NewClaudeAdapter()
+	if _, ok := a.ExtractTurn([]byte(claudeSidechainTurn), "s"); ok {
+		t.Fatal("sidechain turn should be skipped")
+	}
+}
+
+func TestClaudeAdapter_ExtractTurn_SkipsToolResultOnlyTurn(t *testing.T) {
+	a := NewClaudeAdapter()
+	turn, ok := a.ExtractTurn([]byte(claudeToolResultTurn), "s")
+	// Tool-result-only user turns produce no text and no tool_calls;
+	// they should be skipped.
+	if ok && turn.Text == "" && len(turn.ToolCalls) == 0 {
+		t.Fatal("tool-result-only turn returned ok=true with empty payload — should be skipped")
+	}
+}
+
+func TestClaudeAdapter_ExtractTurn_FallsBackToSessionIDArg(t *testing.T) {
+	// A line without a top-level sessionId field should fall back to
+	// the watcher-supplied sessionID (derived from filename).
+	line := `{"type":"user","message":{"role":"user","content":"hi"}}`
+	a := NewClaudeAdapter()
+	turn, ok := a.ExtractTurn([]byte(line), "s-from-filename")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if turn.SessionID != "s-from-filename" {
+		t.Errorf("SessionID = %q, want fallback s-from-filename", turn.SessionID)
+	}
+}
+
+func TestClaudeAdapter_ExtractTurn_RejectsMalformedJSON(t *testing.T) {
+	a := NewClaudeAdapter()
+	if _, ok := a.ExtractTurn([]byte("not valid json"), "s"); ok {
+		t.Fatal("malformed line should return ok=false")
+	}
+}
+
+// Sanity: the rich extraction does not depend on legacy ParseLine
+// semantics — make sure ExtractTurn works on the same fixtures
+// without using the recorder.RawEntry type at all.
+func TestClaudeAdapter_ExtractTurn_DoesNotPolluteRawEntry(t *testing.T) {
+	a := NewClaudeAdapter()
+	turn, _ := a.ExtractTurn([]byte(claudeAssistantTextTurn), "s")
+	// Reflect-based smoke check: the type returned is watcher.Turn,
+	// not recorder.RawEntry.
+	if reflect.TypeOf(turn).Name() != "Turn" {
+		t.Errorf("ExtractTurn returned %v, want watcher.Turn", reflect.TypeOf(turn))
+	}
+}

--- a/cli/internal/watcher/adapter_pi.go
+++ b/cli/internal/watcher/adapter_pi.go
@@ -283,6 +283,25 @@ type piMessage struct {
 	Content any    `json:"content"` // string or []map[string]any
 }
 
+// ExtractTurn delegates to ParseLine for now and synthesises a thin
+// Turn from the resulting RawEntry. Pi-specific tool_use / usage
+// extraction will land in a follow-up slice; the legacy Pi
+// SessionParser already covers session-end aggregates so the
+// metadata projection has fallback data.
+func (a *PiAdapter) ExtractTurn(line []byte, sessionID string) (Turn, bool) {
+	entry, ok := a.ParseLine(line, sessionID)
+	if !ok {
+		return Turn{}, false
+	}
+	return Turn{
+		SessionID: entry.SessionID,
+		Timestamp: time.Now().UTC(),
+		Role:      strings.TrimPrefix(entry.Event, "watch-"),
+		Text:      entry.Text,
+		Provider:  "pi",
+	}, true
+}
+
 // ParseLine parses one JSONL line. Returns a RawEntry only for user/assistant
 // message entries with non-empty text content.
 func (a *PiAdapter) ParseLine(line []byte, sessionID string) (recorder.RawEntry, bool) {

--- a/cli/internal/watcher/adapter_pi.go
+++ b/cli/internal/watcher/adapter_pi.go
@@ -298,7 +298,7 @@ func (a *PiAdapter) ExtractTurn(line []byte, sessionID string) (Turn, bool) {
 		Timestamp: time.Now().UTC(),
 		Role:      strings.TrimPrefix(entry.Event, "watch-"),
 		Text:      entry.Text,
-		Provider:  "pi",
+		Harness:   "pi",
 	}, true
 }
 

--- a/cli/internal/watcher/adapter_windsurf.go
+++ b/cli/internal/watcher/adapter_windsurf.go
@@ -160,7 +160,7 @@ func (a *WindsurfAdapter) ExtractTurn(line []byte, sessionID string) (Turn, bool
 		Timestamp: time.Now().UTC(),
 		Role:      role,
 		Text:      entry.Text,
-		Provider:  "codeium",
+		Harness:   "windsurf",
 	}, true
 }
 

--- a/cli/internal/watcher/adapter_windsurf.go
+++ b/cli/internal/watcher/adapter_windsurf.go
@@ -143,6 +143,27 @@ type windsurfPlannerResponse struct {
 	Response string `json:"response"`
 }
 
+// ExtractTurn delegates to ParseLine for PR 1 and synthesises a thin
+// Turn from the resulting RawEntry. Windsurf-specific tool_use /
+// usage extraction lands in a follow-up slice.
+func (a *WindsurfAdapter) ExtractTurn(line []byte, sessionID string) (Turn, bool) {
+	entry, ok := a.ParseLine(line, sessionID)
+	if !ok {
+		return Turn{}, false
+	}
+	role := "user"
+	if entry.Event == "watch-planner_response" || entry.Event == "watch-assistant" {
+		role = "assistant"
+	}
+	return Turn{
+		SessionID: entry.SessionID,
+		Timestamp: time.Now().UTC(),
+		Role:      role,
+		Text:      entry.Text,
+		Provider:  "codeium",
+	}, true
+}
+
 // ParseLine implements Adapter. It parses one JSONL line and returns a
 // RawEntry if the line contains user_input or planner_response content.
 func (a *WindsurfAdapter) ParseLine(line []byte, sessionID string) (recorder.RawEntry, bool) {

--- a/cli/internal/watcher/categorize.go
+++ b/cli/internal/watcher/categorize.go
@@ -1,0 +1,68 @@
+package watcher
+
+import "strings"
+
+// CategorizeToolCall buckets a tool name into one of the v0.30 op
+// categories. Logbook persists categories (not names) on the metadata
+// projection, so this is the boundary between harness-specific tool
+// vocabulary and the dashboard's stable category model.
+//
+// Five buckets, by convention used in lens panels:
+//
+//	mom_memory     — memory-touching MCP tools
+//	mom_cli        — mom-specific CLI invocations
+//	codebase_read  — reads of repo content
+//	codebase_write — writes to repo content
+//	system         — everything else (Bash, Glob, harness internals…)
+//
+// The function lived in internal/logbook in the v1 design; it moves
+// here because the watcher is the only component that sees individual
+// tool names in v0.30. Logbook never categorises — it persists the
+// pre-computed category from the watcher.
+func CategorizeToolCall(toolName string) string {
+	name := NormalizeToolName(toolName)
+	switch {
+	case isMemoryTool(name):
+		return "mom_memory"
+	case isMomCLI(name):
+		return "mom_cli"
+	case isCodebaseRead(name):
+		return "codebase_read"
+	case isCodebaseWrite(name):
+		return "codebase_write"
+	default:
+		return "system"
+	}
+}
+
+// NormalizeToolName strips runtime-specific prefixes from tool names.
+// Claude Code namespaces MCP tools as "mcp__<server>__<tool>"; this
+// returns the bare tool name so categorisation is harness-agnostic.
+func NormalizeToolName(toolName string) string {
+	if strings.HasPrefix(toolName, "mcp__") {
+		if i := strings.Index(toolName[5:], "__"); i >= 0 {
+			return toolName[5+i+2:]
+		}
+	}
+	return toolName
+}
+
+func isMemoryTool(name string) bool {
+	return name == "mom_recall" || name == "search_memories" || name == "get_memory" ||
+		name == "create_memory_draft" || name == "list_landmarks" ||
+		name == "mom_record_turn" || name == "mom_record" ||
+		name == "mom_get" || name == "mom_landmarks" || name == "mom_status"
+}
+
+func isMomCLI(name string) bool {
+	return name == "mom_draft" || name == "mom_log"
+}
+
+func isCodebaseRead(name string) bool {
+	return name == "Read" || name == "read" || name == "Grep" || name == "grep" ||
+		name == "Glob" || name == "glob" || name == "rg"
+}
+
+func isCodebaseWrite(name string) bool {
+	return name == "Edit" || name == "edit" || name == "Write" || name == "write"
+}

--- a/cli/internal/watcher/categorize_test.go
+++ b/cli/internal/watcher/categorize_test.go
@@ -1,0 +1,54 @@
+package watcher
+
+import "testing"
+
+func TestCategorizeToolCall(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		// Memory tools — bare and MCP-prefixed.
+		{"mom_recall", "mom_memory"},
+		{"mom_record", "mom_memory"},
+		{"mom_get", "mom_memory"},
+		{"mom_landmarks", "mom_memory"},
+		{"mom_status", "mom_memory"},
+		{"mcp__mom__mom_recall", "mom_memory"},
+		{"mcp__mom__mom_record", "mom_memory"},
+		// Codebase reads.
+		{"Read", "codebase_read"},
+		{"Grep", "codebase_read"},
+		{"Glob", "codebase_read"},
+		// Codebase writes.
+		{"Write", "codebase_write"},
+		{"Edit", "codebase_write"},
+		// Anything else falls to system.
+		{"Bash", "system"},
+		{"WebSearch", "system"},
+		{"unknown_tool", "system"},
+		{"", "system"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CategorizeToolCall(tc.name)
+			if got != tc.want {
+				t.Errorf("CategorizeToolCall(%q) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeToolName(t *testing.T) {
+	cases := map[string]string{
+		"Read":                 "Read",
+		"mcp__mom__mom_recall": "mom_recall",
+		"mcp__github__create":  "create",
+		"mcp__":                "mcp__",     // malformed: no second separator
+		"":                     "",
+	}
+	for in, want := range cases {
+		if got := NormalizeToolName(in); got != want {
+			t.Errorf("NormalizeToolName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/internal/watcher/turn.go
+++ b/cli/internal/watcher/turn.go
@@ -1,0 +1,95 @@
+package watcher
+
+import "time"
+
+// Turn is the per-turn structured payload emitted by the watcher's
+// adapters. It carries everything Drafter needs to make filter
+// decisions (raw text, tool inputs) AND everything Logbook needs to
+// produce a privacy-safe metadata projection (role, tool categories,
+// usage, model, provider).
+//
+// The full Turn rides on the Herald bus inside `turn.observed` events.
+// It is NEVER persisted in raw form. Drafter persists a redacted
+// memory through Librarian; Logbook persists a metadata projection.
+// See PRD 0003 + ADR 0014 for the privacy contract.
+type Turn struct {
+	SessionID string
+	Timestamp time.Time
+	Role      string // "user" | "assistant"
+	Text      string
+	ToolCalls []ToolCall
+	Usage     *Usage
+	Model     string // empty when the harness does not surface it
+	Provider  string // empty when the harness does not surface it
+}
+
+// ToolCall is one tool invocation observed in an assistant turn.
+// `Input` carries the raw tool arguments (file paths, shell commands,
+// etc.) for Drafter's filter pipeline. `Category` is pre-computed by
+// the adapter using CategorizeToolCall so Logbook's projection does
+// not need to look at tool names.
+type ToolCall struct {
+	Name     string
+	Input    map[string]any
+	Category string // "mom_memory" | "mom_cli" | "codebase_read" | "codebase_write" | "system"
+}
+
+// Usage carries token-accounting numbers for a single turn. Optional —
+// not every harness surfaces it (e.g. user turns rarely have usage).
+type Usage struct {
+	InputTokens      int
+	OutputTokens     int
+	CacheReadTokens  int
+	CacheWriteTokens int
+	TotalTokens      int
+	CostUSD          float64
+	StopReason       string
+}
+
+// ToPayload renders a Turn into the map[string]any shape carried by
+// Herald's turn.observed event. Drafter and Logbook both read these
+// keys; the map convention is documented here so subscribers don't
+// reinvent extraction.
+//
+// Keys: "role", "text", "tool_calls" ([]map with name/input/category),
+// "usage" (map of token counts), "model", "provider".
+func (t Turn) ToPayload() map[string]any {
+	out := map[string]any{
+		"role": t.Role,
+	}
+	if t.Text != "" {
+		out["text"] = t.Text
+	}
+	if len(t.ToolCalls) > 0 {
+		tcs := make([]map[string]any, 0, len(t.ToolCalls))
+		for _, tc := range t.ToolCalls {
+			m := map[string]any{
+				"name":     tc.Name,
+				"category": tc.Category,
+			}
+			if tc.Input != nil {
+				m["input"] = tc.Input
+			}
+			tcs = append(tcs, m)
+		}
+		out["tool_calls"] = tcs
+	}
+	if t.Usage != nil {
+		out["usage"] = map[string]any{
+			"input_tokens":       t.Usage.InputTokens,
+			"output_tokens":      t.Usage.OutputTokens,
+			"cache_read_tokens":  t.Usage.CacheReadTokens,
+			"cache_write_tokens": t.Usage.CacheWriteTokens,
+			"total_tokens":       t.Usage.TotalTokens,
+			"cost_usd":           t.Usage.CostUSD,
+			"stop_reason":        t.Usage.StopReason,
+		}
+	}
+	if t.Model != "" {
+		out["model"] = t.Model
+	}
+	if t.Provider != "" {
+		out["provider"] = t.Provider
+	}
+	return out
+}

--- a/cli/internal/watcher/turn.go
+++ b/cli/internal/watcher/turn.go
@@ -19,8 +19,13 @@ type Turn struct {
 	Text      string
 	ToolCalls []ToolCall
 	Usage     *Usage
-	Model     string // empty when the harness does not surface it
-	Provider  string // empty when the harness does not surface it
+
+	// Three orthogonal identity fields, each answering a different
+	// question. Any may be empty when the source transcript does not
+	// surface the data.
+	Model    string // "the model": e.g. "claude-sonnet-4-6", "gpt-4o"
+	Provider string // "provided by whom": model vendor — "anthropic", "openai", …
+	Harness  string // "used in which client": "claude-code", "codex", "windsurf", "pi"
 }
 
 // ToolCall is one tool invocation observed in an assistant turn.

--- a/cli/internal/watcher/turn_emit_test.go
+++ b/cli/internal/watcher/turn_emit_test.go
@@ -1,0 +1,171 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/momhq/mom/cli/internal/herald"
+)
+
+// TestIngestFile_PublishesTurnObserved locks the watcher's v0.30
+// emission contract: every parsed turn produces ONE turn.observed
+// event on the configured bus, with the rich payload Drafter and
+// Logbook consume.
+func TestIngestFile_PublishesTurnObserved(t *testing.T) {
+	transcriptDir := t.TempDir()
+	momDir := t.TempDir()
+	bus := herald.NewBus()
+
+	var mu sync.Mutex
+	var captured []herald.Event
+	bus.Subscribe(herald.TurnObserved, func(e herald.Event) {
+		mu.Lock()
+		captured = append(captured, e)
+		mu.Unlock()
+	})
+
+	w := &Watcher{
+		cfg: Config{
+			TranscriptDir: transcriptDir,
+			MomDir:        momDir,
+			Adapter:       NewClaudeAdapter(),
+			Bus:           bus,
+			DebounceMs:    300,
+		},
+		timers:  make(map[string]*time.Timer),
+		rawDir:  filepath.Join(momDir, "raw"),
+		logFile: filepath.Join(momDir, "watch.log"),
+	}
+	_ = os.MkdirAll(w.rawDir, 0755)
+
+	// Two real Claude transcript lines: one user, one assistant with
+	// usage + a tool_use block.
+	transcriptPath := filepath.Join(transcriptDir, "s-emit.jsonl")
+	body := claudeUserTurn + "\n" + claudeAssistantToolUseTurn + "\n"
+	if err := os.WriteFile(transcriptPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("writing transcript: %v", err)
+	}
+
+	w.ingestFile(transcriptPath)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 2 {
+		t.Fatalf("got %d turn.observed events, want 2", len(captured))
+	}
+
+	// First event: user turn.
+	user := captured[0]
+	if user.SessionID != "s-test" {
+		t.Errorf("user event SessionID = %q, want s-test", user.SessionID)
+	}
+	if got, _ := user.Payload["role"].(string); got != "user" {
+		t.Errorf("user event role = %v, want user", user.Payload["role"])
+	}
+
+	// Second event: assistant turn with tool_use.
+	asst := captured[1]
+	if asst.SessionID != "s-test" {
+		t.Errorf("assistant event SessionID = %q, want s-test", asst.SessionID)
+	}
+	if got, _ := asst.Payload["role"].(string); got != "assistant" {
+		t.Errorf("assistant event role = %v, want assistant", asst.Payload["role"])
+	}
+	tcs, _ := asst.Payload["tool_calls"].([]map[string]any)
+	if len(tcs) != 2 {
+		t.Errorf("tool_calls len = %d, want 2 (Read + Bash)", len(tcs))
+	}
+	// Verify the Bash command (which contains an AKIA-shaped sentinel
+	// in the fixture) IS preserved in the bus payload — Drafter needs
+	// it for filter decisions. The privacy stripping happens in
+	// Logbook's projection, not in the bus event itself.
+	if len(tcs) >= 2 {
+		input, _ := tcs[1]["input"].(map[string]any)
+		cmd, _ := input["command"].(string)
+		if cmd == "" {
+			t.Errorf("Bash tool_call.input.command should be preserved on the bus, got empty")
+		}
+	}
+
+	// Sanity: timestamps were stamped (the bus stamps Timestamp).
+	for i, e := range captured {
+		if e.Timestamp.IsZero() {
+			t.Errorf("event[%d] missing Timestamp (bus should stamp)", i)
+		}
+	}
+}
+
+// TestIngestFile_PublishesNothingWithoutBus locks the inverse: when
+// the watcher has no Bus configured, ingestion still works (legacy
+// raw writer) but no events are published. Catches a future
+// regression where someone accidentally creates a default Bus.
+func TestIngestFile_PublishesNothingWithoutBus(t *testing.T) {
+	transcriptDir := t.TempDir()
+	momDir := t.TempDir()
+
+	w := &Watcher{
+		cfg: Config{
+			TranscriptDir: transcriptDir,
+			MomDir:        momDir,
+			Adapter:       NewClaudeAdapter(),
+			DebounceMs:    300,
+			// Bus intentionally nil
+		},
+		timers:  make(map[string]*time.Timer),
+		rawDir:  filepath.Join(momDir, "raw"),
+		logFile: filepath.Join(momDir, "watch.log"),
+	}
+	_ = os.MkdirAll(w.rawDir, 0755)
+
+	transcriptPath := filepath.Join(transcriptDir, "s-no-bus.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte(claudeUserTurn+"\n"), 0o644); err != nil {
+		t.Fatalf("writing transcript: %v", err)
+	}
+
+	// Should not panic; should still write to raw.
+	count := w.ingestFile(transcriptPath)
+	if count == 0 {
+		t.Errorf("expected ingest count > 0, got 0")
+	}
+}
+
+// TestIngestFile_PublishesOneEventPerTurn uses a watcher with three
+// turns to verify the per-turn-not-per-batch contract.
+func TestIngestFile_PublishesOneEventPerTurn(t *testing.T) {
+	transcriptDir := t.TempDir()
+	momDir := t.TempDir()
+	bus := herald.NewBus()
+
+	var fires atomic.Int64
+	bus.Subscribe(herald.TurnObserved, func(e herald.Event) { fires.Add(1) })
+
+	w := &Watcher{
+		cfg: Config{
+			TranscriptDir: transcriptDir,
+			MomDir:        momDir,
+			Adapter:       NewClaudeAdapter(),
+			Bus:           bus,
+			DebounceMs:    300,
+		},
+		timers:  make(map[string]*time.Timer),
+		rawDir:  filepath.Join(momDir, "raw"),
+		logFile: filepath.Join(momDir, "watch.log"),
+	}
+	_ = os.MkdirAll(w.rawDir, 0755)
+
+	transcriptPath := filepath.Join(transcriptDir, "s-three.jsonl")
+	body := claudeUserTurn + "\n" + claudeAssistantTextTurn + "\n" + claudeAssistantToolUseTurn + "\n"
+	if err := os.WriteFile(transcriptPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("writing transcript: %v", err)
+	}
+
+	w.ingestFile(transcriptPath)
+
+	if got := fires.Load(); got != 3 {
+		t.Errorf("turn.observed fired %d times, want 3 (one per turn)", got)
+	}
+}

--- a/cli/internal/watcher/watcher.go
+++ b/cli/internal/watcher/watcher.go
@@ -371,8 +371,10 @@ func (w *Watcher) ingestFile(path string) int {
 	// Read new content. Use ReadBytes('\n') instead of Scanner to distinguish
 	// complete lines (terminated by \n) from truncated trailing data (#153).
 	var entries []recorder.RawEntry
+	var turns []Turn
 	var committedBytes int64
 	reader := bufio.NewReaderSize(f, 2*1024*1024)
+	adapter := w.adapterForPath(path)
 
 	for {
 		line, err := reader.ReadBytes('\n')
@@ -386,11 +388,17 @@ func (w *Watcher) ingestFile(path string) int {
 			continue
 		}
 
-		entry, ok := w.adapterForPath(path).ParseLine(raw, sessionID)
-		if !ok {
-			continue
+		// Legacy path: collect RawEntry for the .mom/raw/ writer (retired
+		// in #240 PR 3).
+		if entry, ok := adapter.ParseLine(raw, sessionID); ok {
+			entries = append(entries, entry)
 		}
-		entries = append(entries, entry)
+		// v0.30 path: collect Turn for the turn.observed bus event
+		// consumed by Drafter (filter pipeline) and Logbook (metadata
+		// projection).
+		if turn, ok := adapter.ExtractTurn(raw, sessionID); ok {
+			turns = append(turns, turn)
+		}
 	}
 
 	if committedBytes == 0 {
@@ -429,6 +437,20 @@ func (w *Watcher) ingestFile(path string) int {
 				"runtime":         w.adapterForPath(path).Name(),
 			},
 		})
+	}
+
+	// v0.30 emission: one turn.observed event per parsed Turn. Carries
+	// the full structured payload Drafter needs for filter decisions.
+	// Logbook subscribes and persists a metadata projection; Drafter
+	// (lands in #240 PR 2) subscribes and persists redacted memories.
+	if w.cfg.Bus != nil {
+		for _, t := range turns {
+			w.cfg.Bus.Publish(herald.Event{
+				Type:      herald.TurnObserved,
+				SessionID: t.SessionID,
+				Payload:   t.ToPayload(),
+			})
+		}
 	}
 
 	return len(entries)

--- a/cli/internal/watcher/watcher_test.go
+++ b/cli/internal/watcher/watcher_test.go
@@ -31,6 +31,22 @@ func (m *mockAdapter) ParseLine(line []byte, sessionID string) (recorder.RawEntr
 	}, true
 }
 
+// ExtractTurn returns a minimal Turn for the watcher's bus emission
+// tests. Does NOT call ParseLine (would double-count m.calls in tests
+// that assert on parse-call frequency). Rich-content adapter tests
+// exercise the real ClaudeAdapter.
+func (m *mockAdapter) ExtractTurn(line []byte, sessionID string) (Turn, bool) {
+	if len(strings.TrimSpace(string(line))) == 0 {
+		return Turn{}, false
+	}
+	return Turn{
+		SessionID: sessionID,
+		Timestamp: time.Now().UTC(),
+		Role:      "assistant",
+		Text:      "mock: " + string(line),
+	}, true
+}
+
 // TestSessionIDFromPath verifies that the session ID is derived from the filename.
 func TestSessionIDFromPath(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary

First slice of the Drafter refactor (#240). Wires the watcher → Herald → Logbook half of the v0.30 capture pipeline. Drafter (consumer of `turn.observed` for memory persistence) lands in PR 2; cartographer adapter + legacy cleanup land in PR 3.

## Architecture

```
Watcher (harness adapter)
    │  ExtractTurn → Turn{role, text, tool_calls[…], usage, model, provider}
    ▼
Herald.Publish(turn.observed)        ← full payload, on bus only
    │
    └──► Logbook.SubscribeTurnObserved
            │  projects to metadata: role, tool_categories[], usage, model, provider
            ▼  (NO text, NO tool inputs, NO names)
        Librarian.InsertOpEvent → op_events row
```

## Privacy contract — locked by test

`TestSubscribeTurnObserved_PersistsMetadataProjection` injects an AKIA-shaped sentinel + file path + shell command into a `turn.observed` payload and asserts the persisted `op_events` row contains **none** of them. Drafter's redaction promise is end-to-end because the audit substrate stores only metadata that contains no redactable content.

## Test plan

- [x] 8 ClaudeAdapter `ExtractTurn` cases
- [x] 16 categorize cases
- [x] 3 watcher emit cases (`turn.observed` per turn, no-bus graceful, count)
- [x] 2 Logbook projection cases (privacy + empty-session drop)
- [x] `go test ./...` — full repo green
- [x] `go test -race ./internal/watcher/ ./internal/logbook/ ./internal/herald/ ./internal/cmd/` — race-clean

## What's not in this PR

- Drafter (consumer of turn.observed for memory persistence) — PR 2
- Hard secret filter, soft noise filter — PR 2
- Cartographer adapter — PR 3
- Legacy `.mom/raw/` writer deletion — PR 3
- Legacy `internal/logbook.SessionLog`/`ParseTranscript` deletion — PR 3 / #248
- Pi and Windsurf rich `ExtractTurn` — follow-up; PR 1 ships thin stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)