### PR TITLE
feat(upgrade): import legacy memories to central vault

### DIFF
--- a/cli/internal/centralvault/centralvault.go
+++ b/cli/internal/centralvault/centralvault.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/logbook"
@@ -48,6 +49,28 @@ func Path() (string, error) {
 func Migrations() []vault.Migration {
 	migs := append([]vault.Migration{}, librarian.Migrations()...)
 	migs = append(migs, logbook.Migrations()...)
+	migs = append(migs, vault.Migration{
+		Version: 4,
+		Stmts: []string{
+			`CREATE TABLE legacy_imports (
+				source_path        TEXT PRIMARY KEY,
+				source_fingerprint TEXT NOT NULL,
+				imported_at        TEXT NOT NULL,
+				memory_count       INTEGER NOT NULL,
+				mapping_count      INTEGER NOT NULL
+			)`,
+			`CREATE TABLE legacy_import_items (
+				source_path  TEXT NOT NULL,
+				old_id       TEXT NOT NULL,
+				new_id       TEXT NOT NULL,
+				content_hash TEXT NOT NULL,
+				created_at   TEXT NOT NULL,
+				PRIMARY KEY (source_path, old_id),
+				FOREIGN KEY (source_path) REFERENCES legacy_imports(source_path)
+			)`,
+		},
+	})
+	sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	return migs
 }
 

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/momhq/mom/cli/internal/adapters/harness"
 	"github.com/momhq/mom/cli/internal/adapters/storage"
 	"github.com/momhq/mom/cli/internal/config"
 	"github.com/momhq/mom/cli/internal/ux"
+	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
@@ -22,14 +22,15 @@ var upgradeCmd = &cobra.Command{
 	Long: `Upgrades core infrastructure (schema, constraints, skills, runtime files)
 to match the installed mom binary. Your documents in .mom/memory/ are never touched.
 
-Use --all to propagate the upgrade to all child scopes in the hierarchy
-(org folders and repos beneath the current scope).`,
+Use --all to propagate the legacy filesystem upgrade to all child scopes in the hierarchy
+(org folders and repos beneath the current scope). Memory import always scans $HOME.`,
 	RunE: runUpgrade,
 }
 
 func init() {
 	upgradeCmd.Flags().Bool("dry-run", false, "Show what would change without modifying anything")
 	upgradeCmd.Flags().Bool("all", false, "Upgrade all child scopes in the hierarchy")
+	upgradeCmd.Flags().Bool("skip-memories", false, "Skip importing legacy .mom/memory docs into the central vault")
 }
 
 // upgradeAction tracks a single change for reporting.
@@ -41,6 +42,7 @@ type upgradeAction struct {
 func runUpgrade(cmd *cobra.Command, args []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	all, _ := cmd.Flags().GetBool("all")
+	skipMemories, _ := cmd.Flags().GetBool("skip-memories")
 
 	momDir, err := findMomDir()
 	if err != nil {
@@ -54,12 +56,12 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Propagate to child scopes if --all.
+	// Propagate legacy filesystem upgrade to child scopes if --all.
 	if all {
 		propagateUpgrade(cmd, projectRoot, dryRun)
 	}
 
-	return nil
+	return runCentralMemoryImport(cmd, dryRun, skipMemories)
 }
 
 // upgradeSingleDir runs the full upgrade pipeline on a single .mom/ directory.

--- a/cli/internal/cmd/upgrade_import.go
+++ b/cli/internal/cmd/upgrade_import.go
@@ -1,0 +1,353 @@
+package cmd
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/momhq/mom/cli/internal/ux"
+	"github.com/spf13/cobra"
+)
+
+type legacyVaultPlan struct {
+	Path        string
+	Fingerprint string
+	Docs        []legacyMemoryDoc
+}
+
+type legacyMemoryDoc struct {
+	Path string
+	Raw  []byte
+	Doc  map[string]any
+	Hash string
+}
+
+type importSummary struct {
+	Vaults   int
+	Memories int
+	Mappings []librarian.LegacyImportMapping
+	Skipped  int
+	Audit    string
+}
+
+func runCentralMemoryImport(cmd *cobra.Command, dryRun, skip bool) error {
+	if skip {
+		ux.NewPrinter(cmd.OutOrStdout()).Muted("Central memory import skipped (--skip-memories).")
+		return nil
+	}
+	plans, err := discoverLegacyVaultsForImport()
+	if err != nil {
+		return err
+	}
+	p := ux.NewPrinter(cmd.OutOrStdout())
+	if len(plans) == 0 {
+		p.Muted("No legacy .mom/memory folders found for central import.")
+		return nil
+	}
+	memoryCount := 0
+	for _, plan := range plans {
+		memoryCount += len(plan.Docs)
+	}
+	p.Blank()
+	if dryRun {
+		p.Bold("Dry run — central memory import plan:")
+	} else {
+		p.Bold("Central memory import plan:")
+	}
+	for _, plan := range plans {
+		p.KeyValue(shortenPath(plan.Path), fmt.Sprintf("%d memories", len(plan.Docs)), 28)
+	}
+	p.KeyValue("Total", fmt.Sprintf("%d vaults, %d memories", len(plans), memoryCount), 28)
+	p.Blank()
+	if dryRun {
+		return nil
+	}
+	if !confirmUpgradeImport(cmd, len(plans), memoryCount) {
+		return fmt.Errorf("upgrade aborted by user")
+	}
+	summary, err := executeCentralMemoryImport(plans)
+	if err != nil {
+		return err
+	}
+	p.Bold("Central memory import complete:")
+	p.Checkf("vaults imported: %d", summary.Vaults)
+	p.Checkf("memories imported: %d", summary.Memories)
+	if summary.Skipped > 0 {
+		p.Warnf("vaults skipped (already imported): %d", summary.Skipped)
+	}
+	if summary.Audit != "" {
+		p.Checkf("ID mapping written: %s", summary.Audit)
+	}
+	return nil
+}
+
+func discoverLegacyVaultsForImport() ([]legacyVaultPlan, error) {
+	home := os.Getenv("MOM_UPGRADE_SCAN_ROOT")
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve $HOME: %w", err)
+		}
+	}
+	centralDir, _ := centralvault.Dir()
+	var plans []legacyVaultPlan
+	err := filepath.WalkDir(home, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path == home {
+			return nil
+		}
+		if depth(home, path) > 5 {
+			return filepath.SkipDir
+		}
+		name := d.Name()
+		if name == ".mom" {
+			if samePath(path, centralDir) {
+				return filepath.SkipDir
+			}
+			docs, fingerprint, err := readLegacyMemoryDocs(path)
+			if err == nil && len(docs) > 0 {
+				plans = append(plans, legacyVaultPlan{Path: path, Fingerprint: fingerprint, Docs: docs})
+			}
+			return filepath.SkipDir
+		}
+		if shouldSkipImportDir(name) {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discover legacy vaults: %w", err)
+	}
+	sort.Slice(plans, func(i, j int) bool { return plans[i].Path < plans[j].Path })
+	return plans, nil
+}
+
+func shouldSkipImportDir(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	switch name {
+	case "Library", "Applications", "Movies", "Music", "Pictures", "Public", "node_modules", "vendor", "Caches", "Trash", "tmp", "temp":
+		return true
+	default:
+		return false
+	}
+}
+
+func depth(root, path string) int {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." {
+		return 0
+	}
+	return len(strings.Split(rel, string(os.PathSeparator)))
+}
+
+func samePath(a, b string) bool {
+	aa, errA := filepath.EvalSymlinks(a)
+	bb, errB := filepath.EvalSymlinks(b)
+	if errA == nil && errB == nil {
+		return aa == bb
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func readLegacyMemoryDocs(momDir string) ([]legacyMemoryDoc, string, error) {
+	memDir := filepath.Join(momDir, "memory")
+	entries, err := os.ReadDir(memDir)
+	if err != nil {
+		return nil, "", err
+	}
+	var docs []legacyMemoryDoc
+	var parts []string
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(memDir, e.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			continue
+		}
+		sum := sha256.Sum256(raw)
+		hash := fmt.Sprintf("%x", sum[:])
+		docs = append(docs, legacyMemoryDoc{Path: path, Raw: raw, Doc: doc, Hash: hash})
+		parts = append(parts, e.Name()+":"+hash)
+	}
+	sort.Strings(parts)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return docs, fmt.Sprintf("%x", sum[:]), nil
+}
+
+func confirmUpgradeImport(cmd *cobra.Command, vaults, memories int) bool {
+	if strings.EqualFold(os.Getenv("MOM_UPGRADE_ASSUME_YES"), "1") || strings.EqualFold(os.Getenv("MOM_UPGRADE_ASSUME_YES"), "true") {
+		return true
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Import %d memories from %d legacy .mom folders into the central vault? [y/N] ", memories, vaults)
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes"
+}
+
+func executeCentralMemoryImport(plans []legacyVaultPlan) (importSummary, error) {
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	if err != nil {
+		return importSummary{}, fmt.Errorf("open central vault: %w", err)
+	}
+	defer func() { _ = closeFn() }()
+	var summary importSummary
+	for _, plan := range plans {
+		records := make([]librarian.LegacyImportMemory, 0, len(plan.Docs))
+		for _, d := range plan.Docs {
+			rec, err := legacyDocToImportRecord(d)
+			if err != nil {
+				return importSummary{}, fmt.Errorf("%s: %w", d.Path, err)
+			}
+			records = append(records, rec)
+		}
+		mappings, skipped, err := lib.ImportLegacyMemories(plan.Path, plan.Fingerprint, records)
+		if err != nil {
+			return importSummary{}, err
+		}
+		if skipped {
+			summary.Skipped++
+			continue
+		}
+		summary.Vaults++
+		summary.Memories += len(records)
+		summary.Mappings = append(summary.Mappings, mappings...)
+	}
+	if len(summary.Mappings) > 0 {
+		audit, err := writeImportAudit(summary.Mappings)
+		if err != nil {
+			return importSummary{}, err
+		}
+		summary.Audit = audit
+	}
+	return summary, nil
+}
+
+func legacyDocToImportRecord(d legacyMemoryDoc) (librarian.LegacyImportMemory, error) {
+	doc := d.Doc
+	oldID := strField(doc, "id")
+	contentAny := doc["content"]
+	if contentAny == nil {
+		contentAny = map[string]any{"text": string(d.Raw)}
+	}
+	content, err := json.Marshal(contentAny)
+	if err != nil {
+		return librarian.LegacyImportMemory{}, err
+	}
+	createdAt := time.Now().UTC()
+	if s := strField(doc, "created"); s != "" {
+		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+			createdAt = t
+		}
+	}
+	tags := normaliseLegacyTags(doc["tags"])
+	createdBy := strField(doc, "created_by")
+	actor := createdBy
+	if actor == "" {
+		actor = "legacy-import"
+	}
+	sessionID := strField(doc, "session_id")
+	if sessionID == "" {
+		sessionID = "legacy-import"
+	}
+	return librarian.LegacyImportMemory{
+		OldID: oldID,
+		Memory: librarian.InsertMemory{
+			Type:                   mapLegacyType(strField(doc, "type")),
+			Summary:                strField(doc, "summary"),
+			Content:                string(content),
+			CreatedAt:              createdAt,
+			SessionID:              sessionID,
+			ProvenanceActor:        actor,
+			ProvenanceSourceType:   "legacy-memory-json",
+			ProvenanceTriggerEvent: "upgrade",
+		},
+		Tags:      tags,
+		CreatedBy: createdBy,
+		Hash:      d.Hash,
+	}, nil
+}
+
+func strField(m map[string]any, key string) string {
+	v, _ := m[key].(string)
+	return strings.TrimSpace(v)
+}
+
+func normaliseLegacyTags(v any) []string {
+	var out []string
+	seen := map[string]bool{}
+	if arr, ok := v.([]any); ok {
+		for _, item := range arr {
+			if s, ok := item.(string); ok {
+				n := librarian.NormalizeTagName(s)
+				if n != "" && !seen[n] {
+					seen[n] = true
+					out = append(out, n)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func mapLegacyType(t string) string {
+	switch strings.ToLower(strings.TrimSpace(t)) {
+	case "decision", "fact", "pattern", "semantic":
+		return "semantic"
+	case "procedure", "runbook", "how-to", "procedural":
+		return "procedural"
+	case "session-log", "event", "episodic":
+		return "episodic"
+	case "untyped":
+		return "untyped"
+	default:
+		return "untyped"
+	}
+}
+
+func writeImportAudit(mappings []librarian.LegacyImportMapping) (string, error) {
+	dir, err := centralvault.Dir()
+	if err != nil {
+		return "", err
+	}
+	upgradeDir := filepath.Join(dir, "upgrade")
+	if err := os.MkdirAll(upgradeDir, 0o700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(upgradeDir, "import-"+time.Now().UTC().Format("20060102-150405")+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, m := range mappings {
+		if err := enc.Encode(m); err != nil {
+			return "", err
+		}
+	}
+	return path, nil
+}

--- a/cli/internal/cmd/upgrade_import_test.go
+++ b/cli/internal/cmd/upgrade_import_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/librarian"
+)
+
+func writeLegacyMemory(t *testing.T, momDir, name, body string) {
+	t.Helper()
+	memDir := filepath.Join(momDir, "memory")
+	if err := os.MkdirAll(memDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(memDir, name+".json"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDiscoverLegacyVaultsForImport_WalksHomeMaxDepth(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", home)
+	t.Setenv("MOM_VAULT", filepath.Join(home, "central.db"))
+	legacy := filepath.Join(home, "work", "repo", ".mom")
+	writeLegacyMemory(t, legacy, "a", `{"id":"a","type":"fact","tags":["Deploy"],"created":"2026-01-01T00:00:00Z","created_by":"alice","content":{"text":"deploy flow"}}`)
+	tooDeep := filepath.Join(home, "a", "b", "c", "d", "e", "repo", ".mom")
+	writeLegacyMemory(t, tooDeep, "b", `{"id":"b","content":{"text":"too deep"}}`)
+
+	plans, err := discoverLegacyVaultsForImport()
+	if err != nil {
+		t.Fatalf("discoverLegacyVaultsForImport: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %d, want 1: %+v", len(plans), plans)
+	}
+	if plans[0].Path != legacy {
+		t.Fatalf("plan path = %s, want %s", plans[0].Path, legacy)
+	}
+}
+
+func TestExecuteCentralMemoryImport_ImportsAndIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", home)
+	t.Setenv("MOM_VAULT", filepath.Join(home, "central.db"))
+	legacy := filepath.Join(home, "repo", ".mom")
+	legacyFile := filepath.Join(legacy, "memory", "decision.json")
+	body := `{"id":"decision","type":"decision","tags":["Deploy", "AWS"],"created":"2026-01-01T00:00:00Z","created_by":"alice","summary":"Use canary deploy","content":{"text":"Use AWS canary deploy"}}`
+	writeLegacyMemory(t, legacy, "decision", body)
+
+	plans, err := discoverLegacyVaultsForImport()
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	summary, err := executeCentralMemoryImport(plans)
+	if err != nil {
+		t.Fatalf("executeCentralMemoryImport: %v", err)
+	}
+	if summary.Vaults != 1 || summary.Memories != 1 || len(summary.Mappings) != 1 {
+		t.Fatalf("summary = %+v", summary)
+	}
+	if _, err := os.Stat(legacyFile); err != nil {
+		t.Fatalf("legacy file was touched/removed: %v", err)
+	}
+	if summary.Audit == "" || !strings.Contains(summary.Audit, "upgrade") {
+		t.Fatalf("audit path missing: %+v", summary)
+	}
+
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	if err != nil {
+		t.Fatalf("OpenLibrarian: %v", err)
+	}
+	defer func() { _ = closeFn() }()
+	rows, err := lib.SearchMemories(librarian.SearchFilter{FTSQuery: "AWS", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchMemories: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Type != "semantic" || rows[0].PromotionState != "draft" {
+		t.Fatalf("imported row = %+v", rows)
+	}
+	ids, err := lib.MemoriesByEntity("user", "alice")
+	if err != nil || len(ids) != 1 {
+		t.Fatalf("created_by entity ids=%v err=%v", ids, err)
+	}
+
+	again, err := executeCentralMemoryImport(plans)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if again.Skipped != 1 || again.Memories != 0 {
+		t.Fatalf("second summary = %+v", again)
+	}
+}
+
+func TestLegacyDocToImportRecord_DefaultsDraftAndUntyped(t *testing.T) {
+	rec, err := legacyDocToImportRecord(legacyMemoryDoc{Raw: []byte(`{"id":"x"}`), Doc: map[string]any{"id": "x", "content": map[string]any{"text": "x"}}, Hash: "h"})
+	if err != nil {
+		t.Fatalf("legacyDocToImportRecord: %v", err)
+	}
+	if rec.Memory.Type != "untyped" || rec.Memory.SessionID != "legacy-import" || rec.Memory.ProvenanceTriggerEvent != "upgrade" {
+		t.Fatalf("record mapping = %+v", rec)
+	}
+}

--- a/cli/internal/cmd/upgrade_test.go
+++ b/cli/internal/cmd/upgrade_test.go
@@ -15,14 +15,20 @@ import (
 // resetUpgradeFlags resets cobra flag state between tests.
 func resetUpgradeFlags(t *testing.T) {
 	t.Helper()
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", t.TempDir())
+	t.Setenv("MOM_UPGRADE_ASSUME_YES", "1")
 	t.Cleanup(func() {
 		upgradeCmd.Flags().Set("dry-run", "false")
+		upgradeCmd.Flags().Set("skip-memories", "false")
 	})
 }
 
 func setupV060Project(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", dir)
+	t.Setenv("MOM_UPGRADE_ASSUME_YES", "1")
 	leoDir := filepath.Join(dir, ".mom")
 
 	// Create directories using the legacy kb/ layout to simulate a pre-v0.8 install.
@@ -805,16 +811,16 @@ func TestUpgradeCmd_MigratesFactASTToPattern(t *testing.T) {
 
 	// Write a plain fact doc (should NOT be converted).
 	plainFactDoc := map[string]interface{}{
-		"id":              "plain-fact",
-		"type":            "fact",
-		"lifecycle":       "state",
-		"scope":           "project",
-		"tags":            []string{"architecture"},
-		"created":         "2026-04-10T00:00:00Z",
-		"created_by":      "owner",
-		"updated":         "2026-04-10T00:00:00Z",
-		"updated_by":      "owner",
-		"content":         map[string]interface{}{"fact": "plain fact", "why": "testing", "source": "owner"},
+		"id":         "plain-fact",
+		"type":       "fact",
+		"lifecycle":  "state",
+		"scope":      "project",
+		"tags":       []string{"architecture"},
+		"created":    "2026-04-10T00:00:00Z",
+		"created_by": "owner",
+		"updated":    "2026-04-10T00:00:00Z",
+		"updated_by": "owner",
+		"content":    map[string]interface{}{"fact": "plain fact", "why": "testing", "source": "owner"},
 	}
 	docData3, _ := json.MarshalIndent(plainFactDoc, "", "  ")
 	os.WriteFile(filepath.Join(memDir, "plain-fact.json"), docData3, 0644)

--- a/cli/internal/librarian/legacy_import.go
+++ b/cli/internal/librarian/legacy_import.go
@@ -1,0 +1,121 @@
+package librarian
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// LegacyImportMemory is one legacy JSON memory prepared for central import.
+type LegacyImportMemory struct {
+	OldID     string
+	Memory    InsertMemory
+	Tags      []string
+	CreatedBy string
+	Hash      string
+}
+
+// LegacyImportMapping records one old-to-new memory ID mapping.
+type LegacyImportMapping struct {
+	SourcePath  string `json:"source"`
+	OldID       string `json:"old_id"`
+	NewID       string `json:"new_id"`
+	ContentHash string `json:"content_hash"`
+}
+
+// ImportLegacyMemories imports all records for one legacy source in one
+// transaction. If the source was already imported with the same fingerprint,
+// it returns skipped=true and performs no writes.
+func (l *Librarian) ImportLegacyMemories(sourcePath, fingerprint string, records []LegacyImportMemory) ([]LegacyImportMapping, bool, error) {
+	if strings.TrimSpace(sourcePath) == "" || strings.TrimSpace(fingerprint) == "" {
+		return nil, false, fmt.Errorf("ImportLegacyMemories: %w", ErrEmptyArg)
+	}
+	mappings := make([]LegacyImportMapping, 0, len(records))
+	var skipped bool
+
+	err := l.v.Tx(func(tx *sql.Tx) error {
+		var existing string
+		err := tx.QueryRow(`SELECT source_fingerprint FROM legacy_imports WHERE source_path = ?`, sourcePath).Scan(&existing)
+		if err == nil {
+			if existing == fingerprint {
+				skipped = true
+				return nil
+			}
+			return fmt.Errorf("source already imported with different fingerprint: %s", sourcePath)
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+
+		for i := range records {
+			r := records[i]
+			id, err := l.validateInsert(&r.Memory)
+			if err != nil {
+				return fmt.Errorf("record %s: %w", r.OldID, err)
+			}
+			if strings.TrimSpace(r.OldID) == "" {
+				r.OldID = id
+			}
+			if r.Hash == "" {
+				sum := sha256.Sum256([]byte(r.Memory.Content))
+				r.Hash = fmt.Sprintf("%x", sum[:])
+			}
+			if err := l.insertMemoryRow(tx, id, r.Memory); err != nil {
+				return fmt.Errorf("insert memory %s: %w", r.OldID, err)
+			}
+			for _, name := range r.Tags {
+				if strings.TrimSpace(name) == "" {
+					continue
+				}
+				tagID, err := l.upsertTagInTx(tx, name)
+				if err != nil {
+					return fmt.Errorf("upsert tag %q: %w", name, err)
+				}
+				if _, err := tx.Exec(`INSERT OR IGNORE INTO memory_tags (memory_id, tag_id, created_at) VALUES (?, ?, ?)`, id, tagID, formatTime(l.now())); err != nil {
+					return fmt.Errorf("link tag %q: %w", name, err)
+				}
+			}
+			if strings.TrimSpace(r.CreatedBy) != "" {
+				entityID, err := l.upsertEntityInTx(tx, "user", r.CreatedBy)
+				if err != nil {
+					return fmt.Errorf("upsert created_by entity: %w", err)
+				}
+				if _, err := tx.Exec(`INSERT OR IGNORE INTO memory_entities (memory_id, entity_id, relationship, created_at) VALUES (?, ?, ?, ?)`, id, entityID, "created_by", formatTime(l.now())); err != nil {
+					return fmt.Errorf("link created_by entity: %w", err)
+				}
+			}
+			mappings = append(mappings, LegacyImportMapping{SourcePath: sourcePath, OldID: r.OldID, NewID: id, ContentHash: r.Hash})
+		}
+
+		_, err = tx.Exec(`INSERT INTO legacy_imports (source_path, source_fingerprint, imported_at, memory_count, mapping_count) VALUES (?, ?, ?, ?, ?)`, sourcePath, fingerprint, formatTime(l.now()), len(records), len(mappings))
+		if err != nil {
+			return err
+		}
+		for _, m := range mappings {
+			if _, err := tx.Exec(`INSERT INTO legacy_import_items (source_path, old_id, new_id, content_hash, created_at) VALUES (?, ?, ?, ?, ?)`, m.SourcePath, m.OldID, m.NewID, m.ContentHash, formatTime(l.now())); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("ImportLegacyMemories: %w", err)
+	}
+	return mappings, skipped, nil
+}
+
+func (l *Librarian) upsertEntityInTx(tx *sql.Tx, entityType, displayName string) (string, error) {
+	newID := uuid.NewString()
+	if _, err := tx.Exec(`INSERT INTO entities (id, type, display_name, created_at) VALUES (?, ?, ?, ?) ON CONFLICT(type, display_name) DO NOTHING`, newID, entityType, displayName, formatTime(l.now())); err != nil {
+		return "", err
+	}
+	var id string
+	if err := tx.QueryRow(`SELECT id FROM entities WHERE type = ? AND display_name = ?`, entityType, displayName).Scan(&id); err != nil {
+		return "", err
+	}
+	return id, nil
+}


### PR DESCRIPTION
## Summary

- Add central upgrade import for legacy `.mom/memory/*.json` discovered under `$HOME`
- Walks child folders by default with max depth 5, skips dot/system/cache folders, and leaves legacy directories untouched
- Adds central SQLite import ledger for idempotency
- Writes JSONL old→new ID mapping audit file beside the central vault
- Maps legacy memory types into the central memory typology and defaults missing `promotion_state` to draft
- Adds `--skip-memories` escape hatch
- Defers `.mom/logs/` and `.mom/telemetry/` migration to #247

## Closes

Closes #243

## Test plan

- [x] `cd cli && go test ./...`
