### PR TITLE
feat(vault): add central vault resolver

### DIFF
--- a/cli/internal/centralvault/centralvault.go
+++ b/cli/internal/centralvault/centralvault.go
@@ -11,10 +11,18 @@ import (
 	"github.com/momhq/mom/cli/internal/vault"
 )
 
-const dbName = "mom.db"
+const (
+	dbName       = "mom.db"
+	envVaultPath = "MOM_VAULT"
+)
 
-// Dir returns MOM's canonical central vault directory: $HOME/.mom.
+// Dir returns the directory containing MOM's canonical central vault.
+// If MOM_VAULT is set, Dir returns that file's parent directory.
+// Otherwise it returns $HOME/.mom.
 func Dir() (string, error) {
+	if override := os.Getenv(envVaultPath); override != "" {
+		return filepath.Dir(override), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve $HOME: %w", err)
@@ -22,8 +30,13 @@ func Dir() (string, error) {
 	return filepath.Join(home, ".mom"), nil
 }
 
-// Path returns MOM's canonical central vault path: $HOME/.mom/mom.db.
+// Path returns MOM's canonical central vault path. MOM_VAULT overrides
+// the default $HOME/.mom/mom.db location for local testing and contributor
+// workflows.
 func Path() (string, error) {
+	if override := os.Getenv(envVaultPath); override != "" {
+		return override, nil
+	}
 	dir, err := Dir()
 	if err != nil {
 		return "", err
@@ -41,14 +54,14 @@ func Migrations() []vault.Migration {
 // Open opens the central vault, creating $HOME/.mom when needed and
 // applying all registered v0.30 migrations.
 func Open() (*vault.Vault, error) {
-	dir, err := Dir()
+	path, err := Path()
 	if err != nil {
 		return nil, err
 	}
+	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("cannot create %s: %w", dir, err)
 	}
-	path := filepath.Join(dir, dbName)
 	v, err := vault.Open(path, Migrations())
 	if err != nil {
 		return nil, fmt.Errorf("vault.Open %s: %w", path, err)

--- a/cli/internal/centralvault/centralvault.go
+++ b/cli/internal/centralvault/centralvault.go
@@ -1,0 +1,67 @@
+// Package centralvault resolves and opens MOM's canonical v0.30 vault.
+package centralvault
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/momhq/mom/cli/internal/logbook"
+	"github.com/momhq/mom/cli/internal/vault"
+)
+
+const dbName = "mom.db"
+
+// Dir returns MOM's canonical central vault directory: $HOME/.mom.
+func Dir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve $HOME: %w", err)
+	}
+	return filepath.Join(home, ".mom"), nil
+}
+
+// Path returns MOM's canonical central vault path: $HOME/.mom/mom.db.
+func Path() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, dbName), nil
+}
+
+// Migrations returns the full v0.30 central-vault migration set.
+func Migrations() []vault.Migration {
+	migs := append([]vault.Migration{}, librarian.Migrations()...)
+	migs = append(migs, logbook.Migrations()...)
+	return migs
+}
+
+// Open opens the central vault, creating $HOME/.mom when needed and
+// applying all registered v0.30 migrations.
+func Open() (*vault.Vault, error) {
+	dir, err := Dir()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("cannot create %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, dbName)
+	v, err := vault.Open(path, Migrations())
+	if err != nil {
+		return nil, fmt.Errorf("vault.Open %s: %w", path, err)
+	}
+	return v, nil
+}
+
+// OpenLibrarian opens the central vault and returns a Librarian bound to it.
+// The returned close function releases the underlying database handle.
+func OpenLibrarian() (*librarian.Librarian, func() error, error) {
+	v, err := Open()
+	if err != nil {
+		return nil, nil, err
+	}
+	return librarian.New(v), v.Close, nil
+}

--- a/cli/internal/centralvault/centralvault_test.go
+++ b/cli/internal/centralvault/centralvault_test.go
@@ -14,6 +14,7 @@ import (
 func TestPathUsesHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("MOM_VAULT", "")
 
 	got, err := centralvault.Path()
 	if err != nil {
@@ -26,9 +27,33 @@ func TestPathUsesHome(t *testing.T) {
 	}
 }
 
+func TestPathUsesMomVaultOverride(t *testing.T) {
+	home := t.TempDir()
+	override := filepath.Join(t.TempDir(), "custom", "mom-v030.db")
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_VAULT", override)
+
+	got, err := centralvault.Path()
+	if err != nil {
+		t.Fatalf("Path returned error: %v", err)
+	}
+	if got != override {
+		t.Fatalf("Path = %q, want MOM_VAULT override %q", got, override)
+	}
+
+	dir, err := centralvault.Dir()
+	if err != nil {
+		t.Fatalf("Dir returned error: %v", err)
+	}
+	if dir != filepath.Dir(override) {
+		t.Fatalf("Dir = %q, want %q", dir, filepath.Dir(override))
+	}
+}
+
 func TestOpenLibrarianCreatesOnlyTempHomeVault(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("MOM_VAULT", "")
 
 	lib, closeFn, err := centralvault.OpenLibrarian()
 	if err != nil {
@@ -55,6 +80,7 @@ func TestOpenLibrarianCreatesOnlyTempHomeVault(t *testing.T) {
 func TestOpenRunsFullCentralMigrations(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("MOM_VAULT", "")
 
 	v, err := centralvault.Open()
 	if err != nil {
@@ -87,6 +113,27 @@ func TestOpenRunsFullCentralMigrations(t *testing.T) {
 	}
 }
 
+func TestOpenCreatesMomVaultOverrideParent(t *testing.T) {
+	home := t.TempDir()
+	override := filepath.Join(t.TempDir(), "nested", "mom-v030.db")
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_VAULT", override)
+
+	v, err := centralvault.Open()
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer func() { _ = v.Close() }()
+
+	if _, err := os.Stat(override); err != nil {
+		t.Fatalf("MOM_VAULT database not created at %s: %v", override, err)
+	}
+	defaultPath := filepath.Join(home, ".mom", "mom.db")
+	if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
+		t.Fatalf("default HOME vault should not be touched when MOM_VAULT is set: %s", defaultPath)
+	}
+}
+
 func TestNoCentralVaultPathAssemblyOutsideHelper(t *testing.T) {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
@@ -98,6 +145,7 @@ func TestNoCentralVaultPathAssemblyOutsideHelper(t *testing.T) {
 	patterns := []string{
 		`filepath.Join(home, ".mom", "mom.db")`,
 		`filepath.Join(momHome, "mom.db")`,
+		`os.Getenv("MOM_VAULT")`,
 	}
 
 	err := filepath.WalkDir(internalDir, func(path string, d os.DirEntry, err error) error {

--- a/cli/internal/centralvault/centralvault_test.go
+++ b/cli/internal/centralvault/centralvault_test.go
@@ -1,0 +1,128 @@
+package centralvault_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/centralvault"
+)
+
+func TestPathUsesHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := centralvault.Path()
+	if err != nil {
+		t.Fatalf("Path returned error: %v", err)
+	}
+
+	want := filepath.Join(home, ".mom", "mom.db")
+	if got != want {
+		t.Fatalf("Path = %q, want %q", got, want)
+	}
+}
+
+func TestOpenLibrarianCreatesOnlyTempHomeVault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	if err != nil {
+		t.Fatalf("OpenLibrarian returned error: %v", err)
+	}
+	if lib == nil {
+		t.Fatal("OpenLibrarian returned nil Librarian")
+	}
+	defer func() { _ = closeFn() }()
+
+	dbPath := filepath.Join(home, ".mom", "mom.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("central vault not created at temp HOME path %s: %v", dbPath, err)
+	}
+
+	for _, sidecar := range []string{dbPath + "-wal", dbPath + "-shm"} {
+		if strings.HasPrefix(sidecar, home) {
+			continue
+		}
+		t.Fatalf("sidecar path escaped temp HOME: %s", sidecar)
+	}
+}
+
+func TestOpenRunsFullCentralMigrations(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	v, err := centralvault.Open()
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer func() { _ = v.Close() }()
+
+	for _, table := range []string{"memories", "tags", "entities", "op_events", "filter_audit"} {
+		table := table
+		err := v.Query(
+			`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+			[]any{table},
+			func(rows *sql.Rows) error {
+				if !rows.Next() {
+					t.Fatalf("table %s not found", table)
+				}
+				var name string
+				if err := rows.Scan(&name); err != nil {
+					return err
+				}
+				if name != table {
+					t.Fatalf("got table %q, want %q", name, table)
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("querying table %s: %v", table, err)
+		}
+	}
+}
+
+func TestNoCentralVaultPathAssemblyOutsideHelper(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	internalDir := filepath.Dir(filepath.Dir(file))
+	allowedDir := filepath.Dir(file)
+
+	patterns := []string{
+		`filepath.Join(home, ".mom", "mom.db")`,
+		`filepath.Join(momHome, "mom.db")`,
+	}
+
+	err := filepath.WalkDir(internalDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".go" {
+			return nil
+		}
+		if filepath.Dir(path) == allowedDir {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		text := string(data)
+		for _, p := range patterns {
+			if strings.Contains(text, p) {
+				t.Fatalf("central vault path assembly %q found outside helper in %s", p, path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking internal dir: %v", err)
+	}
+}

--- a/cli/internal/cmd/record.go
+++ b/cli/internal/cmd/record.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/momhq/mom/cli/internal/centralvault"
 	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/spf13/cobra"
 )
@@ -82,7 +83,7 @@ func runRecord(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("mom record: %w", err)
 	}
 
-	lib, closeFn, err := openCentralLibrarian()
+	lib, closeFn, err := centralvault.OpenLibrarian()
 	if err != nil {
 		return fmt.Errorf("mom record: %w", err)
 	}

--- a/cli/internal/cmd/record_test.go
+++ b/cli/internal/cmd/record_test.go
@@ -3,13 +3,11 @@ package cmd
 import (
 	"bytes"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/momhq/mom/cli/internal/centralvault"
 	"github.com/momhq/mom/cli/internal/librarian"
-	"github.com/momhq/mom/cli/internal/logbook"
-	"github.com/momhq/mom/cli/internal/vault"
 )
 
 // resetRecordFlags must run before each test that drives runRecord —
@@ -52,17 +50,12 @@ func openCentralVaultForTest(t *testing.T) *librarian.Librarian {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	momHome := filepath.Join(home, ".mom")
-	if err := os.MkdirAll(momHome, 0o700); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	migs := append(librarian.Migrations(), logbook.Migrations()...)
-	v, err := vault.Open(filepath.Join(momHome, "mom.db"), migs)
+	lib, closeFn, err := centralvault.OpenLibrarian()
 	if err != nil {
-		t.Fatalf("vault.Open: %v", err)
+		t.Fatalf("centralvault.OpenLibrarian: %v", err)
 	}
-	t.Cleanup(func() { _ = v.Close() })
-	return librarian.New(v)
+	t.Cleanup(func() { _ = closeFn() })
+	return lib
 }
 
 // TestRunRecord_PersistsToCentralVault locks the human-path contract:

--- a/cli/internal/cmd/watch.go
+++ b/cli/internal/cmd/watch.go
@@ -12,15 +12,14 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/momhq/mom/cli/internal/centralvault"
 	"github.com/momhq/mom/cli/internal/config"
 	"github.com/momhq/mom/cli/internal/daemon"
 	"github.com/momhq/mom/cli/internal/drafter"
 	"github.com/momhq/mom/cli/internal/herald"
-	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/logbook"
 	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/ux"
-	"github.com/momhq/mom/cli/internal/vault"
 	"github.com/momhq/mom/cli/internal/watcher"
 	"github.com/spf13/cobra"
 )
@@ -205,8 +204,8 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	for rt, dir := range w.TranscriptDirs() {
 		p.Chevron(fmt.Sprintf("%s: %s", rt, dir))
 	}
-	if home, err := os.UserHomeDir(); err == nil {
-		p.Chevron(fmt.Sprintf("vault: %s", filepath.Join(home, ".mom", "mom.db")))
+	if path, err := centralvault.Path(); err == nil {
+		p.Chevron(fmt.Sprintf("vault: %s", path))
 	}
 	p.Muted("press Ctrl-C to stop")
 	p.Blank()
@@ -571,7 +570,7 @@ func (cw centralWorkers) AttachToBus(bus *herald.Bus) {
 // refactor should plumb an explicit Close, but for alpha this is
 // acceptable.
 func openCentralWorkers() centralWorkers {
-	lib, _, err := openCentralLibrarian()
+	lib, _, err := centralvault.OpenLibrarian()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "watch: %v — central workers not wired\n", err)
 		return centralWorkers{}
@@ -580,31 +579,4 @@ func openCentralWorkers() centralWorkers {
 		drafter: drafter.New(lib),
 		logbook: logbook.New(lib),
 	}
-}
-
-// openCentralLibrarian opens the central vault at $HOME/.mom/mom.db
-// (creating the directory and running migrations as needed) and
-// returns a Librarian bound to it plus a closer the caller can run on
-// shutdown. Used by surfaces that need direct vault access without
-// the Drafter/Logbook subscribers — currently only the `mom record`
-// CLI command. Failures return a wrapped error; the watch-mode
-// helper turns those into stderr warnings and falls back to a
-// no-central-workers shape, while the record CLI turns them into
-// hook-friendly silent exits.
-func openCentralLibrarian() (*librarian.Librarian, func() error, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot resolve $HOME: %w", err)
-	}
-	momHome := filepath.Join(home, ".mom")
-	if err := os.MkdirAll(momHome, 0o700); err != nil {
-		return nil, nil, fmt.Errorf("cannot create %s: %w", momHome, err)
-	}
-	dbPath := filepath.Join(momHome, "mom.db")
-	migs := append(librarian.Migrations(), logbook.Migrations()...)
-	v, err := vault.Open(dbPath, migs)
-	if err != nil {
-		return nil, nil, fmt.Errorf("vault.Open %s: %w", dbPath, err)
-	}
-	return librarian.New(v), v.Close, nil
 }

--- a/cli/internal/vault/vault.go
+++ b/cli/internal/vault/vault.go
@@ -1,9 +1,11 @@
-// Package vault is the private SQLite primitive for v0.30. It owns the
-// connection at $HOME/.mom/mom.db, runs schema migrations registered by
-// callers, and mediates every read and write so other packages never
-// touch *sql.DB directly.
+// Package vault is the private SQLite primitive for v0.30. It owns a
+// SQLite connection, runs schema migrations registered by callers, and
+// mediates every read and write so other packages never touch *sql.DB
+// directly. Canonical $HOME/.mom/mom.db path resolution lives in the
+// centralvault package.
 //
-// Vault is the bottom of the v0.30 stack. Only Librarian touches it;
+// Vault is the bottom of the v0.30 stack. Librarian is the domain-facing
+// API over it; centralvault is the shared opener for production surfaces.
 // Drafter, Logbook, Cartographer, Finder, MCP, Upgrade, and Lens go
 // through Librarian. Vault has no knowledge of memories, tags, entities,
 // or any other domain table — those tables and their migrations are


### PR DESCRIPTION
## Summary

- Add `cli/internal/centralvault` as the canonical resolver/opener for `$HOME/.mom/mom.db`
- Centralize v0.30 migration registration for Librarian + Logbook
- Rewire `mom watch` and `mom record` to use the shared helper
- Add tests for temp `$HOME` isolation, full migrations, and no duplicated central DB path assembly

## Closes

Closes #279

## Test plan

- [x] `cd cli && go test ./...`
