### PR TITLE
v0.30: extend hard filter to OpenAI / Anthropic / Slack / Google / DB URL / generic Bearer

### DIFF
--- a/cli/internal/drafter/filters_hard.go
+++ b/cli/internal/drafter/filters_hard.go
@@ -11,6 +11,13 @@ import (
 // the category counter is bumped on filter_audit. The matched
 // substance is NEVER stored anywhere — neither in the memory row nor
 // in the audit row.
+//
+// Redaction scope is determined by the regex itself: if it declares
+// at least one capturing group, ONLY group 1 is redacted (the
+// surrounding match stays so the line still reads as a useful
+// memory). If it has no capturing groups, the whole match is
+// redacted. Use `(?:...)` for non-capturing alternations when you
+// want whole-match redaction with internal grouping.
 type secretPattern struct {
 	category string
 	re       *regexp.Regexp
@@ -20,8 +27,10 @@ type secretPattern struct {
 // names the categories MOM ships with; see lessons/PRD for the
 // rationale on each.
 //
-// Order matters: more-specific patterns run before generic ones so
-// a JWT or PEM block isn't half-matched by env_assignment first.
+// Order matters: more-specific patterns run before generic ones so a
+// JWT or PEM block isn't half-matched by auth_header or env_assignment
+// first, and provider-specific shapes (OpenAI/Slack/Google) win
+// attribution before the generic Authorization-header rule fires.
 var hardFilterPatterns = []secretPattern{
 	// AWS access key id — fixed prefix + 16 base32-ish chars.
 	{
@@ -40,10 +49,33 @@ var hardFilterPatterns = []secretPattern{
 		re:       regexp.MustCompile(`github_pat_[A-Za-z0-9_]{50,}`),
 	},
 	// Stripe live keys (sk_live_ / pk_live_). 24+ alnum chars after
-	// the prefix.
+	// the prefix. Non-capturing alternation so the whole token is
+	// redacted, not just the prefix.
 	{
 		category: "stripe_key",
-		re:       regexp.MustCompile(`(sk|pk)_live_[A-Za-z0-9]{24,}`),
+		re:       regexp.MustCompile(`(?:sk|pk)_live_[A-Za-z0-9]{24,}`),
+	},
+	// OpenAI / Anthropic API keys. OpenAI legacy keys are sk-<long>;
+	// project-scoped are sk-proj-<...>; Anthropic console/admin keys
+	// are sk-ant-<...> (often sk-ant-api03-<...>). Lower bound of 20
+	// chars on the body avoids matching shell prompts ("sk-" alone)
+	// or short examples. Non-capturing prefix alternation so the
+	// whole token redacts.
+	{
+		category: "openai_anthropic_key",
+		re:       regexp.MustCompile(`sk-(?:proj-|ant-(?:api\d+-)?)?[A-Za-z0-9_-]{20,}`),
+	},
+	// Slack tokens — bot/app/admin/refresh/user tokens all share the
+	// `xox<letter>-` prefix followed by dash-separated identifier and
+	// secret components.
+	{
+		category: "slack_token",
+		re:       regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),
+	},
+	// Google API keys — fixed AIza prefix + 35 URL-safe-base64 chars.
+	{
+		category: "google_api_key",
+		re:       regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`),
 	},
 	// PEM private key blocks. Match across newlines (?s) so the body
 	// of the block is captured. Non-greedy on the body so only one
@@ -60,10 +92,15 @@ var hardFilterPatterns = []secretPattern{
 		category: "jwt",
 		re:       regexp.MustCompile(`eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`),
 	},
+	// Database connection URLs with embedded credentials. Capture is
+	// the userinfo portion (user:pass) — that alone gets redacted so
+	// the scheme + host + path remain readable as memory context.
+	{
+		category: "db_url_credentials",
+		re:       regexp.MustCompile(`(?i)\b(?:postgres(?:ql)?|mongodb(?:\+srv)?|mysql|mariadb|redis|amqps?)://([^\s:@/]+:[^\s@/]+)@`),
+	},
 	// Env-style assignment: a name like API_KEY / SECRET / TOKEN /
 	// PASSWORD followed by =, :, or "= " then a non-whitespace value.
-	// The whole match is redacted; "API_KEY=…" surrounding context is
-	// preserved by line/word boundaries on either side.
 	//
 	// We redact ONLY the value (the part after the operator), keeping
 	// the variable name visible. That's intentional: the variable
@@ -73,6 +110,17 @@ var hardFilterPatterns = []secretPattern{
 	{
 		category: "env_assignment",
 		re:       regexp.MustCompile(`(?i)(?:API[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD|AUTH[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY)[\s]*[:=][\s]*"?([^\s"']+)"?`),
+	},
+	// Generic Authorization header carrying an opaque Bearer/Basic
+	// credential. Runs LAST among the credential-shaped rules so
+	// provider-specific patterns above (OpenAI / Slack / Google /
+	// JWT) consume their tokens first and keep attribution; this is
+	// the catch-all for bearer tokens that don't match any known
+	// provider shape. Capture is the credential value — header name
+	// and scheme survive.
+	{
+		category: "auth_header",
+		re:       regexp.MustCompile(`(?i)Authorization:\s*(?:Bearer|Basic)\s+([A-Za-z0-9._~+/=-]{16,})`),
 	},
 }
 
@@ -91,20 +139,20 @@ func redactSecrets(text string) (string, []string) {
 	categories := map[string]struct{}{}
 	for _, p := range hardFilterPatterns {
 		var (
-			matched bool
+			matched  bool
 			redacted string
 		)
-		if p.category == "env_assignment" {
-			// For env-style assignments we only redact the VALUE
-			// capture group, not the whole match. The variable name
-			// stays so the surrounding prose remains useful.
+		if p.re.NumSubexp() >= 1 {
+			// Capture-group redaction: replace only the first capture
+			// group (the credential value) and keep the surrounding
+			// match (variable name, scheme, header name) so the line
+			// still reads as a useful memory.
 			redacted = p.re.ReplaceAllStringFunc(out, func(s string) string {
 				m := p.re.FindStringSubmatch(s)
 				if len(m) < 2 || m[1] == "" {
 					return s
 				}
 				matched = true
-				// Replace just the value within the matched span.
 				start := strings.Index(s, m[1])
 				if start < 0 {
 					return s
@@ -112,6 +160,8 @@ func redactSecrets(text string) (string, []string) {
 				return s[:start] + "[REDACTED]" + s[start+len(m[1]):]
 			})
 		} else {
+			// Whole-match redaction: the token is the secret in full
+			// (AKIA…, AIza…, ghp_…, JWT, PEM block, etc.).
 			locs := p.re.FindAllStringIndex(out, -1)
 			matched = len(locs) > 0
 			redacted = p.re.ReplaceAllString(out, "[REDACTED]")

--- a/cli/internal/drafter/filters_hard_test.go
+++ b/cli/internal/drafter/filters_hard_test.go
@@ -102,6 +102,79 @@ func TestRedactSecrets_PatternFixture(t *testing.T) {
 			wantCategory: "env_assignment",
 			wantSurvives: "JWT_SECRET",
 		},
+		{
+			// OpenAI legacy key shape — `sk-` followed by an opaque
+			// alnum/dash/underscore body. Chosen body length 30 so the
+			// regex's 20-char floor is comfortably exceeded.
+			name:         "openai-legacy-key",
+			input:        `curl -H "Authorization: Bearer sk-AbCdEfGhIjKlMnOpQrStUvWxYz0123" https://api.openai.com/v1/chat`,
+			secret:       "sk-AbCdEfGhIjKlMnOpQrStUvWxYz0123",
+			wantCategory: "openai_anthropic_key",
+			wantSurvives: "https://api.openai.com",
+		},
+		{
+			// Project-scoped OpenAI key — `sk-proj-` prefix.
+			name:         "openai-proj-key",
+			input:        "client = OpenAI(api_key='sk-proj-aB12cD34eF56gH78iJ90kLmNoPqRsTuVwXyZ')",
+			secret:       "sk-proj-aB12cD34eF56gH78iJ90kLmNoPqRsTuVwXyZ",
+			wantCategory: "openai_anthropic_key",
+			wantSurvives: "client = OpenAI",
+		},
+		{
+			// Anthropic console key — `sk-ant-api03-` shape.
+			name:         "anthropic-key",
+			input:        "ANTHROPIC: sk-ant-api03-aB12cD34eF56gH78iJ90kLmNoPqRsTu",
+			secret:       "sk-ant-api03-aB12cD34eF56gH78iJ90kLmNoPqRsTu",
+			wantCategory: "openai_anthropic_key",
+			wantSurvives: "ANTHROPIC:",
+		},
+		{
+			// Slack bot token shape `xoxb-...`. Synthetic placeholder
+			// (literal "x" body) so GitHub secret scanning does not
+			// false-positive the test corpus on push — same approach
+			// as the Stripe fixture above.
+			name:         "slack-bot-token",
+			input:        "webhook config: xoxb-" + strings.Repeat("x", 30) + " landed",
+			secret:       "xoxb-" + strings.Repeat("x", 30),
+			wantCategory: "slack_token",
+			wantSurvives: "webhook config:",
+		},
+		{
+			// Google API key — fixed AIza prefix + 35 char body.
+			name:         "google-api-key",
+			input:        "GOOGLE_MAPS=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz0123456 in config",
+			secret:       "AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz0123456",
+			wantCategory: "google_api_key",
+			wantSurvives: "in config",
+		},
+		{
+			// Postgres connection URL with embedded credentials.
+			// Only the userinfo (user:pass) is redacted; scheme + host
+			// + path stay so the URL still reads as memory context.
+			name:         "postgres-url-creds",
+			input:        "DSN: postgres://admin:hunter2@db.internal:5432/orders",
+			secret:       "admin:hunter2",
+			wantCategory: "db_url_credentials",
+			wantSurvives: "db.internal:5432/orders",
+		},
+		{
+			// MongoDB SRV URL with credentials.
+			name:         "mongodb-srv-url-creds",
+			input:        "uri = mongodb+srv://serviceUser:topsecretpw@cluster0.mongodb.net/prod",
+			secret:       "serviceUser:topsecretpw",
+			wantCategory: "db_url_credentials",
+			wantSurvives: "cluster0.mongodb.net",
+		},
+		{
+			// Bare bearer token in an Authorization header that is
+			// neither JWT-shaped nor a recognized provider shape. The
+			// generic auth_header rule must still redact the value.
+			name:         "auth-header-opaque-bearer",
+			input:        "request: Authorization: Bearer abcDEF123-_456ghiJKLmnopqrstUVWXyz then",
+			secret:       "abcDEF123-_456ghiJKLmnopqrstUVWXyz",
+			wantCategory: "auth_header",
+			wantSurvives: "request:",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

Security review on PR #273 caught a coverage gap in the v0.30 secret detection library. The shipped patterns (AWS / GitHub / Stripe / PEM / JWT / env-assignment) miss the most common LLM-context secret shapes — OpenAI/Anthropic API keys, Slack tokens, Google API keys, database URLs with embedded credentials, and bare bearer tokens not preceded by an env-name keyword. A turn containing e.g. \`Authorization: Bearer sk-proj-...\` would persist verbatim into \`memories.content\` and be FTS5-indexed for recall.

This PR closes that gap.

## What changed

### New patterns in \`hardFilterPatterns\`

| Category | Regex | Notes |
|---|---|---|
| \`openai_anthropic_key\` | \`sk-(?:proj-|ant-(?:api\d+-)?)?[A-Za-z0-9_-]{20,}\` | OpenAI legacy + project-scoped + Anthropic console (incl. \`api03-\`) |
| \`slack_token\` | \`xox[baprs]-[A-Za-z0-9-]{10,}\` | bot/app/admin/refresh/user tokens |
| \`google_api_key\` | \`AIza[0-9A-Za-z_-]{35}\` | fixed prefix + 35-char body |
| \`db_url_credentials\` | \`(?i)\\b(?:postgres(?:ql)?\|mongodb(?:\\+srv)?\|mysql\|mariadb\|redis\|amqps?)://([^\\s:@/]+:[^\\s@/]+)@\` | redacts only \`user:pass\` userinfo; scheme + host + path stay readable |
| \`auth_header\` | \`(?i)Authorization:\\s*(?:Bearer\|Basic)\\s+([A-Za-z0-9._~+/=-]{16,})\` | catch-all for bearer/basic; runs LAST so provider-specific patterns above keep attribution |

### Refactor: uniform redaction rule

Replaced the category-string dispatch (\`if p.category == \"env_assignment\"\`) with a uniform rule based on the regex itself:
- **Capture group present** → redact only group 1 (the credential value); surrounding match (variable name, scheme, header name) stays so the line still reads as memory context.
- **No capture group** → redact the whole match (AKIA…, AIza…, ghp_…, JWT, PEM block, etc.).

The Stripe pattern was changed from \`(sk|pk)\` to non-capturing \`(?:sk|pk)\` to preserve whole-token redaction under the new rule.

### Tests

8 new fixture cases in \`TestRedactSecrets_PatternFixture\`:
- \`openai-legacy-key\`, \`openai-proj-key\`, \`anthropic-key\`
- \`slack-bot-token\` (synthetic placeholder body — GitHub push protection blocks real-shaped Slack tokens, same trick as the existing Stripe fixture)
- \`google-api-key\`
- \`postgres-url-creds\`, \`mongodb-srv-url-creds\` (assert the userinfo redacts but host/path survive)
- \`auth-header-opaque-bearer\` (bearer token that is neither JWT nor a recognized provider shape)

All 18 fixture cases pass; full test suite green.

## Threat model

Privacy contract: \`redactSecrets\` runs in Drafter BEFORE the turn enters the in-memory buffer. A redacted-out token never reaches the persistence layer. This PR does not change that boundary — only widens the set of shapes the boundary recognizes.

## Out of scope

- Heuristic detection of bare high-entropy strings (no shape signal). Considered noisy; would need an entropy threshold + length floor and likely produce false positives on hashes, UUIDs, etc.
- IPv6-bracketed DB URL hosts (\`postgres://u:p@[::1]:5432\`) — current regex is greedy enough to catch but not exercised by a fixture; can extend if seen in practice.

## Test plan

- [x] \`go test ./internal/drafter/...\` (all 18 fixture cases green)
- [x] \`go test ./...\` (full suite green)
- [ ] Manual: paste a curl-with-Bearer line into a captured turn, confirm \`mom_recall\` returns the redacted form

🤖 Generated with [Claude Code](https://claude.com/claude-code)