### PR TITLE
feat(upgrade): import legacy logs to central vault

### DIFF
--- a/cli/internal/centralvault/centralvault.go
+++ b/cli/internal/centralvault/centralvault.go
@@ -70,6 +70,30 @@ func Migrations() []vault.Migration {
 			)`,
 		},
 	})
+	migs = append(migs, vault.Migration{
+		Version: 5,
+		Stmts: []string{
+			`CREATE TABLE legacy_log_imports (
+				source_path        TEXT PRIMARY KEY,
+				source_fingerprint TEXT NOT NULL,
+				imported_at        TEXT NOT NULL,
+				event_count        INTEGER NOT NULL,
+				mapping_count      INTEGER NOT NULL
+			)`,
+			`CREATE TABLE legacy_log_import_items (
+				source_path    TEXT NOT NULL,
+				source_item_id TEXT NOT NULL,
+				op_event_id    INTEGER NOT NULL,
+				content_hash   TEXT NOT NULL,
+				event_type     TEXT NOT NULL,
+				session_id     TEXT NOT NULL,
+				created_at     TEXT NOT NULL,
+				PRIMARY KEY (source_path, source_item_id),
+				FOREIGN KEY (source_path) REFERENCES legacy_log_imports(source_path),
+				FOREIGN KEY (op_event_id) REFERENCES op_events(id)
+			)`,
+		},
+	})
 	sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	return migs
 }

--- a/cli/internal/cmd/integration_test.go
+++ b/cli/internal/cmd/integration_test.go
@@ -59,7 +59,6 @@ func upgradeProject(t *testing.T, dir string, extraArgs ...string) string {
 	rootCmd.SetArgs(args)
 	t.Cleanup(func() {
 		upgradeCmd.Flags().Set("dry-run", "false")
-		upgradeCmd.Flags().Set("all", "false")
 	})
 
 	if err := rootCmd.Execute(); err != nil {
@@ -263,9 +262,9 @@ func TestIntegration_UpgradeRegistersAllRuntimes(t *testing.T) {
 	assertMCPEntry(t, filepath.Join(dir, ".mcp.json"))
 }
 
-// ── Test 3: Upgrade --all propagation ───────────────────────────────────────
+// ── Test 3: Upgrade is local to the current filesystem project ─────────────
 
-func TestIntegration_UpgradeAllPropagation(t *testing.T) {
+func TestIntegration_UpgradeDoesNotPropagateScopes(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("HOME", root)
 
@@ -297,24 +296,27 @@ func TestIntegration_UpgradeAllPropagation(t *testing.T) {
 		os.WriteFile(filepath.Join(momDir, "schema.json"), []byte(`{"old": true}`), 0644)
 	}
 
-	upgradeProject(t, root, "--all")
+	upgradeProject(t, root)
 
-	// All levels should have updated schema.json (not the old placeholder).
-	for _, d := range []string{root, orgDir, repo1, repo2} {
+	rootSchema, err := os.ReadFile(filepath.Join(root, ".mom", "schema.json"))
+	if err != nil {
+		t.Fatalf("missing root schema.json: %v", err)
+	}
+	if string(rootSchema) == `{"old": true}` {
+		t.Fatal("root schema.json was not updated")
+	}
+	assertFileExists(t, filepath.Join(root, ".claude", "CLAUDE.md"))
+
+	for _, d := range []string{orgDir, repo1, repo2} {
 		schemaPath := filepath.Join(d, ".mom", "schema.json")
 		data, err := os.ReadFile(schemaPath)
 		if err != nil {
 			t.Errorf("missing schema.json in %s", d)
 			continue
 		}
-		if string(data) == `{"old": true}` {
-			t.Errorf("schema.json not updated in %s", d)
+		if string(data) != `{"old": true}` {
+			t.Errorf("schema.json unexpectedly updated in %s", d)
 		}
-	}
-
-	// All levels should have Claude context file.
-	for _, d := range []string{root, orgDir, repo1, repo2} {
-		assertFileExists(t, filepath.Join(d, ".claude", "CLAUDE.md"))
 	}
 }
 

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -22,15 +22,12 @@ var upgradeCmd = &cobra.Command{
 	Long: `Upgrades core infrastructure (schema, constraints, skills, runtime files)
 to match the installed mom binary. Your documents in .mom/memory/ are never touched.
 
-Use --all to propagate the legacy filesystem upgrade to all child scopes in the hierarchy
-(org folders and repos beneath the current scope). Memory import always scans $HOME.`,
+Legacy central import scans $HOME and asks before writing.`,
 	RunE: runUpgrade,
 }
 
 func init() {
 	upgradeCmd.Flags().Bool("dry-run", false, "Show what would change without modifying anything")
-	upgradeCmd.Flags().Bool("all", false, "Upgrade all child scopes in the hierarchy")
-	upgradeCmd.Flags().Bool("skip-memories", false, "Skip importing legacy .mom/memory docs into the central vault")
 }
 
 // upgradeAction tracks a single change for reporting.
@@ -41,8 +38,6 @@ type upgradeAction struct {
 
 func runUpgrade(cmd *cobra.Command, args []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	all, _ := cmd.Flags().GetBool("all")
-	skipMemories, _ := cmd.Flags().GetBool("skip-memories")
 
 	momDir, err := findMomDir()
 	if err != nil {
@@ -56,12 +51,7 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Propagate legacy filesystem upgrade to child scopes if --all.
-	if all {
-		propagateUpgrade(cmd, projectRoot, dryRun)
-	}
-
-	return runCentralMemoryImport(cmd, dryRun, skipMemories)
+	return runCentralImport(cmd, dryRun)
 }
 
 // upgradeSingleDir runs the full upgrade pipeline on a single .mom/ directory.

--- a/cli/internal/cmd/upgrade_import.go
+++ b/cli/internal/cmd/upgrade_import.go
@@ -14,14 +14,15 @@ import (
 
 	"github.com/momhq/mom/cli/internal/centralvault"
 	"github.com/momhq/mom/cli/internal/librarian"
-	"github.com/momhq/mom/cli/internal/ux"
 	"github.com/spf13/cobra"
 )
 
 type legacyVaultPlan struct {
-	Path        string
-	Fingerprint string
-	Docs        []legacyMemoryDoc
+	Path           string
+	Fingerprint    string
+	Docs           []legacyMemoryDoc
+	LogFingerprint string
+	Logs           []legacyLogEvent
 }
 
 type legacyMemoryDoc struct {
@@ -32,62 +33,15 @@ type legacyMemoryDoc struct {
 }
 
 type importSummary struct {
-	Vaults   int
-	Memories int
-	Mappings []librarian.LegacyImportMapping
-	Skipped  int
-	Audit    string
-}
-
-func runCentralMemoryImport(cmd *cobra.Command, dryRun, skip bool) error {
-	if skip {
-		ux.NewPrinter(cmd.OutOrStdout()).Muted("Central memory import skipped (--skip-memories).")
-		return nil
-	}
-	plans, err := discoverLegacyVaultsForImport()
-	if err != nil {
-		return err
-	}
-	p := ux.NewPrinter(cmd.OutOrStdout())
-	if len(plans) == 0 {
-		p.Muted("No legacy .mom/memory folders found for central import.")
-		return nil
-	}
-	memoryCount := 0
-	for _, plan := range plans {
-		memoryCount += len(plan.Docs)
-	}
-	p.Blank()
-	if dryRun {
-		p.Bold("Dry run — central memory import plan:")
-	} else {
-		p.Bold("Central memory import plan:")
-	}
-	for _, plan := range plans {
-		p.KeyValue(shortenPath(plan.Path), fmt.Sprintf("%d memories", len(plan.Docs)), 28)
-	}
-	p.KeyValue("Total", fmt.Sprintf("%d vaults, %d memories", len(plans), memoryCount), 28)
-	p.Blank()
-	if dryRun {
-		return nil
-	}
-	if !confirmUpgradeImport(cmd, len(plans), memoryCount) {
-		return fmt.Errorf("upgrade aborted by user")
-	}
-	summary, err := executeCentralMemoryImport(plans)
-	if err != nil {
-		return err
-	}
-	p.Bold("Central memory import complete:")
-	p.Checkf("vaults imported: %d", summary.Vaults)
-	p.Checkf("memories imported: %d", summary.Memories)
-	if summary.Skipped > 0 {
-		p.Warnf("vaults skipped (already imported): %d", summary.Skipped)
-	}
-	if summary.Audit != "" {
-		p.Checkf("ID mapping written: %s", summary.Audit)
-	}
-	return nil
+	Vaults      int
+	Memories    int
+	Mappings    []librarian.LegacyImportMapping
+	Skipped     int
+	Audit       string
+	LogEvents   int
+	LogMappings []librarian.LegacyLogImportMapping
+	LogSkipped  int
+	LogAudit    string
 }
 
 func discoverLegacyVaultsForImport() ([]legacyVaultPlan, error) {
@@ -119,9 +73,13 @@ func discoverLegacyVaultsForImport() ([]legacyVaultPlan, error) {
 			if samePath(path, centralDir) {
 				return filepath.SkipDir
 			}
-			docs, fingerprint, err := readLegacyMemoryDocs(path)
-			if err == nil && len(docs) > 0 {
-				plans = append(plans, legacyVaultPlan{Path: path, Fingerprint: fingerprint, Docs: docs})
+			docs, fingerprint, memErr := readLegacyMemoryDocs(path)
+			logs, logFingerprint, logErr := readLegacyLogEvents(path)
+			if logErr != nil && !os.IsNotExist(logErr) {
+				return logErr
+			}
+			if (memErr == nil && len(docs) > 0) || (logErr == nil && len(logs) > 0) {
+				plans = append(plans, legacyVaultPlan{Path: path, Fingerprint: fingerprint, Docs: docs, LogFingerprint: logFingerprint, Logs: logs})
 			}
 			return filepath.SkipDir
 		}
@@ -209,11 +167,15 @@ func legacyMemoryJSONPath(memDir string, e fs.DirEntry) (string, bool) {
 	return path, true
 }
 
-func confirmUpgradeImport(cmd *cobra.Command, vaults, memories int) bool {
+func confirmUpgradeImport(cmd *cobra.Command, vaults, memories int, logs ...int) bool {
 	if strings.EqualFold(os.Getenv("MOM_UPGRADE_ASSUME_YES"), "1") || strings.EqualFold(os.Getenv("MOM_UPGRADE_ASSUME_YES"), "true") {
 		return true
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Import %d memories from %d legacy .mom folders into the central vault? [y/N] ", memories, vaults)
+	logCount := 0
+	if len(logs) > 0 {
+		logCount = logs[0]
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Import %d memories and %d log events from %d legacy .mom folders into the central vault? [y/N] ", memories, logCount, vaults)
 	reader := bufio.NewReader(os.Stdin)
 	line, _ := reader.ReadString('\n')
 	line = strings.ToLower(strings.TrimSpace(line))
@@ -228,6 +190,9 @@ func executeCentralMemoryImport(plans []legacyVaultPlan) (importSummary, error) 
 	defer func() { _ = closeFn() }()
 	var summary importSummary
 	for _, plan := range plans {
+		if len(plan.Docs) == 0 {
+			continue
+		}
 		records := make([]librarian.LegacyImportMemory, 0, len(plan.Docs))
 		for _, d := range plan.Docs {
 			rec, err := legacyDocToImportRecord(d)

--- a/cli/internal/cmd/upgrade_logs_import.go
+++ b/cli/internal/cmd/upgrade_logs_import.go
@@ -1,0 +1,441 @@
+package cmd
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/momhq/mom/cli/internal/ux"
+	"github.com/spf13/cobra"
+)
+
+type legacyLogEvent struct {
+	SourceItemID string
+	Raw          []byte
+	Event        librarian.OpEvent
+	Hash         string
+}
+
+var legacyJSONLPayloadKeys = []string{
+	"kind",
+	"memory_id",
+	"runtime",
+	"repo_id",
+	"trigger",
+	"turn_count",
+	"tool_call_count",
+	"wrap_up_success",
+	"error_type",
+	"latency_ms",
+	"by_agent",
+	"context",
+}
+
+var legacyUsageKeys = []string{
+	"input_tokens",
+	"output_tokens",
+	"cache_read_tokens",
+	"cache_write_tokens",
+	"total_tokens",
+	"cost_usd",
+	"stop_reasons",
+}
+
+var legacyToolCategoryNames = map[string]bool{
+	"mom_memory":     true,
+	"mom_cli":        true,
+	"codebase_read":  true,
+	"codebase_write": true,
+	"system":         true,
+}
+
+func runCentralImport(cmd *cobra.Command, dryRun bool) error {
+	plans, err := discoverLegacyVaultsForImport()
+	if err != nil {
+		return err
+	}
+	p := ux.NewPrinter(cmd.OutOrStdout())
+	if len(plans) == 0 {
+		p.Muted("No legacy .mom folders found for central import.")
+		return nil
+	}
+	memoryCount, logCount := 0, 0
+	for _, plan := range plans {
+		memoryCount += len(plan.Docs)
+		logCount += len(plan.Logs)
+	}
+	p.Blank()
+	if dryRun {
+		p.Bold("Dry run — central import plan:")
+	} else {
+		p.Bold("Central import plan:")
+	}
+	for _, plan := range plans {
+		p.KeyValue(shortenPath(plan.Path), fmt.Sprintf("%d memories, %d log events", len(plan.Docs), len(plan.Logs)), 28)
+	}
+	p.KeyValue("Total", fmt.Sprintf("%d vaults, %d memories, %d log events", len(plans), memoryCount, logCount), 28)
+	p.Blank()
+	if dryRun {
+		return nil
+	}
+	if !confirmUpgradeImport(cmd, len(plans), memoryCount, logCount) {
+		p.Muted("Central import skipped.")
+		return nil
+	}
+	summary, err := executeCentralImport(plans)
+	if err != nil {
+		return err
+	}
+	p.Bold("Central import complete:")
+	p.Checkf("memories imported: %d", summary.Memories)
+	p.Checkf("log events imported: %d", summary.LogEvents)
+	if summary.Skipped > 0 {
+		p.Warnf("memory sources skipped (already imported): %d", summary.Skipped)
+	}
+	if summary.LogSkipped > 0 {
+		p.Warnf("log sources skipped (already imported): %d", summary.LogSkipped)
+	}
+	if summary.Audit != "" {
+		p.Checkf("memory ID mapping written: %s", summary.Audit)
+	}
+	if summary.LogAudit != "" {
+		p.Checkf("log import mapping written: %s", summary.LogAudit)
+	}
+	return nil
+}
+
+func executeCentralImport(plans []legacyVaultPlan) (importSummary, error) {
+	summary, memErr := executeCentralMemoryImport(plans)
+	logSummary, logErr := executeCentralLogImport(plans)
+	summary.LogEvents = logSummary.LogEvents
+	summary.LogMappings = logSummary.LogMappings
+	summary.LogSkipped = logSummary.LogSkipped
+	summary.LogAudit = logSummary.LogAudit
+	if memErr != nil {
+		return summary, memErr
+	}
+	if logErr != nil {
+		return summary, logErr
+	}
+	return summary, nil
+}
+
+func executeCentralLogImport(plans []legacyVaultPlan) (importSummary, error) {
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	if err != nil {
+		return importSummary{}, fmt.Errorf("open central vault: %w", err)
+	}
+	defer func() { _ = closeFn() }()
+	var summary importSummary
+	for _, plan := range plans {
+		if len(plan.Logs) == 0 {
+			continue
+		}
+		records := make([]librarian.LegacyLogImportEvent, 0, len(plan.Logs))
+		for _, e := range plan.Logs {
+			records = append(records, librarian.LegacyLogImportEvent{SourceItemID: e.SourceItemID, Event: e.Event, Hash: e.Hash})
+		}
+		mappings, skipped, err := lib.ImportLegacyLogEvents(filepath.Join(plan.Path, "logs"), plan.LogFingerprint, records)
+		if err != nil {
+			return summary, err
+		}
+		if skipped {
+			summary.LogSkipped++
+			continue
+		}
+		summary.LogEvents += len(records)
+		summary.LogMappings = append(summary.LogMappings, mappings...)
+	}
+	if len(summary.LogMappings) > 0 {
+		audit, err := writeLogImportAudit(summary.LogMappings)
+		if err != nil {
+			return importSummary{}, err
+		}
+		summary.LogAudit = audit
+	}
+	return summary, nil
+}
+
+func readLegacyLogEvents(momDir string) ([]legacyLogEvent, string, error) {
+	logsDir := filepath.Join(momDir, "logs")
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		return nil, "", err
+	}
+	var events []legacyLogEvent
+	var parts []string
+	for _, e := range entries {
+		path, info, ok := legacyLogFilePath(logsDir, e)
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(e.Name(), "session-") && filepath.Ext(e.Name()) == ".json" {
+			ev, ok, err := parseLegacySessionSummary(path, e.Name(), info.ModTime())
+			if err != nil {
+				return nil, "", err
+			}
+			if ok {
+				events = append(events, ev)
+				parts = append(parts, ev.SourceItemID+":"+ev.Hash)
+			}
+			continue
+		}
+		if filepath.Ext(e.Name()) == ".jsonl" {
+			parsed, err := parseLegacyJSONLLog(path, e.Name(), info.ModTime(), legacySourceKey(momDir))
+			if err != nil {
+				return nil, "", err
+			}
+			for _, ev := range parsed {
+				events = append(events, ev)
+				parts = append(parts, ev.SourceItemID+":"+ev.Hash)
+			}
+		}
+	}
+	sort.Strings(parts)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return events, fmt.Sprintf("%x", sum[:]), nil
+}
+
+func legacyLogFilePath(logsDir string, e fs.DirEntry) (string, fs.FileInfo, bool) {
+	ext := filepath.Ext(e.Name())
+	if e.IsDir() || e.Type()&fs.ModeSymlink != 0 || (ext != ".json" && ext != ".jsonl") {
+		return "", nil, false
+	}
+	path := filepath.Join(logsDir, e.Name())
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", nil, false
+	}
+	return path, info, true
+}
+
+func parseLegacyJSONLLog(path, name string, fallback time.Time, sourceKey string) ([]legacyLogEvent, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var events []legacyLogEvent
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		raw := append([]byte(nil), scanner.Bytes()...)
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			continue
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("%s:%d: %w", path, lineNo, err)
+		}
+		createdAt := fallback
+		if t, ok := parseFirstLegacyTime(doc, "ts", "ended_at", "started_at"); ok {
+			createdAt = t
+		}
+		sessionID := strField(doc, "session_id")
+		if sessionID == "" {
+			sessionID = fmt.Sprintf("legacy:%s:%s", sourceKey, legacySessionDate(createdAt))
+		}
+		payload := projectLegacyJSONLPayload(doc)
+		sum := sha256.Sum256(raw)
+		events = append(events, legacyLogEvent{
+			SourceItemID: fmt.Sprintf("%s:%d", name, lineNo),
+			Raw:          raw,
+			Hash:         fmt.Sprintf("%x", sum[:]),
+			Event: librarian.OpEvent{
+				EventType: legacyJSONLEventType(strField(doc, "kind")),
+				SessionID: sessionID,
+				CreatedAt: createdAt,
+				Payload:   payload,
+			},
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func legacySourceKey(source string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(source)))
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func legacySessionDate(t time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	return t.UTC().Format("2006-01-02")
+}
+
+func legacyJSONLEventType(kind string) string {
+	switch kind {
+	case "ConsumptionEvent":
+		return "legacy.consumption"
+	case "SessionEvent":
+		return "legacy.session"
+	case "RuntimeHealth":
+		return "legacy.runtime_health"
+	default:
+		return "legacy.event"
+	}
+}
+
+func projectLegacyJSONLPayload(doc map[string]any) map[string]any {
+	out := map[string]any{"legacy_format": "jsonl_event"}
+	copyAllowedFields(out, doc, legacyJSONLPayloadKeys)
+	return out
+}
+
+func parseLegacySessionSummary(path, name string, fallback time.Time) (legacyLogEvent, bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return legacyLogEvent{}, false, err
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return legacyLogEvent{}, false, fmt.Errorf("%s: %w", path, err)
+	}
+	sessionID := strField(doc, "session_id")
+	if sessionID == "" {
+		if _, hasContent := doc["content"]; hasContent {
+			return legacyLogEvent{}, false, nil
+		}
+		return legacyLogEvent{}, false, fmt.Errorf("%s: missing session_id", path)
+	}
+	createdAt := fallback
+	if t, ok := parseFirstLegacyTime(doc, "ended", "started"); ok {
+		createdAt = t
+	}
+	payload := map[string]any{"legacy_format": "session_summary"}
+	copyLegacyString(payload, doc, "started")
+	copyLegacyString(payload, doc, "ended")
+	copyLegacyNumber(payload, doc, "interactions")
+	copyLegacyNumber(payload, doc, "files_changed")
+	copyLegacyNumber(payload, doc, "memories_created")
+	copyLegacyString(payload, doc, "model")
+	copyLegacyString(payload, doc, "provider")
+	if usage, ok := projectLegacyUsage(doc["usage"]); ok {
+		payload["usage"] = usage
+	}
+	if cats := legacyToolCategoryTotals(doc["tool_calls"]); len(cats) > 0 {
+		payload["tool_categories"] = cats
+	}
+	sum := sha256.Sum256(raw)
+	return legacyLogEvent{
+		SourceItemID: name,
+		Raw:          raw,
+		Hash:         fmt.Sprintf("%x", sum[:]),
+		Event: librarian.OpEvent{
+			EventType: "legacy.session.summary",
+			SessionID: sessionID,
+			CreatedAt: createdAt,
+			Payload:   payload,
+		},
+	}, true, nil
+}
+
+func parseFirstLegacyTime(doc map[string]any, keys ...string) (time.Time, bool) {
+	for _, key := range keys {
+		s := strField(doc, key)
+		if s == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+			return t, true
+		}
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func copyLegacyString(out, in map[string]any, key string) {
+	if s := strField(in, key); s != "" {
+		out[key] = s
+	}
+}
+
+func copyLegacyNumber(out, in map[string]any, key string) {
+	switch v := in[key].(type) {
+	case float64:
+		out[key] = v
+	case int:
+		out[key] = v
+	}
+}
+
+func copyAllowedFields(out, in map[string]any, keys []string) {
+	for _, key := range keys {
+		if v, ok := in[key]; ok {
+			out[key] = v
+		}
+	}
+}
+
+func projectLegacyUsage(v any) (map[string]any, bool) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	out := map[string]any{}
+	copyAllowedFields(out, m, legacyUsageKeys)
+	return out, len(out) > 0
+}
+
+func legacyToolCategoryTotals(v any) map[string]any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := map[string]any{}
+	for cat, raw := range m {
+		if !legacyToolCategoryNames[cat] {
+			continue
+		}
+		group, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if total, ok := group["total"].(float64); ok {
+			out[cat] = total
+		}
+	}
+	return out
+}
+
+func writeLogImportAudit(mappings []librarian.LegacyLogImportMapping) (string, error) {
+	dir, err := centralvault.Dir()
+	if err != nil {
+		return "", err
+	}
+	upgradeDir := filepath.Join(dir, "upgrade")
+	if err := os.MkdirAll(upgradeDir, 0o700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(upgradeDir, "log-import-"+time.Now().UTC().Format("20060102-150405")+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, m := range mappings {
+		if err := enc.Encode(m); err != nil {
+			return "", err
+		}
+	}
+	return path, nil
+}

--- a/cli/internal/cmd/upgrade_logs_test.go
+++ b/cli/internal/cmd/upgrade_logs_test.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/spf13/cobra"
+)
+
+func writeLegacyLog(t *testing.T, momDir, name, body string) {
+	t.Helper()
+	logsDir := filepath.Join(momDir, "logs")
+	if err := os.MkdirAll(logsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, name), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunCentralImport_DryRunWritesNothing(t *testing.T) {
+	home := t.TempDir()
+	vaultPath := filepath.Join(home, "central.db")
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", home)
+	t.Setenv("MOM_VAULT", vaultPath)
+	legacy := filepath.Join(home, "repo", ".mom")
+	writeLegacyMemory(t, legacy, "m", `{"id":"m","content":{"text":"memory"}}`)
+	writeLegacyLog(t, legacy, "session-s-1.json", `{"session_id":"s-1","started":"2026-04-10T14:39:52Z","ended":"2026-04-10T14:40:00Z","interactions":1}`)
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	if err := runCentralImport(cmd, true); err != nil {
+		t.Fatalf("runCentralImport dry-run: %v", err)
+	}
+	if _, err := os.Stat(vaultPath); !os.IsNotExist(err) {
+		t.Fatalf("vault exists after dry-run: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "1 memories, 1 log events") {
+		t.Fatalf("dry-run output = %q", out)
+	}
+}
+
+func TestUpgradeCmd_OnlyDryRunFlag(t *testing.T) {
+	if upgradeCmd.Flags().Lookup("dry-run") == nil {
+		t.Fatal("upgrade --dry-run flag missing")
+	}
+	for _, name := range []string{"all", "skip-memories", "skip-logs"} {
+		if upgradeCmd.Flags().Lookup(name) != nil {
+			t.Fatalf("upgrade flag %q should not exist", name)
+		}
+	}
+}
+
+func TestDiscoverLegacyVaultsForImport_SkipsSymlinkedLogs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", home)
+	t.Setenv("MOM_VAULT", filepath.Join(home, "central.db"))
+	legacy := filepath.Join(home, "repo", ".mom")
+	writeLegacyLog(t, legacy, "session-real.json", `{"session_id":"real","started":"2026-04-10T14:39:52Z","ended":"2026-04-10T14:40:00Z","interactions":1}`)
+	outside := filepath.Join(home, "outside.json")
+	if err := os.WriteFile(outside, []byte(`{"session_id":"secret","started":"2026-04-10T14:39:52Z","ended":"2026-04-10T14:40:00Z","interactions":1}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(legacy, "logs", "session-secret.json")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	plans, err := discoverLegacyVaultsForImport()
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(plans) != 1 || len(plans[0].Logs) != 1 || plans[0].Logs[0].Event.SessionID != "real" {
+		t.Fatalf("plans = %+v", plans)
+	}
+}
+
+func TestDiscoverLegacyVaultsForImport_FailsMalformedImportableLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", home)
+	t.Setenv("MOM_VAULT", filepath.Join(home, "central.db"))
+	legacy := filepath.Join(home, "repo", ".mom")
+	writeLegacyLog(t, legacy, "2026-04-29.jsonl", `{"kind":"ConsumptionEvent","ts":"2026-04-29T22:32:22Z"}
+not-json
+`)
+
+	_, err := discoverLegacyVaultsForImport()
+	if err == nil {
+		t.Fatal("discoverLegacyVaultsForImport succeeded, want malformed log error")
+	}
+}
+
+func TestExecuteCentralImport_ImportsLegacyJSONLWithAllowlistedPayload(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", home)
+	t.Setenv("MOM_VAULT", filepath.Join(home, "central.db"))
+	legacy := filepath.Join(home, "repo", ".mom")
+	writeLegacyLog(t, legacy, "2026-04-29.jsonl", `{"kind":"ConsumptionEvent","memory_id":"mem-1","session_id":null,"ts":"2026-04-29T22:32:22Z","by_agent":"mcp","context":"mom_recall","secret":"AKIA-SHOULD-NOT-PERSIST"}
+{"kind":"RuntimeHealth","runtime":"claude","ts":"2026-04-29T22:35:00Z","wrap_up_success":true,"error_type":null,"latency_ms":42,"command":"cat secrets.env"}
+`)
+
+	plans, err := discoverLegacyVaultsForImport()
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	summary, err := executeCentralImport(plans)
+	if err != nil {
+		t.Fatalf("executeCentralImport: %v", err)
+	}
+	if summary.LogEvents != 2 {
+		t.Fatalf("LogEvents = %d, want 2", summary.LogEvents)
+	}
+
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	if err != nil {
+		t.Fatalf("OpenLibrarian: %v", err)
+	}
+	defer func() { _ = closeFn() }()
+	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("QueryOpEvents: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	for _, row := range rows {
+		b, _ := json.Marshal(row.Payload)
+		if strings.Contains(string(b), "AKIA") || strings.Contains(string(b), "secrets.env") {
+			t.Fatalf("payload leaked non-allowlisted data: %s", b)
+		}
+		if !strings.HasPrefix(row.SessionID, "legacy:") {
+			t.Fatalf("SessionID = %q, want legacy pseudo-session", row.SessionID)
+		}
+	}
+}
+
+func TestExecuteCentralImport_ImportsLegacySessionSummaryLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_UPGRADE_SCAN_ROOT", home)
+	t.Setenv("MOM_VAULT", filepath.Join(home, "central.db"))
+	legacy := filepath.Join(home, "repo", ".mom")
+	writeLegacyLog(t, legacy, "session-s-1.json", `{
+		"session_id":"s-1",
+		"started":"2026-04-10T14:39:52.745Z",
+		"ended":"2026-04-10T15:10:41.294Z",
+		"interactions":34,
+		"files_changed":2,
+		"memories_created":1,
+		"tool_calls":{
+			"codebase_read":{"total":10,"detail":{"Read":10}},
+			"system":{"total":3,"detail":{"Bash":3}},
+			"raw_tool_name":{"total":99,"detail":{"SecretTool":99}}
+		},
+		"model":"claude-sonnet",
+		"provider":"anthropic",
+		"usage":{"total_tokens":1290,"cost_usd":0.0185,"raw":"SECRET-USAGE"}
+	}`)
+
+	plans, err := discoverLegacyVaultsForImport()
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	summary, err := executeCentralImport(plans)
+	if err != nil {
+		t.Fatalf("executeCentralImport: %v", err)
+	}
+	if summary.LogEvents != 1 {
+		t.Fatalf("LogEvents = %d, want 1", summary.LogEvents)
+	}
+	if summary.LogAudit == "" || !strings.Contains(summary.LogAudit, "log-import") {
+		t.Fatalf("LogAudit = %q", summary.LogAudit)
+	}
+
+	lib, closeFn, err := centralvault.OpenLibrarian()
+	if err != nil {
+		t.Fatalf("OpenLibrarian: %v", err)
+	}
+	defer func() { _ = closeFn() }()
+	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "legacy.session.summary", SessionID: "s-1", Limit: 10})
+	if err != nil {
+		t.Fatalf("QueryOpEvents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	wantTime, _ := time.Parse(time.RFC3339Nano, "2026-04-10T15:10:41.294Z")
+	if !rows[0].CreatedAt.Equal(wantTime) {
+		t.Fatalf("CreatedAt = %s, want %s", rows[0].CreatedAt, wantTime)
+	}
+	if rows[0].Payload["legacy_format"] != "session_summary" || rows[0].Payload["interactions"] != float64(34) {
+		t.Fatalf("payload = %#v", rows[0].Payload)
+	}
+	cats, ok := rows[0].Payload["tool_categories"].(map[string]any)
+	if !ok || cats["codebase_read"] != float64(10) || cats["system"] != float64(3) {
+		b, _ := json.Marshal(rows[0].Payload)
+		t.Fatalf("tool_categories not category totals only: %s", b)
+	}
+	payloadJSON, _ := json.Marshal(rows[0].Payload)
+	if strings.Contains(string(payloadJSON), "raw_tool_name") || strings.Contains(string(payloadJSON), "SecretTool") || strings.Contains(string(payloadJSON), "SECRET-USAGE") {
+		t.Fatalf("session summary payload leaked non-category details: %s", payloadJSON)
+	}
+
+	again, err := executeCentralImport(plans)
+	if err != nil {
+		t.Fatalf("second executeCentralImport: %v", err)
+	}
+	if again.LogSkipped != 1 || again.LogEvents != 0 {
+		t.Fatalf("second summary = %+v", again)
+	}
+	writeLegacyLog(t, legacy, "session-s-2.json", `{"session_id":"s-2","started":"2026-04-10T16:00:00Z","ended":"2026-04-10T16:01:00Z","interactions":1}`)
+	changed, err := discoverLegacyVaultsForImport()
+	if err != nil {
+		t.Fatalf("rediscover: %v", err)
+	}
+	if _, err := executeCentralImport(changed); err == nil || !strings.Contains(err.Error(), "different fingerprint") {
+		t.Fatalf("changed fingerprint err = %v, want different fingerprint", err)
+	}
+}

--- a/cli/internal/cmd/upgrade_test.go
+++ b/cli/internal/cmd/upgrade_test.go
@@ -19,7 +19,6 @@ func resetUpgradeFlags(t *testing.T) {
 	t.Setenv("MOM_UPGRADE_ASSUME_YES", "1")
 	t.Cleanup(func() {
 		upgradeCmd.Flags().Set("dry-run", "false")
-		upgradeCmd.Flags().Set("skip-memories", "false")
 	})
 }
 

--- a/cli/internal/librarian/legacy_log_import.go
+++ b/cli/internal/librarian/legacy_log_import.go
@@ -1,0 +1,127 @@
+package librarian
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// LegacyLogImportEvent is one legacy operational event prepared for central import.
+type LegacyLogImportEvent struct {
+	SourceItemID string
+	Event        OpEvent
+	Hash         string
+}
+
+// LegacyLogImportMapping records one legacy log item to op_events row mapping.
+type LegacyLogImportMapping struct {
+	SourcePath   string `json:"source"`
+	SourceItemID string `json:"source_item_id"`
+	OpEventID    int64  `json:"op_event_id"`
+	ContentHash  string `json:"content_hash"`
+	EventType    string `json:"event_type"`
+	SessionID    string `json:"session_id"`
+	CreatedAt    string `json:"created_at"`
+}
+
+// ImportLegacyLogEvents imports all records for one legacy log source in one transaction.
+func (l *Librarian) ImportLegacyLogEvents(sourcePath, fingerprint string, events []LegacyLogImportEvent) ([]LegacyLogImportMapping, bool, error) {
+	if strings.TrimSpace(sourcePath) == "" || strings.TrimSpace(fingerprint) == "" {
+		return nil, false, fmt.Errorf("ImportLegacyLogEvents: %w", ErrEmptyArg)
+	}
+	mappings := make([]LegacyLogImportMapping, 0, len(events))
+	var skipped bool
+
+	err := l.v.Tx(func(tx *sql.Tx) error {
+		var existing string
+		err := tx.QueryRow(`SELECT source_fingerprint FROM legacy_log_imports WHERE source_path = ?`, sourcePath).Scan(&existing)
+		if err == nil {
+			if existing == fingerprint {
+				skipped = true
+				return nil
+			}
+			return fmt.Errorf("source already imported with different fingerprint: %s", sourcePath)
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+
+		for i := range events {
+			e := events[i]
+			if strings.TrimSpace(e.SourceItemID) == "" {
+				return fmt.Errorf("event %d: source_item_id: %w", i, ErrEmptyArg)
+			}
+			if strings.TrimSpace(e.Event.EventType) == "" {
+				return fmt.Errorf("event %s: event_type: %w", e.SourceItemID, ErrEmptyArg)
+			}
+			if strings.TrimSpace(e.Event.SessionID) == "" {
+				return fmt.Errorf("event %s: session_id: %w", e.SourceItemID, ErrEmptyArg)
+			}
+			if e.Event.CreatedAt.IsZero() {
+				e.Event.CreatedAt = l.now()
+			}
+			payload := e.Event.Payload
+			if len(payload) == 0 {
+				payload = nil
+			}
+			payloadJSON, err := json.Marshal(payload)
+			if err != nil {
+				return fmt.Errorf("event %s payload: %w", e.SourceItemID, err)
+			}
+			if e.Hash == "" {
+				sum := sha256.Sum256(payloadJSON)
+				e.Hash = fmt.Sprintf("%x", sum[:])
+			}
+			res, err := tx.Exec(
+				`INSERT INTO op_events (event_type, session_id, created_at, payload)
+				 VALUES (?, ?, ?, ?)`,
+				e.Event.EventType, e.Event.SessionID, formatTime(e.Event.CreatedAt), string(payloadJSON),
+			)
+			if err != nil {
+				return fmt.Errorf("insert event %s: %w", e.SourceItemID, err)
+			}
+			id, err := res.LastInsertId()
+			if err != nil {
+				return err
+			}
+			mappings = append(mappings, LegacyLogImportMapping{
+				SourcePath:   sourcePath,
+				SourceItemID: e.SourceItemID,
+				OpEventID:    id,
+				ContentHash:  e.Hash,
+				EventType:    e.Event.EventType,
+				SessionID:    e.Event.SessionID,
+				CreatedAt:    formatTime(e.Event.CreatedAt),
+			})
+		}
+
+		_, err = tx.Exec(
+			`INSERT INTO legacy_log_imports
+			 (source_path, source_fingerprint, imported_at, event_count, mapping_count)
+			 VALUES (?, ?, ?, ?, ?)`,
+			sourcePath, fingerprint, formatTime(l.now()), len(events), len(mappings),
+		)
+		if err != nil {
+			return err
+		}
+		for _, m := range mappings {
+			_, err := tx.Exec(
+				`INSERT INTO legacy_log_import_items
+				 (source_path, source_item_id, op_event_id, content_hash, event_type, session_id, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				m.SourcePath, m.SourceItemID, m.OpEventID, m.ContentHash, m.EventType, m.SessionID, m.CreatedAt,
+			)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("ImportLegacyLogEvents: %w", err)
+	}
+	return mappings, skipped, nil
+}


### PR DESCRIPTION
## Summary

- Import legacy `.mom/logs/session-*.json` summaries into central `op_events` as `legacy.session.summary`
- Import legacy `.mom/logs/*.jsonl` lines into bounded legacy event types with allowlisted metadata only
- Add separate legacy log import ledger + mapping audit file
- Refactor central upgrade import into one memory + logs plan and confirmation
- Simplify `mom upgrade` flags to `--dry-run` only; remove `--all` and skip flags
- Keep legacy sources untouched and skip symlinked/non-regular log files

## Security / privacy

- JSONL payloads are allowlist-projected only
- Session summary tool details are reduced to category totals
- Unknown usage fields and raw tool names are not persisted

## Closes

Closes #247

## Test plan

- [x] `cd cli && go test ./...`
