### PR TITLE
Install MOM skills through init

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/momhq/mom/cli/internal/adapters/harness"
@@ -20,6 +22,10 @@ import (
 //go:embed schema.json
 var embeddedSchema embed.FS
 
+var runExternalCommand = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Install MOM's global vault and agent integrations",
@@ -27,7 +33,7 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
-	initCmd.Flags().StringSlice("runtimes", nil, "AI runtimes to configure (claude, codex, windsurf, pi)")
+	initCmd.Flags().String("harnesses", "", "AI harnesses to configure as a comma list (claude,codex,windsurf,pi,all)")
 	initCmd.Flags().Bool("force", false, "Overwrite existing global MOM configuration")
 	initCmd.Flags().BoolP("no-interactive", "y", false, "Skip the interactive wizard and use defaults/flags")
 }
@@ -43,8 +49,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// Run the interactive onboarding wizard unless:
 	//   - --no-interactive / -y was passed, OR
-	//   - --runtimes was explicitly provided by the user (direct/scripted mode).
-	if !noInteractive && !cmd.Flags().Changed("runtimes") {
+	//   - --harnesses was explicitly provided by the user (direct/scripted mode).
+	if !noInteractive && !cmd.Flags().Changed("harnesses") {
 		result, err := runOnboarding(cmd.InOrStdin(), cmd.OutOrStdout(), cwd)
 		if err != nil {
 			return err
@@ -71,13 +77,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 	// active project for watcher metadata.
 	installDir := cwd
 
-	harnesses, _ := cmd.Flags().GetStringSlice("harnesses")
-	if len(harnesses) == 0 {
-		harnesses, _ = cmd.Flags().GetStringSlice("runtimes")
-	}
+	harnessesFlag, _ := cmd.Flags().GetString("harnesses")
+	harnesses := parseHarnessList(harnessesFlag)
 	if len(harnesses) == 0 {
 		harnesses = []string{"claude"}
 	}
+	harnesses = resolveInitHarnesses(cwd, harnesses)
 
 	defaults := config.Default()
 	return runInitWithConfig(cmd, installDir, force, OnboardingResult{
@@ -87,6 +92,31 @@ func runInit(cmd *cobra.Command, args []string) error {
 		InstallDir: installDir,
 		ScopeLabel: "repo",
 	})
+}
+
+func parseHarnessList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func resolveInitHarnesses(cwd string, requested []string) []string {
+	if len(requested) != 1 || strings.TrimSpace(requested[0]) != "all" {
+		return requested
+	}
+	registry := harness.NewRegistry(cwd)
+	detected := registry.DetectAll()
+	out := make([]string, 0, len(detected))
+	for _, adapter := range detected {
+		out = append(out, adapter.Name())
+	}
+	return out
 }
 
 // runInitWithConfig performs central vault setup and global harness integration
@@ -254,13 +284,13 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 		return kbErr
 	}
 
-	// Re-load config for runtime generation.
+	// Re-load config for harness generation.
 	cfg, err := config.Load(leoDir)
 	if err != nil {
 		return fmt.Errorf("loading config after write: %w", err)
 	}
 
-	// ── Phase 3: Generate runtime context files ────────────────────────────
+	// ── Phase 3: Generate harness context files ────────────────────────────
 	var genErr error
 	doGenerate := func() {
 		runtimeCfg := buildRuntimeConfig(cfg)
@@ -270,7 +300,7 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 		runtimeSkills := buildRuntimeSkills()
 		runtimeIdentity := buildRuntimeIdentity()
 
-		// Install global context/tool integration for all selected runtimes.
+		// Install global context/tool integration for all selected harnesses.
 		for _, rt := range result.Harnesses {
 			adapter, ok := registry.Get(rt)
 			if !ok {
@@ -299,7 +329,10 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 		return genErr
 	}
 
-	// ── Phase 3.5: Register with global watch daemon ────────────────────────
+	// ── Phase 3.5: Install global skills ────────────────────────────────────
+	installGlobalSkills(p, result.Harnesses)
+
+	// ── Phase 4: Register with global watch daemon ──────────────────────────
 	if err := ensureGlobalDaemon(cwd, leoDir, result.Harnesses); err != nil {
 		p.Warnf("watch daemon: %v", err)
 	} else {
@@ -330,7 +363,7 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 		p.Checkf("%s global integration installed", harnessLabel(rt))
 	}
 	p.Blank()
-	p.Textf("MOM is ready. Run %s to check health.", p.HighlightCmd("mom status"))
+	p.Textf("MOM is ready. Try /mom-status or run %s.", p.HighlightCmd("mom status"))
 	return nil
 }
 
@@ -394,6 +427,8 @@ func runReinit(cmd *cobra.Command, cwd, leoDir string, result OnboardingResult, 
 		}
 		installed = append(installed, rt)
 	}
+
+	installGlobalSkills(p, cfg.EnabledHarnesses())
 
 	// Register with global watch daemon (updated harnesses).
 	if err := ensureGlobalDaemon(cwd, leoDir, cfg.EnabledHarnesses()); err != nil {
@@ -487,6 +522,46 @@ func buildRuntimeIdentity() *harness.Identity {
 		What:        identityData.What,
 		Philosophy:  identityData.Philosophy,
 		Constraints: identityData.Constraints,
+	}
+}
+
+func installGlobalSkills(p *ux.Printer, harnesses []string) {
+	for _, h := range harnesses {
+		agent, ok := skillsAgentForHarness(h)
+		if !ok {
+			p.Warnf("skills: unsupported harness %s", h)
+			continue
+		}
+		args, command := skillsInstallCommand(agent)
+		if output, err := runExternalCommand("npx", args...); err != nil {
+			p.Warnf("skills install %s → %s failed: %v", h, agent, err)
+			if len(output) > 0 {
+				p.Muted(strings.TrimSpace(string(output)))
+			}
+			p.Muted(fmt.Sprintf("Retry: mom init --force, or run: %s", command))
+			continue
+		}
+		p.Checkf("skills installed for %s → %s", h, agent)
+	}
+}
+
+func skillsInstallCommand(agent string) ([]string, string) {
+	args := []string{"skills", "add", "momhq/mom", "-g", "-s", "*", "-a", agent, "-y"}
+	return args, fmt.Sprintf("npx skills add momhq/mom -g -s '*' -a %s -y", agent)
+}
+
+func skillsAgentForHarness(h string) (string, bool) {
+	switch h {
+	case "claude":
+		return "claude-code", true
+	case "codex":
+		return "codex", true
+	case "windsurf":
+		return "windsurf", true
+	case "pi":
+		return "pi", true
+	default:
+		return "", false
 	}
 }
 

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,9 +16,14 @@ import (
 
 func initTestCentralVault(t *testing.T) string {
 	t.Helper()
+	resetInitFlags()
+	t.Cleanup(resetInitFlags)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("MOM_VAULT", filepath.Join(home, ".mom", "central.db"))
+	oldRunner := runExternalCommand
+	runExternalCommand = func(string, ...string) ([]byte, error) { return []byte("ok"), nil }
+	t.Cleanup(func() { runExternalCommand = oldRunner })
 	dir, err := centralvault.Dir()
 	if err != nil {
 		t.Fatalf("centralvault.Dir: %v", err)
@@ -35,7 +41,7 @@ func TestInitCmd_CreatesLeoStructure(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("init failed: %v", err)
@@ -111,7 +117,7 @@ func TestInitCmd_SkipsScaffoldIfAlreadyExists(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("expected graceful skip when MOM already exists, got error: %v", err)
@@ -131,7 +137,7 @@ func TestInitCmd_ReinitRepairsMissingGlobalFiles(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("initial init failed: %v", err)
 	}
@@ -149,7 +155,7 @@ func TestInitCmd_ReinitRepairsMissingGlobalFiles(t *testing.T) {
 	buf.Reset()
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("reinit failed: %v", err)
 	}
@@ -177,7 +183,7 @@ func TestInitCmd_ForceOverwrite(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude", "--force"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude", "--force"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("init --force failed: %v", err)
@@ -192,7 +198,7 @@ func TestInitCmd_ForceOverwrite(t *testing.T) {
 	}
 }
 
-func TestInitCmd_MultiRuntime(t *testing.T) {
+func TestInitCmd_HarnessesFlagConfiguresGlobalHarnesses(t *testing.T) {
 	dir := t.TempDir()
 	centralDir := initTestCentralVault(t)
 	origDir, _ := os.Getwd()
@@ -202,13 +208,176 @@ func TestInitCmd_MultiRuntime(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude,codex"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude,codex"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("init failed: %v", err)
 	}
 
-	// Both global runtime outputs should exist.
+	home := filepath.Dir(centralDir)
+	for _, path := range []string{
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".codex", "AGENTS.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("missing global harness output: %s", path)
+		}
+	}
+
+	cfg, err := config.Load(centralDir)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if got := cfg.EnabledHarnesses(); len(got) != 2 {
+		t.Errorf("expected 2 enabled harnesses, got %d: %v", len(got), got)
+	}
+}
+
+func TestInitCmd_HarnessesAllUsesDetectedInstalledHarnesses(t *testing.T) {
+	dir := t.TempDir()
+	centralDir := initTestCentralVault(t)
+	t.Setenv("PATH", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(filepath.Dir(centralDir), ".claude"), 0755); err != nil {
+		t.Fatalf("creating fake Claude install: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(filepath.Dir(centralDir), ".codex"), 0755); err != nil {
+		t.Fatalf("creating fake Codex install: %v", err)
+	}
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"init", "--harnesses", "all"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	cfg, err := config.Load(centralDir)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	enabled := strings.Join(cfg.EnabledHarnesses(), ",")
+	if !strings.Contains(enabled, "claude") || !strings.Contains(enabled, "codex") {
+		t.Fatalf("expected detected harnesses to include claude and codex, got %v", cfg.EnabledHarnesses())
+	}
+	if strings.Contains(enabled, "windsurf") || strings.Contains(enabled, "pi") {
+		t.Fatalf("expected undetected harnesses to be excluded, got %v", cfg.EnabledHarnesses())
+	}
+}
+
+func TestInitCmd_InstallsSkillsForSelectedHarnesses(t *testing.T) {
+	dir := t.TempDir()
+	_ = initTestCentralVault(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	var calls []string
+	oldRunner := runExternalCommand
+	runExternalCommand = func(name string, args ...string) ([]byte, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return []byte("ok"), nil
+	}
+	t.Cleanup(func() { runExternalCommand = oldRunner })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude,codex"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	want := []string{
+		"npx skills add momhq/mom -g -s * -a claude-code -y",
+		"npx skills add momhq/mom -g -s * -a codex -y",
+	}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("skills install calls mismatch\nwant: %v\n got: %v", want, calls)
+	}
+}
+
+func TestInitCmd_FinalTextMentionsStatusSkillAndCLI(t *testing.T) {
+	dir := t.TempDir()
+	_ = initTestCentralVault(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "/mom-status") || !strings.Contains(out, "mom status") {
+		t.Fatalf("final output should mention /mom-status and mom status:\n%s", out)
+	}
+}
+
+func TestInitCmd_SkillsInstallFailureIsSoft(t *testing.T) {
+	dir := t.TempDir()
+	centralDir := initTestCentralVault(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	oldRunner := runExternalCommand
+	runExternalCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("network unavailable"), fmt.Errorf("npx failed")
+	}
+	t.Cleanup(func() { runExternalCommand = oldRunner })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init should soft-fail skills install, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(centralDir, "config.yaml")); err != nil {
+		t.Fatalf("core init did not complete: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"skills install", "mom init --force", "npx skills add momhq/mom -g -s '*' -a claude-code -y"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestInitCmd_RuntimesFlagIsNotRegistered(t *testing.T) {
+	if f := initCmd.Flags().Lookup("runtimes"); f != nil {
+		t.Fatalf("--runtimes should not be registered")
+	}
+}
+
+func TestInitCmd_MultiHarness(t *testing.T) {
+	dir := t.TempDir()
+	centralDir := initTestCentralVault(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude,codex"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Both global harness outputs should exist.
 	home := filepath.Dir(centralDir)
 	files := map[string]string{
 		filepath.Join(home, ".claude", "CLAUDE.md"): "Claude",
@@ -224,15 +393,15 @@ func TestInitCmd_MultiRuntime(t *testing.T) {
 		t.Error("project-local .mom/ should not be created")
 	}
 
-	// Config should have both runtimes.
+	// Config should have both harnesses.
 	cfg, err := config.Load(centralDir)
 	if err != nil {
 		t.Fatalf("loading config: %v", err)
 	}
 
-	enabled := cfg.EnabledRuntimes()
+	enabled := cfg.EnabledHarnesses()
 	if len(enabled) != 2 {
-		t.Errorf("expected 2 enabled runtimes, got %d: %v", len(enabled), enabled)
+		t.Errorf("expected 2 enabled harnesses, got %d: %v", len(enabled), enabled)
 	}
 }
 
@@ -250,7 +419,7 @@ func TestInitCmd_DefaultDeliversMinimalContent(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("init failed: %v", err)
@@ -290,7 +459,7 @@ func TestInitCmd_BackupExistingFile(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "codex"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "codex"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("init failed: %v", err)
@@ -350,7 +519,7 @@ func TestInitCmd_CreatesConstraintsInCentralVault(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("init failed: %v", err)
 	}

--- a/cli/internal/cmd/integration_test.go
+++ b/cli/internal/cmd/integration_test.go
@@ -15,17 +15,15 @@ import (
 
 func resetInitFlags() {
 	f := initCmd.Flags()
-	// StringSlice.Set appends when changed=true, so clear Changed first.
-	if rt := f.Lookup("runtimes"); rt != nil {
-		rt.Changed = false
-		rt.Value.Set("")
-		rt.Changed = false
+	if h := f.Lookup("harnesses"); h != nil {
+		h.Value.Set("")
+		h.Changed = false
 	}
 	f.Set("force", "false")
 	f.Set("no-interactive", "false")
 }
 
-func initProject(t *testing.T, dir string, runtimes []string) string {
+func initProject(t *testing.T, dir string, harnesses []string) string {
 	t.Helper()
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
@@ -33,11 +31,14 @@ func initProject(t *testing.T, dir string, runtimes []string) string {
 
 	// Reset flags BEFORE execute to avoid cross-test contamination.
 	resetInitFlags()
+	oldRunner := runExternalCommand
+	runExternalCommand = func(string, ...string) ([]byte, error) { return []byte("ok"), nil }
+	t.Cleanup(func() { runExternalCommand = oldRunner })
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", strings.Join(runtimes, ",")})
+	rootCmd.SetArgs([]string{"init", "--harnesses", strings.Join(harnesses, ",")})
 	t.Cleanup(resetInitFlags)
 
 	if err := rootCmd.Execute(); err != nil {
@@ -123,7 +124,7 @@ func assertMCPEntry(t *testing.T, mcpPath string) {
 	}
 }
 
-func setupMinimalMom(t *testing.T, dir string, runtimes []string) {
+func setupMinimalMom(t *testing.T, dir string, harnesses []string) {
 	t.Helper()
 	momDir := filepath.Join(dir, ".mom")
 	for _, d := range []string{"memory", "constraints", "skills", "logs", "cache", "raw"} {
@@ -132,7 +133,7 @@ func setupMinimalMom(t *testing.T, dir string, runtimes []string) {
 
 	cfg := config.Default()
 	cfg.Harnesses = make(map[string]config.HarnessConfig)
-	for _, rt := range runtimes {
+	for _, rt := range harnesses {
 		cfg.Harnesses[rt] = config.HarnessConfig{Enabled: true}
 	}
 	cfg.Communication.Mode = "efficient"
@@ -145,15 +146,15 @@ func setupMinimalMom(t *testing.T, dir string, runtimes []string) {
 	os.WriteFile(filepath.Join(momDir, "schema.json"), []byte(`{"old": true}`), 0644)
 }
 
-// ── Test 1: Init with all runtimes ──────────────────────────────────────────
+// ── Test 1: Init with all harnesses ──────────────────────────────────────────
 
-func TestIntegration_InitAllRuntimes(t *testing.T) {
+func TestIntegration_InitAllHarnesses(t *testing.T) {
 	dir := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("HOME", home) // isolate global configs
 
-	allRuntimes := []string{"claude", "codex", "windsurf", "pi"}
-	initProject(t, dir, allRuntimes)
+	allHarnesses := []string{"claude", "codex", "windsurf", "pi"}
+	initProject(t, dir, allHarnesses)
 
 	// ── central .mom/ structure ──
 	assertFileNotExists(t, filepath.Join(dir, ".mom"))
@@ -165,9 +166,9 @@ func TestIntegration_InitAllRuntimes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loading config: %v", err)
 	}
-	enabled := cfg.EnabledRuntimes()
+	enabled := cfg.EnabledHarnesses()
 	if len(enabled) != 4 {
-		t.Errorf("expected 4 enabled runtimes, got %d: %v", len(enabled), enabled)
+		t.Errorf("expected 4 enabled harnesses, got %d: %v", len(enabled), enabled)
 	}
 
 	// ── Claude ──
@@ -209,16 +210,16 @@ func TestIntegration_InitAllRuntimes(t *testing.T) {
 	assertFileNotExists(t, filepath.Join(dir, ".mcp.json"))
 }
 
-// ── Test 2: Upgrade registers ALL runtimes (regression) ─────────────────────
+// ── Test 2: Upgrade registers ALL harnesses (regression) ─────────────────────
 
-func TestIntegration_UpgradeRegistersAllRuntimes(t *testing.T) {
+func TestIntegration_UpgradeRegistersAllHarnesses(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	allRuntimes := []string{"claude", "codex", "windsurf", "pi"}
-	setupMinimalMom(t, dir, allRuntimes)
+	allHarnesses := []string{"claude", "codex", "windsurf", "pi"}
+	setupMinimalMom(t, dir, allHarnesses)
 
-	// No runtime artifacts exist yet — this simulates the bug scenario.
+	// No harness artifacts exist yet — this simulates the bug scenario.
 	assertFileNotExists(t, filepath.Join(dir, ".claude", "CLAUDE.md"))
 	assertFileNotExists(t, filepath.Join(dir, "AGENTS.md"))
 	assertFileNotExists(t, filepath.Join(dir, ".windsurf", "rules", "mom.md"))
@@ -226,14 +227,14 @@ func TestIntegration_UpgradeRegistersAllRuntimes(t *testing.T) {
 
 	output := upgradeProject(t, dir)
 
-	// ALL runtimes must be regenerated — not just Claude.
-	for _, rt := range allRuntimes {
-		if !strings.Contains(output, "runtime "+rt+" context file regenerated") {
-			t.Errorf("upgrade output missing regeneration for runtime %s", rt)
+	// ALL harnesses must be regenerated — not just Claude.
+	for _, rt := range allHarnesses {
+		if !strings.Contains(output, "harness "+rt+" context file regenerated") {
+			t.Errorf("upgrade output missing regeneration for harness %s", rt)
 		}
 	}
 
-	// ── Verify artifacts created for ALL runtimes ──
+	// ── Verify artifacts created for ALL harnesses ──
 	assertFileExists(t, filepath.Join(dir, ".claude", "CLAUDE.md"))
 	assertFileContains(t, filepath.Join(dir, ".claude", "CLAUDE.md"), "Generated by MOM")
 
@@ -314,9 +315,9 @@ func TestIntegration_UpgradeDoesNotPropagateScopes(t *testing.T) {
 	}
 }
 
-// ── Test 4: Add runtimes via upgrade ────────────────────────────────────────
+// ── Test 4: Add harnesses via upgrade ────────────────────────────────────────
 
-func TestIntegration_AddRuntimesViaUpgrade(t *testing.T) {
+func TestIntegration_AddHarnessesViaUpgrade(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
@@ -343,7 +344,7 @@ func TestIntegration_AddRuntimesViaUpgrade(t *testing.T) {
 	cfg.Harnesses["codex"] = config.HarnessConfig{Enabled: true}
 	config.Save(momDir, cfg)
 
-	// Upgrade should pick up new runtimes.
+	// Upgrade should pick up new harnesses.
 	upgradeProject(t, dir)
 
 	// All three should now exist.
@@ -367,8 +368,8 @@ func TestIntegration_MCPConfigCorrectness(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	allRuntimes := []string{"claude", "codex", "windsurf"}
-	initProject(t, dir, allRuntimes)
+	allHarnesses := []string{"claude", "codex", "windsurf"}
+	initProject(t, dir, allHarnesses)
 
 	mcpPath := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
 

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -19,7 +19,7 @@ import (
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade .mom/ to the latest version (preserves your memory docs)",
-	Long: `Upgrades core infrastructure (schema, constraints, skills, runtime files)
+	Long: `Upgrades core infrastructure (schema, constraints, skills, harness files)
 to match the installed mom binary. Your documents in .mom/memory/ are never touched.
 
 Legacy central import scans $HOME and asks before writing.`,
@@ -328,18 +328,20 @@ func upgradeSingleDir(cmd *cobra.Command, projectRoot string, dryRun bool) error
 		return phase2Err
 	}
 
-	// ── Phase 3: Rebuild index and regenerate runtime files ─────────────────
+	// ── Phase 3: Rebuild index and regenerate harness files ─────────────────
 	var phase3Err error
 	doPhase3 := func() {
 		if !dryRun {
-			if err := regenerateRuntimeFiles(projectRoot, leoDir, cfg); err != nil {
+			if err := regenerateHarnessFiles(projectRoot, leoDir, cfg); err != nil {
 				phase3Err = err
 				return
 			}
 		}
 		for _, rt := range cfg.EnabledHarnesses() {
-			addAction("✔", fmt.Sprintf("runtime %s context file regenerated", rt))
+			addAction("✔", fmt.Sprintf("harness %s context file regenerated", rt))
 		}
+
+		installSkillsDuringUpgrade(cfg.EnabledHarnesses(), dryRun, addAction)
 
 		// Rebuild SQLite search index from JSON files.
 		if !dryRun {
@@ -359,7 +361,7 @@ func upgradeSingleDir(cmd *cobra.Command, projectRoot string, dryRun bool) error
 
 	if showSpinner {
 		sp := ux.NewSpinner(os.Stderr)
-		sp.Start("Regenerating runtime files")
+		sp.Start("Regenerating harness files")
 		doPhase3()
 		sp.Stop()
 	} else {
@@ -411,6 +413,31 @@ func upgradeSingleDir(cmd *cobra.Command, projectRoot string, dryRun bool) error
 	p.Blank()
 
 	return nil
+}
+
+func installSkillsDuringUpgrade(harnesses []string, dryRun bool, addAction func(string, string)) {
+	for _, h := range harnesses {
+		agent, ok := skillsAgentForHarness(h)
+		if !ok {
+			addAction("⚠", fmt.Sprintf("skills: unsupported harness %s", h))
+			continue
+		}
+		args, command := skillsInstallCommand(agent)
+		if dryRun {
+			addAction("+", "would run "+command)
+			continue
+		}
+		if output, err := runExternalCommand("npx", args...); err != nil {
+			detail := fmt.Sprintf("skills install %s → %s failed: %v", h, agent, err)
+			if len(output) > 0 {
+				detail += ": " + strings.TrimSpace(string(output))
+			}
+			detail += fmt.Sprintf("; retry with mom upgrade, mom init --force, or run: %s", command)
+			addAction("⚠", detail)
+			continue
+		}
+		addAction("✔", fmt.Sprintf("skills installed for %s → %s", h, agent))
+	}
 }
 
 // propagateUpgrade walks child directories and upgrades each legacy .mom/ found.
@@ -765,8 +792,8 @@ func kebabOnly(s string) string {
 	return result
 }
 
-// regenerateRuntimeFiles rebuilds all runtime context files from the current config.
-func regenerateRuntimeFiles(projectRoot, leoDir string, cfg *config.Config) error {
+// regenerateHarnessFiles rebuilds all harness context files from the current config.
+func regenerateHarnessFiles(projectRoot, leoDir string, cfg *config.Config) error {
 	registry := harness.NewRegistry(projectRoot)
 
 	runtimeCfg := buildRuntimeConfig(cfg)
@@ -802,7 +829,7 @@ func regenerateRuntimeFiles(projectRoot, leoDir string, cfg *config.Config) erro
 }
 
 // scrubDeadConfigFields reads config.yaml from leoDir, removes the retired
-// "tiers" key from every runtime block and the "autonomy" key from the user
+// "tiers" key from every harness block and the "autonomy" key from the user
 // block, and returns the cleaned bytes plus a changed flag. It does nothing
 // when the keys are already absent.
 //

--- a/cli/internal/cmd/upgrade_test.go
+++ b/cli/internal/cmd/upgrade_test.go
@@ -17,8 +17,11 @@ func resetUpgradeFlags(t *testing.T) {
 	t.Helper()
 	t.Setenv("MOM_UPGRADE_SCAN_ROOT", t.TempDir())
 	t.Setenv("MOM_UPGRADE_ASSUME_YES", "1")
+	oldRunner := runExternalCommand
+	runExternalCommand = func(string, ...string) ([]byte, error) { return []byte("ok"), nil }
 	t.Cleanup(func() {
 		upgradeCmd.Flags().Set("dry-run", "false")
+		runExternalCommand = oldRunner
 	})
 }
 
@@ -133,13 +136,13 @@ func TestUpgradeCmd_MigratesConfig(t *testing.T) {
 		t.Fatalf("upgrade failed: %v\noutput:\n%s", err, buf.String())
 	}
 
-	// Config should be loadable and have runtimes map.
+	// Config should be loadable and have harnesses map.
 	cfg, err := config.Load(filepath.Join(dir, ".mom"))
 	if err != nil {
 		t.Fatalf("loading config after upgrade: %v", err)
 	}
-	if len(cfg.EnabledRuntimes()) == 0 {
-		t.Error("expected at least one enabled runtime after migration")
+	if len(cfg.EnabledHarnesses()) == 0 {
+		t.Error("expected at least one enabled harness after migration")
 	}
 
 	// User settings should be preserved.
@@ -414,7 +417,7 @@ func TestUpgradeCmd_MigratesMetricDocs(t *testing.T) {
 	}
 }
 
-func TestUpgradeCmd_GeneratesRuntimeFiles(t *testing.T) {
+func TestUpgradeCmd_GeneratesHarnessFiles(t *testing.T) {
 	resetUpgradeFlags(t)
 	dir := setupLegacyProject(t)
 
@@ -431,7 +434,7 @@ func TestUpgradeCmd_GeneratesRuntimeFiles(t *testing.T) {
 		t.Fatalf("upgrade failed: %v", err)
 	}
 
-	// CLAUDE.md should exist (claude is the migrated runtime).
+	// CLAUDE.md should exist (claude is the migrated harness).
 	claudeMD := filepath.Join(dir, ".claude", "CLAUDE.md")
 	if _, err := os.Stat(claudeMD); err != nil {
 		t.Error("CLAUDE.md not generated during upgrade")
@@ -650,7 +653,7 @@ func TestInitCmd_NewLayout_NoKBDir(t *testing.T) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"init", "--runtimes", "claude"})
+	rootCmd.SetArgs([]string{"init", "--harnesses", "claude"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("init failed: %v", err)
@@ -694,7 +697,7 @@ func TestUpgradeCmd_ScrubsDeadConfigFields(t *testing.T) {
 
 	// Write a config that still has the retired fields.
 	staleConfig := `version: "1"
-runtimes:
+harnesses:
   claude:
     enabled: true
     tiers:
@@ -880,6 +883,66 @@ func TestUpgradeCmd_MigratesFactASTToPattern(t *testing.T) {
 	}
 }
 
+func TestUpgradeCmd_InstallsSkillsForConfiguredHarnesses(t *testing.T) {
+	resetUpgradeFlags(t)
+	dir := setupLegacyProject(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	var calls []string
+	oldRunner := runExternalCommand
+	runExternalCommand = func(name string, args ...string) ([]byte, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return []byte("ok"), nil
+	}
+	t.Cleanup(func() { runExternalCommand = oldRunner })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"upgrade"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("upgrade failed: %v\noutput:\n%s", err, buf.String())
+	}
+	joined := strings.Join(calls, "\n")
+	if !strings.Contains(joined, "npx skills add momhq/mom -g -s * -a claude-code -y") {
+		t.Fatalf("skills install command missing, got: %v", calls)
+	}
+}
+
+func TestUpgradeCmd_DryRunPrintsPlannedSkillsInstallCommands(t *testing.T) {
+	resetUpgradeFlags(t)
+	dir := setupLegacyProject(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	var calls []string
+	oldRunner := runExternalCommand
+	runExternalCommand = func(name string, args ...string) ([]byte, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return []byte("ok"), nil
+	}
+	t.Cleanup(func() { runExternalCommand = oldRunner })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"upgrade", "--dry-run"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("upgrade --dry-run failed: %v\noutput:\n%s", err, buf.String())
+	}
+	if len(calls) != 0 {
+		t.Fatalf("dry run should not install skills, got: %v", calls)
+	}
+	if !strings.Contains(buf.String(), "npx skills add momhq/mom -g -s '*' -a claude-code -y") {
+		t.Fatalf("dry run output missing planned skills command:\n%s", buf.String())
+	}
+}
+
 // TestUpgradeCmd_ScrubIdempotent verifies a second upgrade on an already-scrubbed
 // config does not fail or re-report the scrub action.
 func TestUpgradeCmd_ScrubIdempotent(t *testing.T) {
@@ -893,7 +956,7 @@ func TestUpgradeCmd_ScrubIdempotent(t *testing.T) {
 
 	// Write a clean (already-scrubbed) config.
 	cleanConfig := `version: "1"
-runtimes:
+harnesses:
   claude:
     enabled: true
 user:

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "mom",
+  "version": "1.0.0",
+  "description": "User-invocable MOM skills for status, recall, and wrap-up.",
+  "skills": [
+    "skills/mom-status",
+    "skills/mom-recall",
+    "skills/mom-wrap-up"
+  ]
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,13 @@
+# MOM skills
+
+User-invocable slash commands that teach agents MOM's CLI-first workflows.
+
+## Skills
+
+| Skill | Slash command | Canonical CLI |
+|---|---|---|
+| `mom-status` | `/mom-status` | `mom status` |
+| `mom-recall` | `/mom-recall <query>` | `mom recall "<query>"` |
+| `mom-wrap-up` | `/mom-wrap-up` | `mom drafts` + `mom curate` |
+
+Skills use the MOM CLI only. MCP is a fallback/discovery surface, not the skill execution path.

--- a/skills/mom-recall/SKILL.md
+++ b/skills/mom-recall/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: mom-recall
+description: Search MOM's persistent memory. Use when user asks what was decided, discussed, preferred, tried, learned, or remembered about a specific topic.
+user-invocable: true
+allowed-tools: Bash(mom recall*)
+argument-hint: <query>
+---
+
+Require one natural-language query from the user.
+
+Run:
+
+```bash
+mom recall "<query>"
+```
+
+Use Finder through the CLI. Do not call MCP.
+
+Behavior:
+- If user asks to show, find, or list memories: print the recall results.
+- If user asks a question: answer from the recall results and include citations.
+- If recall returns no matches: say no matching memories were found.
+
+Citation format:
+
+```text
+[RECALL:
+sources: <memory-id>, <memory-id>, ...]
+```
+
+Do not:
+- Run recall without a query.
+- Add flags to `mom recall`.
+- Invent answers beyond returned memories.

--- a/skills/mom-status/SKILL.md
+++ b/skills/mom-status/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: mom-status
+description: Show MOM's current state. Use when user asks if MOM is working, what MOM knows, to check setup, after context reset, or when MOM status is requested.
+user-invocable: true
+allowed-tools: Bash(mom status*)
+---
+
+Run:
+
+```bash
+mom status
+```
+
+Print the raw output verbatim. Do not summarize, reinterpret, or call MCP.
+
+If `mom` is missing from PATH, say MOM is not installed or not on PATH and stop.

--- a/skills/mom-wrap-up/SKILL.md
+++ b/skills/mom-wrap-up/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: mom-wrap-up
+description: Curate recent MOM drafts. Use when user asks to wrap up, finish, close the session, preserve decisions, or prepare memory before clearing context.
+user-invocable: true
+allowed-tools: Bash(mom drafts*), Bash(mom curate*)
+---
+
+Run only after explicit user request.
+
+1. Surface recent drafts:
+
+```bash
+mom drafts
+```
+
+If user gives a Go duration window, use it:
+
+```bash
+mom drafts --since 1h
+```
+
+2. Synthesize a curation plan.
+
+For each draft worth keeping, propose:
+- draft id
+- type: `semantic`, `procedural`, or `episodic`
+- approved summary
+- reason to curate
+
+Hide drafts you recommend discarding unless user asks to see them.
+
+3. Wait for user approval.
+
+Do not curate anything before approval.
+
+4. Execute approved curation exactly:
+
+```bash
+mom curate <id> --type <semantic|procedural|episodic> --summary "<approved summary>"
+```
+
+5. Report:
+
+```text
+## Wrap-up complete
+Curated:  <N>
+Deferred: <N or none>
+```
+
+Do not:
+- Use MCP.
+- Use ad hoc database queries.
+- Use removed legacy curation commands.
+- Rewrite draft content.
+- Skip type or summary.


### PR DESCRIPTION
## Summary
- add MOM skills package for status, recall, and wrap-up
- replace init `--runtimes` with `--harnesses` and support `--harnesses all`
- install skills globally through skills.sh during init and upgrade, with soft failures
- print planned skills install commands during upgrade dry runs

## Validation
- `/tdd` red-green-refactor loop
- review/refactor pass
- security review: no high-confidence findings
- `go test ./...`