### PR TITLE
fix(upgrade): skip symlinked legacy memory files

### DIFF
--- a/cli/internal/cmd/upgrade_import.go
+++ b/cli/internal/cmd/upgrade_import.go
@@ -175,10 +175,10 @@ func readLegacyMemoryDocs(momDir string) ([]legacyMemoryDoc, string, error) {
 	var docs []legacyMemoryDoc
 	var parts []string
 	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+		path, ok := legacyMemoryJSONPath(memDir, e)
+		if !ok {
 			continue
 		}
-		path := filepath.Join(memDir, e.Name())
 		raw, err := os.ReadFile(path)
 		if err != nil {
 			continue
@@ -195,6 +195,18 @@ func readLegacyMemoryDocs(momDir string) ([]legacyMemoryDoc, string, error) {
 	sort.Strings(parts)
 	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
 	return docs, fmt.Sprintf("%x", sum[:]), nil
+}
+
+func legacyMemoryJSONPath(memDir string, e fs.DirEntry) (string, bool) {
+	if e.IsDir() || filepath.Ext(e.Name()) != ".json" || e.Type()&fs.ModeSymlink != 0 {
+		return "", false
+	}
+	path := filepath.Join(memDir, e.Name())
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", false
+	}
+	return path, true
 }
 
 func confirmUpgradeImport(cmd *cobra.Command, vaults, memories int) bool {

--- a/cli/internal/cmd/upgrade_import_test.go
+++ b/cli/internal/cmd/upgrade_import_test.go
@@ -43,6 +43,31 @@ func TestDiscoverLegacyVaultsForImport_WalksHomeMaxDepth(t *testing.T) {
 	}
 }
 
+func TestReadLegacyMemoryDocs_SkipsSymlinkedJSON(t *testing.T) {
+	home := t.TempDir()
+	legacy := filepath.Join(home, "repo", ".mom")
+	writeLegacyMemory(t, legacy, "real", `{"id":"real","content":{"text":"safe"}}`)
+	outside := filepath.Join(home, "outside.json")
+	if err := os.WriteFile(outside, []byte(`{"id":"secret","content":{"text":"secret"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(legacy, "memory", "secret.json")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	docs, _, err := readLegacyMemoryDocs(legacy)
+	if err != nil {
+		t.Fatalf("readLegacyMemoryDocs: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("docs = %d, want 1: %+v", len(docs), docs)
+	}
+	if docs[0].Path == link || strField(docs[0].Doc, "id") != "real" {
+		t.Fatalf("symlinked memory was imported: %+v", docs)
+	}
+}
+
 func TestExecuteCentralMemoryImport_ImportsAndIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- Skip symlinked `.json` entries during legacy `.mom/memory` import
- Add an `Lstat` regular-file guard before reading each candidate memory file
- Add regression coverage proving symlinked JSON is not imported

## Security

Fixes a medium-confidence review finding where a malicious repo could place a `.mom/memory/*.json` symlink to another readable JSON file under the user account, causing `mom upgrade` to import unintended contents into the central vault.

## Test plan

- [x] `cd cli && go test ./internal/cmd ./internal/centralvault`
- [x] `cd cli && go test ./...`
