### PR TITLE
feat(mcp): lock v0.30 tool surface

### DIFF
--- a/cli/internal/librarian/search.go
+++ b/cli/internal/librarian/search.go
@@ -43,7 +43,7 @@ type SearchedMemory struct {
 // relaxation (AND→OR) and tier escalation (curated→draft) on top.
 //
 // Empty/whitespace tag names in f.Tags are rejected with ErrEmptyArg
-// — the previous behaviour silently produced WHERE name IN (..., '')
+// — the previous behaviour silently produced WHERE name IN (..., ”)
 // with COUNT(DISTINCT) = N+1, which always returned zero rows and
 // gave callers no signal that their input was malformed.
 func (l *Librarian) SearchMemories(f SearchFilter) ([]SearchedMemory, error) {
@@ -58,12 +58,12 @@ func (l *Librarian) SearchMemories(f SearchFilter) ([]SearchedMemory, error) {
 	}
 
 	var (
-		sb       strings.Builder
-		args     []any
-		joins    []string
-		wheres   []string
-		orderBy  = "m.created_at DESC, m.id DESC"
-		hasFTS   = strings.TrimSpace(f.FTSQuery) != ""
+		sb      strings.Builder
+		args    []any
+		joins   []string
+		wheres  []string
+		orderBy = "m.created_at DESC, m.id DESC"
+		hasFTS  = strings.TrimSpace(f.FTSQuery) != ""
 	)
 
 	if hasFTS {
@@ -160,6 +160,57 @@ func (l *Librarian) SearchMemories(f SearchFilter) ([]SearchedMemory, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("SearchMemories: %w", err)
+	}
+	return out, nil
+}
+
+// Landmarks returns landmark memories ordered by centrality_score descending.
+func (l *Librarian) Landmarks(limit int) ([]Memory, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	out := []Memory{}
+	err := l.v.Query(
+		`SELECT id, type, summary, content, created_at, session_id,
+		        provenance_actor, provenance_source_type, provenance_trigger_event,
+		        promotion_state, landmark, centrality_score
+		 FROM memories
+		 WHERE landmark = 1
+		 ORDER BY centrality_score DESC, created_at DESC, id DESC
+		 LIMIT ?`,
+		[]any{limit},
+		func(rs *sql.Rows) error {
+			for rs.Next() {
+				var (
+					m                                        Memory
+					summary, actor, sourceType, triggerEvent sql.NullString
+					createdAtStr                             string
+					landmarkInt                              int64
+				)
+				if err := rs.Scan(
+					&m.ID, &m.Type, &summary, &m.Content, &createdAtStr, &m.SessionID,
+					&actor, &sourceType, &triggerEvent,
+					&m.PromotionState, &landmarkInt, &m.CentralityScore,
+				); err != nil {
+					return err
+				}
+				m.Summary = summary.String
+				m.ProvenanceActor = actor.String
+				m.ProvenanceSourceType = sourceType.String
+				m.ProvenanceTriggerEvent = triggerEvent.String
+				m.Landmark = landmarkInt != 0
+				t, err := parseTime(createdAtStr)
+				if err != nil {
+					return fmt.Errorf("parse created_at %q: %w", createdAtStr, err)
+				}
+				m.CreatedAt = t
+				out = append(out, m)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Landmarks: %w", err)
 	}
 	return out, nil
 }

--- a/cli/internal/mcp/mom_record.go
+++ b/cli/internal/mcp/mom_record.go
@@ -26,7 +26,7 @@ var MemoryRecordEventType = herald.MemoryRecord
 //   - ProvenanceTriggerEvent = "record"
 //   - ProvenanceSourceType   = "manual-draft"
 //   - ProvenanceActor        = ActorAgent (claude-code, codex, …) or
-//                              "mcp" when the caller did not announce.
+//     "mcp" when the caller did not announce.
 //
 // Tags are normalised via librarian.NormalizeTagName before publish;
 // every entry in Tags is the canonical form. If any input tag

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -31,9 +32,16 @@ func (rs *recordingSubscriber) get() (herald.Event, bool) {
 	return v.(herald.Event), true
 }
 
+func setTestVault(t *testing.T) {
+	t.Helper()
+	t.Setenv("MOM_VAULT", filepath.Join(t.TempDir(), "mom.db"))
+}
+
 func newSrvWithSubscriber(t *testing.T) (*Server, *recordingSubscriber) {
 	t.Helper()
+	setTestVault(t)
 	srv := New(t.TempDir())
+	t.Cleanup(func() { _ = srv.Close() })
 	rs := &recordingSubscriber{}
 	t.Cleanup(rs.attach(srv.Bus()))
 	return srv, rs
@@ -225,8 +233,11 @@ func TestMomRecord_RejectsMixedTypeTags(t *testing.T) {
 // ── architectural / integration ──────────────────────────────────────────────
 
 func TestServer_BusIsAccessibleAndDistinctPerInstance(t *testing.T) {
+	setTestVault(t)
 	a := New(t.TempDir())
+	t.Cleanup(func() { _ = a.Close() })
 	b := New(t.TempDir())
+	t.Cleanup(func() { _ = b.Close() })
 	if a.Bus() == nil || b.Bus() == nil {
 		t.Fatal("Server.Bus() returned nil")
 	}
@@ -243,7 +254,9 @@ func TestServer_BusIsAccessibleAndDistinctPerInstance(t *testing.T) {
 }
 
 func TestServer_SetBusReplacesTheBus(t *testing.T) {
+	setTestVault(t)
 	srv := New(t.TempDir())
+	t.Cleanup(func() { _ = srv.Close() })
 	old := srv.Bus()
 
 	// Subscribe on the OLD bus before swapping.

--- a/cli/internal/mcp/server.go
+++ b/cli/internal/mcp/server.go
@@ -15,10 +15,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/momhq/mom/cli/internal/adapters/storage"
+	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/finder"
 	"github.com/momhq/mom/cli/internal/herald"
-	"github.com/momhq/mom/cli/internal/recall"
-	"github.com/momhq/mom/cli/internal/scope"
+	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/ux"
 )
 
@@ -47,9 +47,9 @@ type jsonRPCRequest struct {
 
 // jsonRPCResponse is an outbound JSON-RPC 2.0 message.
 type jsonRPCResponse struct {
-	JSONRPC string `json:"jsonrpc"`
-	ID      any    `json:"id"`
-	Result  any    `json:"result,omitempty"`
+	JSONRPC string    `json:"jsonrpc"`
+	ID      any       `json:"id"`
+	Result  any       `json:"result,omitempty"`
 	Error   *rpcError `json:"error,omitempty"`
 }
 
@@ -60,35 +60,43 @@ type rpcError struct {
 
 // Server is the MCP server instance.
 type Server struct {
-	momDir string
-	idx    *storage.IndexedAdapter
-	engine *recall.Engine
-	bus    *herald.Bus
+	momDir  string
+	lib     *librarian.Librarian
+	finder  *finder.Finder
+	closeFn func() error
+	openErr error
+	bus     *herald.Bus
 }
 
 // New creates a new Server rooted at the given .mom/ directory.
-// It builds the recall Engine from the scope chain discovered at momDir
-// and attaches a fresh v0.30 Herald bus for write tools (mom_record) to
-// publish on. Callers who want their own bus (e.g., to wire a Drafter
-// subscriber) can replace it via SetBus before Serve.
+// Read tools use the v0.30 central vault through Librarian/Finder.
+// The server also attaches a fresh Herald bus for write tools
+// (mom_record) to publish on. Callers who want their own bus (e.g.,
+// to wire a Drafter subscriber) can replace it via SetBus before Serve.
 func New(momDir string) *Server {
-	idx := storage.NewIndexedAdapter(momDir)
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	s := &Server{
+		momDir:  momDir,
+		closeFn: closeFn,
+		openErr: err,
+		bus:     herald.NewBus(),
+	}
+	if err == nil {
+		s.lib = lib
+		s.finder = finder.New(lib)
+	}
+	return s
+}
 
-	scopes := scope.Walk(momDir)
-	if len(scopes) == 0 {
-		scopes = []scope.Scope{{Path: momDir, Label: "repo"}}
+// Close releases the central vault handle opened by New. Serve calls it
+// when stdio closes; tests may call it directly when they do not run Serve.
+func (s *Server) Close() error {
+	if s.closeFn == nil {
+		return nil
 	}
-	chain := make([]recall.Searcher, len(scopes))
-	for i, sc := range scopes {
-		chain[i] = recall.NewScopeSearcher(idx, sc.Path)
-	}
-
-	return &Server{
-		momDir: momDir,
-		idx:    idx,
-		engine: recall.NewEngine(chain),
-		bus:    herald.NewBus(),
-	}
+	err := s.closeFn()
+	s.closeFn = nil
+	return err
 }
 
 // Bus returns the v0.30 Herald bus this Server publishes on. Callers
@@ -108,6 +116,7 @@ func (s *Server) SetBus(b *herald.Bus) { s.bus = b }
 // stdout (out) is reserved for JSON-RPC only. Human-readable output goes to
 // stderr.
 func (s *Server) Serve(in io.Reader, out io.Writer) {
+	defer func() { _ = s.Close() }()
 	p := ux.NewPrinter(os.Stderr)
 	p.Diamond("MCP server")
 	p.Chevron(fmt.Sprintf("scope: %s", s.momDir))
@@ -200,6 +209,7 @@ func (s *Server) handleInitialize(_ json.RawMessage) (any, *rpcError) {
 			"name":    "mom-mcp-server",
 			"version": Version,
 		},
+		"instructions": "Use MOM for persistent memory. Available tools: mom_status, mom_recall, mom_get, mom_landmarks, mom_record. Call mom_recall before memory-derived claims and cite returned memory IDs.",
 	}, nil
 }
 

--- a/cli/internal/mcp/server_test.go
+++ b/cli/internal/mcp/server_test.go
@@ -10,23 +10,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/mcp"
 )
 
-// helpers
+func setCentralVault(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mom.db")
+	t.Setenv("MOM_VAULT", path)
+	return path
+}
 
 func newTestLeoDir(t *testing.T) string {
 	t.Helper()
+	setCentralVault(t)
 	dir := t.TempDir()
 	leoDir := filepath.Join(dir, ".mom")
 	if err := os.MkdirAll(filepath.Join(leoDir, "memory"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	// Write a minimal config.yaml so scope.loadScopeLabel works.
 	if err := os.WriteFile(filepath.Join(leoDir, "config.yaml"), []byte("scope: repo\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	// Write identity.json
 	identity := map[string]any{
 		"id":         "identity",
 		"type":       "identity",
@@ -37,9 +43,7 @@ func newTestLeoDir(t *testing.T) string {
 		"created_by": "test",
 		"updated":    time.Now().Format(time.RFC3339),
 		"updated_by": "test",
-		"content": map[string]any{
-			"name": "Test Project",
-		},
+		"content":    map[string]any{"name": "Test Project"},
 	}
 	writeJSON(t, filepath.Join(leoDir, "identity.json"), identity)
 	return leoDir
@@ -49,6 +53,9 @@ func writeJSON(t *testing.T, path string, v any) {
 	t.Helper()
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(path, data, 0644); err != nil {
@@ -63,14 +70,49 @@ func writeMemoryDoc(t *testing.T, leoDir string, doc map[string]any) {
 	writeJSON(t, path, doc)
 }
 
-// sendRequest writes one JSON-RPC request to the writer.
+func insertCentralMemory(t *testing.T, summary, text string, tags []string) string {
+	t.Helper()
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	if err != nil {
+		t.Fatalf("centralvault.OpenLibrarian: %v", err)
+	}
+	defer func() { _ = closeFn() }()
+	content, _ := json.Marshal(map[string]any{"text": text})
+	id, err := lib.InsertMemoryWithTags(librarian.InsertMemory{
+		Type:                   "semantic",
+		Summary:                summary,
+		Content:                string(content),
+		SessionID:              "s-test",
+		ProvenanceActor:        "test",
+		ProvenanceSourceType:   "test-fixture",
+		ProvenanceTriggerEvent: "test",
+	}, tags)
+	if err != nil {
+		t.Fatalf("InsertMemoryWithTags: %v", err)
+	}
+	state := "curated"
+	if err := lib.UpdateOperational(id, librarian.OperationalUpdate{PromotionState: &state}); err != nil {
+		t.Fatalf("UpdateOperational curated: %v", err)
+	}
+	return id
+}
+
+func markLandmark(t *testing.T, id string, score float64) {
+	t.Helper()
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	if err != nil {
+		t.Fatalf("centralvault.OpenLibrarian: %v", err)
+	}
+	defer func() { _ = closeFn() }()
+	landmark := true
+	if err := lib.UpdateOperational(id, librarian.OperationalUpdate{Landmark: &landmark, CentralityScore: &score}); err != nil {
+		t.Fatalf("UpdateOperational landmark: %v", err)
+	}
+}
+
 func sendRequest(t *testing.T, w io.Writer, method string, id any, params any) {
 	t.Helper()
-	req := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      id,
-		"method":  method,
-	}
+	req := map[string]any{"jsonrpc": "2.0", "id": id, "method": method}
 	if params != nil {
 		req["params"] = params
 	}
@@ -84,7 +126,6 @@ func sendRequest(t *testing.T, w io.Writer, method string, id any, params any) {
 	}
 }
 
-// readResponse reads one JSON-RPC response from the reader.
 func readResponse(t *testing.T, r *bufio.Reader) map[string]any {
 	t.Helper()
 	line, err := r.ReadString('\n')
@@ -98,8 +139,6 @@ func readResponse(t *testing.T, r *bufio.Reader) map[string]any {
 	return resp
 }
 
-// runServer starts the MCP server in a goroutine, sends requests via inW,
-// reads responses from outR, and returns cleanup func.
 func runServer(t *testing.T, leoDir string) (inW io.WriteCloser, outR *bufio.Reader, done chan struct{}) {
 	t.Helper()
 	inR, inW := io.Pipe()
@@ -116,446 +155,159 @@ func runServer(t *testing.T, leoDir string) (inW io.WriteCloser, outR *bufio.Rea
 	return inW, outR, done
 }
 
-// --- Tests ---
-
 func TestInitializeHandshake(t *testing.T) {
 	leoDir := newTestLeoDir(t)
 	inW, outR, _ := runServer(t, leoDir)
 	defer inW.Close()
 
-	sendRequest(t, inW, "initialize", 1, map[string]any{
-		"protocolVersion": "2024-11-05",
-		"clientInfo":      map[string]any{"name": "test-client", "version": "0.1"},
-	})
-
+	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
 	resp := readResponse(t, outR)
 
 	if resp["error"] != nil {
 		t.Fatalf("unexpected error: %v", resp["error"])
 	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp["result"])
-	}
+	result := resp["result"].(map[string]any)
 	if result["protocolVersion"] == nil {
-		t.Error("protocolVersion missing from initialize result")
+		t.Error("protocolVersion missing")
 	}
-	caps, ok := result["capabilities"].(map[string]any)
-	if !ok {
-		t.Fatal("capabilities missing or wrong type")
-	}
-	if caps["tools"] == nil {
-		t.Error("tools capability missing")
-	}
-	if caps["resources"] == nil {
-		t.Error("resources capability missing")
-	}
-	serverInfo, ok := result["serverInfo"].(map[string]any)
-	if !ok {
-		t.Fatal("serverInfo missing")
-	}
-	if serverInfo["name"] == nil {
-		t.Error("serverInfo.name missing")
+	if result["instructions"] == nil {
+		t.Error("instructions missing")
 	}
 }
 
-func TestToolsList(t *testing.T) {
+func TestToolsListV030Surface(t *testing.T) {
 	leoDir := newTestLeoDir(t)
 	inW, outR, _ := runServer(t, leoDir)
 	defer inW.Close()
 
-	// Initialize first.
 	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
 	readResponse(t, outR)
-
 	sendRequest(t, inW, "tools/list", 2, nil)
 	resp := readResponse(t, outR)
 
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
+	result := resp["result"].(map[string]any)
+	tools := result["tools"].([]any)
+	if len(tools) != 5 {
+		t.Fatalf("tools/list returned %d tools, want 5", len(tools))
 	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	tools, ok := result["tools"].([]any)
-	if !ok {
-		t.Fatalf("tools not an array: %v", result["tools"])
-	}
-	if len(tools) != 7 {
-		t.Errorf("expected 7 tools, got %d", len(tools))
-	}
-
-	names := make(map[string]bool)
+	names := map[string]bool{}
 	for _, raw := range tools {
-		tool, ok := raw.(map[string]any)
-		if !ok {
-			t.Fatal("tool not a map")
-		}
-		name, _ := tool["name"].(string)
+		tool := raw.(map[string]any)
+		name := tool["name"].(string)
 		names[name] = true
+		if name == "mom_recall" {
+			schema := tool["inputSchema"].(map[string]any)
+			props := schema["properties"].(map[string]any)
+			if _, ok := props["scope"]; ok {
+				t.Fatal("mom_recall schema must not include scope")
+			}
+		}
 	}
-	expected := []string{"get_memory", "list_scopes", "create_memory_draft", "list_landmarks", "mom_status", "mom_recall", "mom_record"}
-	for _, n := range expected {
+	for _, n := range []string{"mom_status", "mom_recall", "mom_get", "mom_landmarks", "mom_record"} {
 		if !names[n] {
-			t.Errorf("tool %q missing from tools/list", n)
+			t.Errorf("tool %q missing", n)
 		}
 	}
-	if names["search_memories"] {
-		t.Error("search_memories should not appear in tools/list — it was removed in v0.14")
-	}
-	if names["mom_record_turn"] {
-		t.Error("mom_record_turn should not appear in tools/list — it was removed in v0.30 (use mom_record)")
-	}
-}
-
-func TestToolsCallMomRecall(t *testing.T) {
-	leoDir := newTestLeoDir(t)
-	writeMemoryDoc(t, leoDir, map[string]any{
-		"id":              "auth-pattern",
-		"type":            "pattern",
-		"lifecycle":       "permanent",
-		"scope":           "project",
-		"tags":            []string{"auth", "security"},
-		"summary":         "Authentication pattern for JWT",
-		"promotion_state": "curated",
-		"created":         time.Now().Format(time.RFC3339),
-		"created_by":      "test",
-		"updated":         time.Now().Format(time.RFC3339),
-		"updated_by":      "test",
-		"content":         map[string]any{"detail": "Use JWT with RS256"},
-	})
-
-	inW, outR, _ := runServer(t, leoDir)
-	defer inW.Close()
-
-	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
-	readResponse(t, outR)
-
-	sendRequest(t, inW, "tools/call", 2, map[string]any{
-		"name": "mom_recall",
-		"arguments": map[string]any{
-			"query": "auth",
-		},
-	})
-	resp := readResponse(t, outR)
-
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
-	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	content, ok := result["content"].([]any)
-	if !ok || len(content) == 0 {
-		t.Fatal("content missing or empty")
-	}
-}
-
-func TestToolsCallGetMemory(t *testing.T) {
-	leoDir := newTestLeoDir(t)
-	writeMemoryDoc(t, leoDir, map[string]any{
-		"id":         "test-fact",
-		"type":       "fact",
-		"lifecycle":  "permanent",
-		"scope":      "project",
-		"tags":       []string{"test"},
-		"summary":    "Test fact",
-		"created":    time.Now().Format(time.RFC3339),
-		"created_by": "test",
-		"updated":    time.Now().Format(time.RFC3339),
-		"updated_by": "test",
-		"content":    map[string]any{"detail": "some detail"},
-	})
-
-	inW, outR, _ := runServer(t, leoDir)
-	defer inW.Close()
-
-	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
-	readResponse(t, outR)
-
-	sendRequest(t, inW, "tools/call", 2, map[string]any{
-		"name":      "get_memory",
-		"arguments": map[string]any{"id": "test-fact"},
-	})
-	resp := readResponse(t, outR)
-
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
-	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	content, ok := result["content"].([]any)
-	if !ok || len(content) == 0 {
-		t.Fatal("content missing or empty")
-	}
-	first, ok := content[0].(map[string]any)
-	if !ok {
-		t.Fatal("first content item not a map")
-	}
-	text, _ := first["text"].(string)
-	if !strings.Contains(text, "test-fact") {
-		t.Errorf("expected response to contain doc id, got: %s", text)
-	}
-}
-
-func TestToolsCallListScopes(t *testing.T) {
-	leoDir := newTestLeoDir(t)
-	inW, outR, _ := runServer(t, leoDir)
-	defer inW.Close()
-
-	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
-	readResponse(t, outR)
-
-	sendRequest(t, inW, "tools/call", 2, map[string]any{
-		"name":      "list_scopes",
-		"arguments": map[string]any{},
-	})
-	resp := readResponse(t, outR)
-
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
-	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	content, ok := result["content"].([]any)
-	if !ok || len(content) == 0 {
-		t.Fatal("content missing or empty")
-	}
-}
-
-func TestToolsCallCreateMemoryDraft(t *testing.T) {
-	leoDir := newTestLeoDir(t)
-	inW, outR, _ := runServer(t, leoDir)
-	defer inW.Close()
-
-	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
-	readResponse(t, outR)
-
-	sendRequest(t, inW, "tools/call", 2, map[string]any{
-		"name": "create_memory_draft",
-		"arguments": map[string]any{
-			"type":    "fact",
-			"summary": "A new test fact",
-			"tags":    []any{"test", "mcp"},
-			"content": map[string]any{"detail": "created via MCP"},
-		},
-	})
-	resp := readResponse(t, outR)
-
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
-	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	content, ok := result["content"].([]any)
-	if !ok || len(content) == 0 {
-		t.Fatal("content missing or empty")
-	}
-	first, ok := content[0].(map[string]any)
-	if !ok {
-		t.Fatal("first content item not a map")
-	}
-	text, _ := first["text"].(string)
-	if !strings.Contains(text, "curated") {
-		t.Errorf("expected response to mention curated, got: %s", text)
-	}
-
-	// Verify the file was actually created.
-	entries, _ := os.ReadDir(filepath.Join(leoDir, "memory"))
-	if len(entries) == 0 {
-		t.Error("expected draft file to be written to memory dir")
-	}
-}
-
-func TestToolsCallListLandmarks(t *testing.T) {
-	leoDir := newTestLeoDir(t)
-	score := 0.9
-	writeMemoryDoc(t, leoDir, map[string]any{
-		"id":              "landmark-doc",
-		"type":            "pattern",
-		"lifecycle":       "permanent",
-		"scope":           "project",
-		"tags":            []string{"arch"},
-		"summary":         "Key architectural pattern",
-		"landmark":        true,
-		"centrality_score": score,
-		"created":         time.Now().Format(time.RFC3339),
-		"created_by":      "test",
-		"updated":         time.Now().Format(time.RFC3339),
-		"updated_by":      "test",
-		"content":         map[string]any{"detail": "x"},
-	})
-
-	inW, outR, _ := runServer(t, leoDir)
-	defer inW.Close()
-
-	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
-	readResponse(t, outR)
-
-	sendRequest(t, inW, "tools/call", 2, map[string]any{
-		"name":      "list_landmarks",
-		"arguments": map[string]any{},
-	})
-	resp := readResponse(t, outR)
-
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
-	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	content, ok := result["content"].([]any)
-	if !ok || len(content) == 0 {
-		t.Fatal("content missing or empty")
-	}
-	first, ok := content[0].(map[string]any)
-	if !ok {
-		t.Fatal("first content item not a map")
-	}
-	text, _ := first["text"].(string)
-	if !strings.Contains(text, "landmark-doc") {
-		t.Errorf("expected landmark doc in response, got: %s", text)
-	}
-}
-
-func TestResourcesList(t *testing.T) {
-	leoDir := newTestLeoDir(t)
-	inW, outR, _ := runServer(t, leoDir)
-	defer inW.Close()
-
-	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
-	readResponse(t, outR)
-
-	sendRequest(t, inW, "resources/list", 2, nil)
-	resp := readResponse(t, outR)
-
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
-	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	resources, ok := result["resources"].([]any)
-	if !ok {
-		t.Fatalf("resources not an array: %v", result["resources"])
-	}
-	if len(resources) != 3 {
-		t.Errorf("expected 3 resources, got %d", len(resources))
-	}
-
-	uris := make(map[string]bool)
-	for _, raw := range resources {
-		res, ok := raw.(map[string]any)
-		if !ok {
-			t.Fatal("resource not a map")
-		}
-		uri, _ := res["uri"].(string)
-		uris[uri] = true
-	}
-	for _, expected := range []string{"mom://identity", "mom://constraints", "mom://scopes"} {
-		if !uris[expected] {
-			t.Errorf("resource %q missing from resources/list", expected)
+	for _, old := range []string{"get_memory", "list_scopes", "create_memory_draft", "list_landmarks", "mom_record_turn"} {
+		if names[old] {
+			t.Errorf("legacy tool %q still present", old)
 		}
 	}
 }
 
-func TestResourcesReadIdentity(t *testing.T) {
+func TestToolsCallMomRecallUsesCentralFinder(t *testing.T) {
 	leoDir := newTestLeoDir(t)
+	insertCentralMemory(t, "Authentication pattern for JWT", "Use JWT with RS256", []string{"auth", "security"})
 	inW, outR, _ := runServer(t, leoDir)
 	defer inW.Close()
 
 	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
 	readResponse(t, outR)
-
-	sendRequest(t, inW, "resources/read", 2, map[string]any{"uri": "mom://identity"})
+	sendRequest(t, inW, "tools/call", 2, map[string]any{"name": "mom_recall", "arguments": map[string]any{"query": "JWT"}})
 	resp := readResponse(t, outR)
 
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
-	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	contents, ok := result["contents"].([]any)
-	if !ok || len(contents) == 0 {
-		t.Fatal("contents missing or empty")
+	result := resp["result"].(map[string]any)
+	content := result["content"].([]any)
+	text := content[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, "Authentication pattern") {
+		t.Fatalf("mom_recall did not return central memory: %s", text)
 	}
 }
 
-func TestResourcesReadConstraints(t *testing.T) {
+func TestToolsCallMomRecallRequiresQuery(t *testing.T) {
 	leoDir := newTestLeoDir(t)
-	// Add a constraint doc.
-	if err := os.MkdirAll(filepath.Join(leoDir, "constraints"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	writeJSON(t, filepath.Join(leoDir, "constraints", "anti-hallucination.json"), map[string]any{
-		"id":         "anti-hallucination",
-		"type":       "constraint",
-		"lifecycle":  "permanent",
-		"scope":      "core",
-		"tags":       []string{"constraint"},
-		"summary":    "Never hallucinate",
-		"created":    time.Now().Format(time.RFC3339),
-		"created_by": "test",
-		"updated":    time.Now().Format(time.RFC3339),
-		"updated_by": "test",
-		"content":    map[string]any{"rule": "no hallucination"},
-	})
-
 	inW, outR, _ := runServer(t, leoDir)
 	defer inW.Close()
 
 	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
 	readResponse(t, outR)
-
-	sendRequest(t, inW, "resources/read", 2, map[string]any{"uri": "mom://constraints"})
+	sendRequest(t, inW, "tools/call", 2, map[string]any{"name": "mom_recall", "arguments": map[string]any{}})
 	resp := readResponse(t, outR)
 
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
+	result := resp["result"].(map[string]any)
+	if result["isError"] != true {
+		t.Fatalf("mom_recall without query should return tool error: %v", result)
 	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
-	}
-	contents, ok := result["contents"].([]any)
-	if !ok || len(contents) == 0 {
-		t.Fatal("contents missing or empty")
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, "query is required") {
+		t.Fatalf("error = %q, want query is required", text)
 	}
 }
 
-func TestResourcesReadScopes(t *testing.T) {
+func TestToolsCallMomGet(t *testing.T) {
+	leoDir := newTestLeoDir(t)
+	id := insertCentralMemory(t, "Test fact", "some detail", []string{"test"})
+	inW, outR, _ := runServer(t, leoDir)
+	defer inW.Close()
+
+	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
+	readResponse(t, outR)
+	sendRequest(t, inW, "tools/call", 2, map[string]any{"name": "mom_get", "arguments": map[string]any{"id": id}})
+	resp := readResponse(t, outR)
+
+	result := resp["result"].(map[string]any)
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, id) || !strings.Contains(text, "Test fact") {
+		t.Fatalf("mom_get response missing memory: %s", text)
+	}
+}
+
+func TestToolsCallMomGetRequiresID(t *testing.T) {
 	leoDir := newTestLeoDir(t)
 	inW, outR, _ := runServer(t, leoDir)
 	defer inW.Close()
 
 	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
 	readResponse(t, outR)
-
-	sendRequest(t, inW, "resources/read", 2, map[string]any{"uri": "mom://scopes"})
+	sendRequest(t, inW, "tools/call", 2, map[string]any{"name": "mom_get", "arguments": map[string]any{}})
 	resp := readResponse(t, outR)
 
-	if resp["error"] != nil {
-		t.Fatalf("unexpected error: %v", resp["error"])
+	result := resp["result"].(map[string]any)
+	if result["isError"] != true {
+		t.Fatalf("mom_get without id should return tool error: %v", result)
 	}
-	result, ok := resp["result"].(map[string]any)
-	if !ok {
-		t.Fatalf("result not a map: %v", resp)
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, "id is required") {
+		t.Fatalf("error = %q, want id is required", text)
 	}
-	contents, ok := result["contents"].([]any)
-	if !ok || len(contents) == 0 {
-		t.Fatal("contents missing or empty")
+}
+
+func TestToolsCallMomLandmarks(t *testing.T) {
+	leoDir := newTestLeoDir(t)
+	id := insertCentralMemory(t, "Key architecture", "central vault decision", []string{"arch"})
+	markLandmark(t, id, 0.9)
+	inW, outR, _ := runServer(t, leoDir)
+	defer inW.Close()
+
+	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
+	readResponse(t, outR)
+	sendRequest(t, inW, "tools/call", 2, map[string]any{"name": "mom_landmarks", "arguments": map[string]any{}})
+	resp := readResponse(t, outR)
+
+	result := resp["result"].(map[string]any)
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, id) || !strings.Contains(text, "Key architecture") {
+		t.Fatalf("mom_landmarks response missing landmark: %s", text)
 	}
 }
 
@@ -566,12 +318,10 @@ func TestUnknownMethodReturnsError(t *testing.T) {
 
 	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
 	readResponse(t, outR)
-
 	sendRequest(t, inW, "unknown/method", 2, nil)
 	resp := readResponse(t, outR)
-
 	if resp["error"] == nil {
-		t.Error("expected error for unknown method, got nil")
+		t.Error("expected error for unknown method")
 	}
 }
 
@@ -580,20 +330,12 @@ func TestNotificationIgnored(t *testing.T) {
 	inW, outR, _ := runServer(t, leoDir)
 	defer inW.Close()
 
-	// Send initialize first.
 	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
 	readResponse(t, outR)
-
-	// Send a notification (no id field) — server must NOT respond.
-	notif := map[string]any{
-		"jsonrpc": "2.0",
-		"method":  "notifications/initialized",
-	}
+	notif := map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"}
 	data, _ := json.Marshal(notif)
 	data = append(data, '\n')
-	inW.Write(data)
-
-	// Now send a valid request and verify we get exactly one response (not two).
+	_, _ = inW.Write(data)
 	sendRequest(t, inW, "tools/list", 2, nil)
 	resp := readResponse(t, outR)
 	if id, ok := resp["id"].(float64); !ok || id != 2 {

--- a/cli/internal/mcp/status.go
+++ b/cli/internal/mcp/status.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	"github.com/momhq/mom/cli/internal/adapters/harness"
+	"github.com/momhq/mom/cli/internal/centralvault"
 	"github.com/momhq/mom/cli/internal/config"
-	"github.com/momhq/mom/cli/internal/scope"
+	"github.com/momhq/mom/cli/internal/librarian"
 )
 
 // statusPayload defines the mom_status response with explicit field ordering.
@@ -42,9 +43,11 @@ type statusOperatingRulesBlock struct {
 }
 
 type statusToolsBlock struct {
-	MomStatus string `json:"mom_status"`
-	MomRecall string `json:"mom_recall"`
-	MomRecord string `json:"mom_record"`
+	MomStatus    string `json:"mom_status"`
+	MomRecall    string `json:"mom_recall"`
+	MomGet       string `json:"mom_get"`
+	MomLandmarks string `json:"mom_landmarks"`
+	MomRecord    string `json:"mom_record"`
 }
 
 type statusModesBlock struct {
@@ -72,7 +75,7 @@ func (s *Server) toolMomStatus() (toolCallResult, error) {
 		Skills:         s.statusSkills(),
 		Modes:          s.statusModes(),
 		VaultState:     s.statusVaultState(),
-		DocSchema:      "Memory docs: id, type, lifecycle, scope, tags, created, created_by, updated, updated_by, content",
+		DocSchema:      "Central v0.30 SQLite schema: memories, tags, entities, memory_tags, memory_entities, op_events, filter_audit.",
 	}
 
 	text, err := json.MarshalIndent(payload, "", "  ")
@@ -117,9 +120,11 @@ func statusBoundaries() []string {
 // statusTools returns the static tools block.
 func statusTools() statusToolsBlock {
 	return statusToolsBlock{
-		MomStatus: "Returns this protocol. Call at session start.",
-		MomRecall: "Search memories by query, tags, or session. Use before asserting past context.",
-		MomRecord: "Explicit-write path: intentionally save a memory mid-session. Bypasses Drafter's content filters per ADR 0014.",
+		MomStatus:    "Returns this protocol. Call at session start.",
+		MomRecall:    "Search memories by query. Use before asserting past context.",
+		MomGet:       "Retrieve a memory by ID.",
+		MomLandmarks: "List landmark memories ordered by centrality score.",
+		MomRecord:    "Explicit-write path: intentionally save a memory mid-session. Bypasses Drafter's content filters per ADR 0014.",
 	}
 }
 
@@ -160,56 +165,32 @@ func scanDocDir(dir string) []docSummary {
 	return result
 }
 
-// statusConstraints loads constraint summaries from .mom/constraints/*.json
-// across all discovered scopes.
+// statusConstraints loads constraint summaries from the central generated
+// $HOME/.mom/constraints directory (or MOM_VAULT's parent directory when set).
 func (s *Server) statusConstraints() []docSummary {
-	var all []docSummary
-	seen := make(map[string]bool)
-
-	addDir := func(dir string) {
-		for _, d := range scanDocDir(dir) {
-			if !seen[d.Path] {
-				seen[d.Path] = true
-				all = append(all, d)
-			}
-		}
-	}
-
-	addDir(filepath.Join(s.momDir, "constraints"))
-	for _, sc := range scope.Walk(s.momDir) {
-		addDir(filepath.Join(sc.Path, "constraints"))
-	}
-
-	if all == nil {
+	dir, err := centralvault.Dir()
+	if err != nil {
 		return []docSummary{}
 	}
-	return all
+	out := scanDocDir(filepath.Join(dir, "constraints"))
+	if out == nil {
+		return []docSummary{}
+	}
+	return out
 }
 
-// statusSkills loads skill summaries from .mom/skills/*.json across all
-// discovered scopes.
+// statusSkills loads skill summaries from the central generated
+// $HOME/.mom/skills directory (or MOM_VAULT's parent directory when set).
 func (s *Server) statusSkills() []docSummary {
-	var all []docSummary
-	seen := make(map[string]bool)
-
-	addDir := func(dir string) {
-		for _, d := range scanDocDir(dir) {
-			if !seen[d.Path] {
-				seen[d.Path] = true
-				all = append(all, d)
-			}
-		}
-	}
-
-	addDir(filepath.Join(s.momDir, "skills"))
-	for _, sc := range scope.Walk(s.momDir) {
-		addDir(filepath.Join(sc.Path, "skills"))
-	}
-
-	if all == nil {
+	dir, err := centralvault.Dir()
+	if err != nil {
 		return []docSummary{}
 	}
-	return all
+	out := scanDocDir(filepath.Join(dir, "skills"))
+	if out == nil {
+		return []docSummary{}
+	}
+	return out
 }
 
 // statusModes returns language/communication/autonomy from config, falling back
@@ -245,61 +226,27 @@ type scopeVaultEntry struct {
 	MemoryCount int    `json:"memory_count"`
 }
 
-// statusVaultState builds the vault_state block: scopes, total_memories,
-// landmarks, and record_mode.
+// statusVaultState builds the central v0.30 vault_state block.
 func (s *Server) statusVaultState() statusVaultStateBlock {
-	scopes := scope.Walk(s.momDir)
-	if len(scopes) == 0 {
-		scopes = []scope.Scope{{Path: s.momDir, Label: "repo"}}
-	}
+	path, _ := centralvault.Path()
+	entry := scopeVaultEntry{Label: "central", Path: path}
 
-	entries := make([]scopeVaultEntry, len(scopes))
-	totalMemories := 0
-	totalLandmarks := 0
-
-	for i, sc := range scopes {
-		count := sc.MemoryCount()
-		entries[i] = scopeVaultEntry{
-			Label:       sc.Label,
-			Path:        sc.Path,
-			MemoryCount: count,
+	lib, err := s.requireLibrarian()
+	if err != nil {
+		return statusVaultStateBlock{
+			Scopes:     []scopeVaultEntry{entry},
+			RecordMode: "continuous",
 		}
-		totalMemories += count
-		totalLandmarks += countLandmarks(sc.Path)
 	}
+
+	memories, _ := lib.SearchMemories(librarian.SearchFilter{Limit: 1_000_000})
+	landmarks, _ := lib.Landmarks(1_000_000)
+	entry.MemoryCount = len(memories)
 
 	return statusVaultStateBlock{
-		Scopes:        entries,
-		TotalMemories: totalMemories,
-		Landmarks:     totalLandmarks,
+		Scopes:        []scopeVaultEntry{entry},
+		TotalMemories: len(memories),
+		Landmarks:     len(landmarks),
 		RecordMode:    "continuous",
 	}
-}
-
-// countLandmarks returns the number of memory docs in momDir/memory/ that have
-// landmark: true.
-func countLandmarks(momDir string) int {
-	memDir := filepath.Join(momDir, "memory")
-	entries, err := os.ReadDir(memDir)
-	if err != nil {
-		return 0
-	}
-	n := 0
-	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(memDir, e.Name()))
-		if err != nil {
-			continue
-		}
-		var raw map[string]any
-		if err := json.Unmarshal(data, &raw); err != nil {
-			continue
-		}
-		if lm, _ := raw["landmark"].(bool); lm {
-			n++
-		}
-	}
-	return n
 }

--- a/cli/internal/mcp/status_test.go
+++ b/cli/internal/mcp/status_test.go
@@ -7,18 +7,27 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/momhq/mom/cli/internal/centralvault"
 )
 
 // newStatusTestDir creates a temp .mom/ dir with constraints, skills, and config
 // set up for mom_status tests.
 func newStatusTestDir(t *testing.T) string {
 	t.Helper()
+	vaultPath := setCentralVault(t)
+	centralDir := filepath.Dir(vaultPath)
 	dir := t.TempDir()
 	leoDir := filepath.Join(dir, ".mom")
 
 	// Required dirs.
-	for _, sub := range []string{"memory", "constraints", "skills"} {
+	for _, sub := range []string{"memory"} {
 		if err := os.MkdirAll(filepath.Join(leoDir, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, sub := range []string{"constraints", "skills"} {
+		if err := os.MkdirAll(filepath.Join(centralDir, sub), 0755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -55,7 +64,7 @@ communication:
 	writeJSON(t, filepath.Join(leoDir, "identity.json"), identity)
 
 	// Two constraint docs.
-	writeJSON(t, filepath.Join(leoDir, "constraints", "anti-hallucination.json"), map[string]any{
+	writeJSON(t, filepath.Join(centralDir, "constraints", "anti-hallucination.json"), map[string]any{
 		"id":         "anti-hallucination",
 		"type":       "constraint",
 		"lifecycle":  "permanent",
@@ -68,7 +77,7 @@ communication:
 		"updated_by": "test",
 		"content":    map[string]any{"rule": "no hallucination"},
 	})
-	writeJSON(t, filepath.Join(leoDir, "constraints", "escalation-triggers.json"), map[string]any{
+	writeJSON(t, filepath.Join(centralDir, "constraints", "escalation-triggers.json"), map[string]any{
 		"id":         "escalation-triggers",
 		"type":       "constraint",
 		"lifecycle":  "permanent",
@@ -83,7 +92,7 @@ communication:
 	})
 
 	// One skill doc.
-	writeJSON(t, filepath.Join(leoDir, "skills", "session-wrap-up.json"), map[string]any{
+	writeJSON(t, filepath.Join(centralDir, "skills", "session-wrap-up.json"), map[string]any{
 		"id":         "session-wrap-up",
 		"type":       "skill",
 		"lifecycle":  "permanent",
@@ -97,20 +106,8 @@ communication:
 		"content":    map[string]any{"steps": "inventory, classify, write, report"},
 	})
 
-	// One memory doc to verify total_memories count.
-	writeMemoryDoc(t, leoDir, map[string]any{
-		"id":         "test-mem",
-		"type":       "fact",
-		"lifecycle":  "permanent",
-		"scope":      "project",
-		"tags":       []string{"test"},
-		"summary":    "A test memory",
-		"created":    time.Now().Format(time.RFC3339),
-		"created_by": "test",
-		"updated":    time.Now().Format(time.RFC3339),
-		"updated_by": "test",
-		"content":    map[string]any{"detail": "x"},
-	})
+	// One memory row to verify total_memories count.
+	insertCentralMemory(t, "A test memory", "detail x", []string{"test"})
 
 	return leoDir
 }
@@ -405,9 +402,13 @@ func TestMomStatusDocSchema(t *testing.T) {
 }
 
 func TestMomStatusNoConstraintsDir(t *testing.T) {
-	// mom_status must not fail when constraints/ is absent.
+	// mom_status must not fail when central constraints/ is absent.
 	leoDir := newStatusTestDir(t)
-	if err := os.RemoveAll(filepath.Join(leoDir, "constraints")); err != nil {
+	centralDir, err := centralvault.Dir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(centralDir, "constraints")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -422,9 +423,13 @@ func TestMomStatusNoConstraintsDir(t *testing.T) {
 }
 
 func TestMomStatusNoSkillsDir(t *testing.T) {
-	// mom_status must not fail when skills/ is absent.
+	// mom_status must not fail when central skills/ is absent.
 	leoDir := newStatusTestDir(t)
-	if err := os.RemoveAll(filepath.Join(leoDir, "skills")); err != nil {
+	centralDir, err := centralvault.Dir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(centralDir, "skills")); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -2,17 +2,12 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
-	"time"
 
-	"github.com/momhq/mom/cli/internal/adapters/storage"
-	"github.com/momhq/mom/cli/internal/herald"
-	"github.com/momhq/mom/cli/internal/memory"
-	"github.com/momhq/mom/cli/internal/recall"
-	"github.com/momhq/mom/cli/internal/scope"
+	"github.com/momhq/mom/cli/internal/finder"
+	"github.com/momhq/mom/cli/internal/librarian"
 )
 
 // toolDef describes one MCP tool for the tools/list response.
@@ -34,56 +29,45 @@ type toolCallResult struct {
 	IsError bool          `json:"isError,omitempty"`
 }
 
-// allTools returns the static tool catalogue.
+// allTools returns the static v0.30 tool catalogue.
 func allTools() []toolDef {
 	return []toolDef{
 		{
-			Name:        "get_memory",
-			Description: "Retrieve a single memory document by its ID.",
+			Name:        "mom_status",
+			Description: "Returns MOM's operating protocol and central v0.30 vault status. Call this at the start of every session.",
+			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+		},
+		{
+			Name:        "mom_recall",
+			Description: "Search persistent memory with a natural-language query.",
+			InputSchema: map[string]any{
+				"type":     "object",
+				"required": []string{"query"},
+				"properties": map[string]any{
+					"query": map[string]any{"type": "string", "description": "Search query"},
+				},
+			},
+		},
+		{
+			Name:        "mom_get",
+			Description: "Retrieve a single memory by ID from the central vault.",
 			InputSchema: map[string]any{
 				"type":     "object",
 				"required": []string{"id"},
 				"properties": map[string]any{
-					"id": map[string]any{"type": "string", "description": "Memory document ID"},
+					"id": map[string]any{"type": "string", "description": "Memory ID"},
 				},
 			},
 		},
 		{
-			Name:        "list_scopes",
-			Description: "List all discovered .mom/ scopes from the current working directory walk-up.",
-			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
-			},
-		},
-		{
-			Name:        "create_memory_draft",
-			Description: "Create a draft memory document in the nearest .mom/memory/ directory.",
-			InputSchema: map[string]any{
-				"type":     "object",
-				"required": []string{"summary", "tags", "content"},
-				"properties": map[string]any{
-					"summary": map[string]any{"type": "string", "description": "One-line summary"},
-					"tags":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Kebab-case tags"},
-					"content": map[string]any{"type": "object", "description": "Freeform content map"},
-				},
-			},
-		},
-		{
-			Name:        "list_landmarks",
-			Description: "List landmark memories sorted by centrality_score descending.",
+			Name:        "mom_landmarks",
+			Description: "List landmark memories from the central vault sorted by centrality_score descending.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"scope": map[string]any{"type": "string", "description": "Restrict to scope label"},
 					"limit": map[string]any{"type": "integer", "description": "Maximum results (default 20)"},
 				},
 			},
-		},
-		{
-			Name:        "mom_status",
-			Description: "Returns MOM's full operating protocol — identity, boundaries, constraints, modes, and memory overview. Call this at the start of every session.",
-			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
 		},
 		{
 			Name:        "mom_record",
@@ -100,28 +84,12 @@ func allTools() []toolDef {
 				},
 			},
 		},
-		{
-			Name:        "mom_recall",
-			Description: "Search your memory for relevant context. Uses progressive scope escalation (repo→org→user) with AND→OR query relaxation and curated-first, draft-fallback quality tiers.",
-			InputSchema: map[string]any{
-				"type":     "object",
-				"required": []string{"query"},
-				"properties": map[string]any{
-					"query":       map[string]any{"type": "string", "description": "Search query (keywords or natural language)"},
-					"max_results": map[string]any{"type": "integer", "description": "Maximum results (default 5)"},
-					"tags":        map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Filter by tags (AND logic)"},
-					"session_id":  map[string]any{"type": "string", "description": "Filter by source session"},
-					"scope":       map[string]any{"type": "string", "description": "Pin search to a single scope label (repo/org/user); omit to use full escalation chain"},
-				},
-			},
-		},
 	}
 }
 
 // handleToolsList returns the static tool catalogue.
 func (s *Server) handleToolsList() (any, *rpcError) {
 	tools := allTools()
-	// Convert to []any for JSON serialisation.
 	out := make([]any, len(tools))
 	for i, t := range tools {
 		out[i] = t
@@ -145,20 +113,16 @@ func (s *Server) handleToolsCall(params json.RawMessage) (any, *rpcError) {
 	)
 
 	switch req.Name {
-	case "get_memory":
-		result, err = s.toolGetMemory(req.Arguments)
-	case "list_scopes":
-		result, err = s.toolListScopes()
-	case "create_memory_draft":
-		result, err = s.toolCreateMemoryDraft(req.Arguments)
-	case "list_landmarks":
-		result, err = s.toolListLandmarks(req.Arguments)
 	case "mom_status":
 		result, err = s.toolMomStatus()
-	case "mom_record":
-		result, err = s.toolMomRecord(req.Arguments)
 	case "mom_recall":
 		result, err = s.toolMomRecall(req.Arguments)
+	case "mom_get":
+		result, err = s.toolMomGet(req.Arguments)
+	case "mom_landmarks":
+		result, err = s.toolMomLandmarks(req.Arguments)
+	case "mom_record":
+		result, err = s.toolMomRecord(req.Arguments)
 	default:
 		return nil, &rpcError{Code: errCodeMethodNotFound, Message: "unknown tool: " + req.Name}
 	}
@@ -174,237 +138,74 @@ func (s *Server) handleToolsCall(params json.RawMessage) (any, *rpcError) {
 
 // --- Tool implementations ---
 
-// toolGetMemory retrieves a single memory doc by ID.
-func (s *Server) toolGetMemory(args map[string]any) (toolCallResult, error) {
+func (s *Server) requireLibrarian() (*librarian.Librarian, error) {
+	if s.lib == nil {
+		if s.openErr != nil {
+			return nil, s.openErr
+		}
+		return nil, errors.New("central vault is not open")
+	}
+	return s.lib, nil
+}
+
+func (s *Server) toolMomGet(args map[string]any) (toolCallResult, error) {
 	id := stringArg(args, "id")
-	if id == "" {
+	if strings.TrimSpace(id) == "" {
 		return toolCallResult{}, fmt.Errorf("id is required")
 	}
-
-	scopes := scope.Walk(s.momDir)
-	if len(scopes) == 0 {
-		scopes = []scope.Scope{{Path: s.momDir, Label: "repo"}}
-	}
-
-	for _, sc := range scopes {
-		path := filepath.Join(sc.Path, "memory", id+".json")
-		doc, err := memory.LoadDoc(path)
-		if err != nil {
-			continue
-		}
-		// Emit telemetry.
-		em := herald.New(s.momDir, true)
-		em.EmitConsumptionEvent(herald.ConsumptionEvent{
-			MemoryID: doc.ID,
-			TS:       time.Now().UTC().Format(time.RFC3339),
-			ByAgent:  "mcp",
-			Context:  "get_memory",
-		})
-
-		text, _ := json.MarshalIndent(doc, "", "  ")
-		return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
-	}
-
-	return toolCallResult{}, fmt.Errorf("memory %q not found in any scope", id)
-}
-
-// toolListScopes lists discovered .mom/ scopes.
-func (s *Server) toolListScopes() (toolCallResult, error) {
-	scopes := scope.Walk(s.momDir)
-	if len(scopes) == 0 {
-		scopes = []scope.Scope{{Path: s.momDir, Label: "repo"}}
-	}
-
-	type scopeItem struct {
-		Label       string `json:"label"`
-		Path        string `json:"path"`
-		MemoryCount int    `json:"memory_count"`
-	}
-	items := make([]scopeItem, len(scopes))
-	for i, sc := range scopes {
-		items[i] = scopeItem{
-			Label:       sc.Label,
-			Path:        sc.Path,
-			MemoryCount: sc.MemoryCount(),
-		}
-	}
-	text, _ := json.MarshalIndent(items, "", "  ")
-	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
-}
-
-// toolCreateMemoryDraft creates a new draft memory document.
-func (s *Server) toolCreateMemoryDraft(args map[string]any) (toolCallResult, error) {
-	summary := stringArg(args, "summary")
-	tags := stringSliceArg(args, "tags")
-	content, _ := args["content"].(map[string]any)
-
-	if summary == "" || len(tags) == 0 {
-		return toolCallResult{}, fmt.Errorf("summary and tags are required")
-	}
-	if content == nil {
-		content = map[string]any{}
-	}
-
-	// Sanitize tags: convert underscores to hyphens for kebab-case compliance.
-	for i, t := range tags {
-		tags[i] = strings.ReplaceAll(strings.ToLower(strings.TrimSpace(t)), "_", "-")
-	}
-
-	// Use nearest writable scope or fall back to leoDir.
-	targetDir := s.momDir
-	if sc, ok := scope.NearestWritable(s.momDir); ok {
-		targetDir = sc.Path
-	}
-
-	// Generate a slug ID from summary.
-	id := slugify(summary)
-	now := time.Now().UTC()
-
-	memDir := filepath.Join(targetDir, "memory")
-	if err := os.MkdirAll(memDir, 0755); err != nil {
-		return toolCallResult{}, fmt.Errorf("creating memory dir: %w", err)
-	}
-
-	// Write through IndexedAdapter for SQLite index sync.
-	storageDoc := &storage.Doc{
-		ID:             id,
-		Scope:          "project",
-		Tags:           tags,
-		Created:        now,
-		CreatedBy:      "mcp",
-		PromotionState: "curated",
-		Classification: "INTERNAL",
-		Compartments:   map[string][]string{},
-		Provenance: &memory.Provenance{
-			Runtime:      "mcp",
-			TriggerEvent: "create_memory_draft",
-		},
-		Content: content,
-	}
-	if err := s.idx.Write(storageDoc); err != nil {
-		return toolCallResult{}, fmt.Errorf("saving draft: %w", err)
-	}
-
-	path := filepath.Join(memDir, id+".json")
-	result := map[string]any{
-		"id":              id,
-		"promotion_state": "curated",
-		"path":            path,
-		"message":         fmt.Sprintf("Memory created at %s", path),
-	}
-	text, _ := json.MarshalIndent(result, "", "  ")
-	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
-}
-
-// toolListLandmarks lists landmark memories sorted by centrality_score.
-func (s *Server) toolListLandmarks(args map[string]any) (toolCallResult, error) {
-	scopeLabel := stringArg(args, "scope")
-	limit := intArg(args, "limit", 20)
-
-	scopes := scope.Walk(s.momDir)
-	if len(scopes) == 0 {
-		scopes = []scope.Scope{{Path: s.momDir, Label: "repo"}}
-	}
-
-	var scopePaths []string
-	for _, sc := range scopes {
-		if scopeLabel == "" || sc.Label == scopeLabel {
-			scopePaths = append(scopePaths, sc.Path)
-		}
-	}
-
-	results, err := s.idx.ListLandmarks(scopePaths, limit)
+	lib, err := s.requireLibrarian()
 	if err != nil {
-		return toolCallResult{}, fmt.Errorf("list_landmarks failed: %w", err)
+		return toolCallResult{}, err
 	}
+	mem, err := lib.Get(id)
+	if err != nil {
+		return toolCallResult{}, fmt.Errorf("mom_get: %w", err)
+	}
+	text, _ := json.MarshalIndent(mem, "", "  ")
+	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
+}
 
-	if len(results) == 0 {
+func (s *Server) toolMomLandmarks(args map[string]any) (toolCallResult, error) {
+	limit := intArg(args, "limit", 20)
+	lib, err := s.requireLibrarian()
+	if err != nil {
+		return toolCallResult{}, err
+	}
+	items, err := lib.Landmarks(limit)
+	if err != nil {
+		return toolCallResult{}, fmt.Errorf("mom_landmarks: %w", err)
+	}
+	if len(items) == 0 {
 		return toolCallResult{Content: []toolContent{{Type: "text", Text: "No landmarks found."}}}, nil
 	}
-
-	type landmarkItem struct {
-		ID              string   `json:"id"`
-		Summary         string   `json:"summary"`
-		Tags            []string `json:"tags"`
-		CentralityScore float64  `json:"centrality_score"`
-	}
-	items := make([]landmarkItem, len(results))
-	for i, r := range results {
-		cs := 0.0
-		if r.CentralityScore != nil {
-			cs = *r.CentralityScore
-		}
-		items[i] = landmarkItem{
-			ID:              r.ID,
-			Summary:         r.Summary,
-			Tags:            r.Tags,
-			CentralityScore: cs,
-		}
-	}
-
 	text, _ := json.MarshalIndent(items, "", "  ")
 	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
 }
 
-// toolMomRecall searches memories using the progressive escalation engine.
-// When scope is provided, the engine chain is pinned to that single scope.
 func (s *Server) toolMomRecall(args map[string]any) (toolCallResult, error) {
 	query := stringArg(args, "query")
-	maxResults := intArg(args, "max_results", 5)
-	tags := stringSliceArg(args, "tags")
-	sessionID := stringArg(args, "session_id")
-	scopeLabel := stringArg(args, "scope")
-
-	engine := s.engine
-	// Pin to a single scope when the caller requests it.
-	if scopeLabel != "" {
-		scopes := scope.Walk(s.momDir)
-		if len(scopes) == 0 {
-			scopes = []scope.Scope{{Path: s.momDir, Label: "repo"}}
-		}
-		var chain []recall.Searcher
-		for _, sc := range scopes {
-			if sc.Label == scopeLabel {
-				chain = append(chain, recall.NewScopeSearcher(s.idx, sc.Path))
-			}
-		}
-		if len(chain) > 0 {
-			engine = recall.NewEngine(chain)
-		}
+	if strings.TrimSpace(query) == "" {
+		return toolCallResult{}, fmt.Errorf("query is required")
 	}
-
-	results, err := engine.Search(recall.Options{
-		Query:      query,
-		MaxResults: maxResults,
-		Tags:       tags,
-		SessionID:  sessionID,
-	})
+	if s.finder == nil {
+		if s.openErr != nil {
+			return toolCallResult{}, s.openErr
+		}
+		return toolCallResult{}, errors.New("finder is not available")
+	}
+	results, err := s.finder.Recall(finder.Options{Query: query, Limit: 5})
 	if err != nil {
-		return toolCallResult{}, fmt.Errorf("mom_recall search failed: %w", err)
-	}
-
-	// Emit telemetry for consumed memories.
-	if s.momDir != "" {
-		em := herald.New(s.momDir, true)
-		for _, r := range results {
-			em.EmitConsumptionEvent(herald.ConsumptionEvent{
-				MemoryID: r.ID,
-				TS:       time.Now().UTC().Format(time.RFC3339),
-				ByAgent:  "mcp",
-				Context:  "mom_recall",
-			})
+		if errors.Is(err, finder.ErrEmptyQuery) {
+			return toolCallResult{}, fmt.Errorf("query is required")
 		}
+		return toolCallResult{}, fmt.Errorf("mom_recall: %w", err)
 	}
-
 	if len(results) == 0 {
 		return toolCallResult{Content: []toolContent{{Type: "text", Text: "No memories matched."}}}, nil
 	}
-
 	text, _ := json.MarshalIndent(results, "", "  ")
 	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
 }
-
-
 
 // --- Argument helpers ---
 
@@ -449,28 +250,4 @@ func intArg(args map[string]any, key string, defaultVal int) int {
 		return t
 	}
 	return defaultVal
-}
-
-// slugify converts a string to a kebab-case ID suitable for file names.
-func slugify(s string) string {
-	s = strings.ToLower(s)
-	var b strings.Builder
-	prev := '-'
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-			prev = r
-		default:
-			if prev != '-' {
-				b.WriteRune('-')
-			}
-			prev = '-'
-		}
-	}
-	result := strings.Trim(b.String(), "-")
-	if result == "" {
-		result = fmt.Sprintf("draft-%d", time.Now().UnixMilli())
-	}
-	return result
 }


### PR DESCRIPTION
## Summary

- Lock `tools/list` to exactly 5 v0.30 tools: `mom_status`, `mom_recall`, `mom_get`, `mom_landmarks`, `mom_record`
- Remove legacy MCP tool names and dispatch paths (`get_memory`, `list_scopes`, `create_memory_draft`, `list_landmarks`, `mom_record_turn`)
- Rewire read tools to the central v0.30 vault through `centralvault` + Librarian/Finder
- Add MCP `initialize.instructions` protocol metadata without changing current context injection
- Make `mom_status` read generated constraints/skills from the central vault directory
- Add `Librarian.Landmarks` for landmark reads through the v0.30 boundary

## Closes

Closes #245

## Test plan

- [x] `cd cli && go test ./...`
