### PR TITLE
Shrink status and context guidance

### DIFF
--- a/cli/internal/adapters/harness/content.go
+++ b/cli/internal/adapters/harness/content.go
@@ -10,11 +10,11 @@ import (
 func BuildMinimalContextContent() string {
 	return `# MOM — Memory Oriented Machine
 
-You have MOM tools via MCP. Call ` + "`mom_status`" + ` at the start of every session.
+MOM remembers project decisions across sessions.
 
-For memory operations: mom_recall, mom_get, mom_landmarks, mom_record.
+At session start, call ` + "`mom_status`" + `.
 
-Do NOT skip mom_status — it contains your operating instructions.
+Prefer skills and CLI: /mom-status, /mom-recall, /mom-wrap-up. MCP fallback is for startup and discovery.
 `
 }
 

--- a/cli/internal/adapters/harness/content_test.go
+++ b/cli/internal/adapters/harness/content_test.go
@@ -9,22 +9,18 @@ import (
 func TestBuildMinimalContextContent(t *testing.T) {
 	content := BuildMinimalContextContent()
 
-	if !strings.Contains(content, "mom_status") {
-		t.Error("minimal content must mention mom_status")
+	for _, want := range []string{"mom_status", "/mom-status", "/mom-recall", "/mom-wrap-up", "CLI", "MCP fallback"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("minimal content must mention %q", want)
+		}
 	}
 
-	if !strings.Contains(content, "mom_recall") {
-		t.Error("minimal content must mention mom_recall")
-	}
-
-	// Under 100 words.
 	words := strings.Fields(content)
 	if len(words) >= 100 {
 		t.Errorf("minimal content should be <100 words, got %d", len(words))
 	}
 
-	// Must not contain the legacy verbose sections.
-	forbidden := []string{"## Voice", "## Constraints", "## Skills", "## During work"}
+	forbidden := []string{"## Voice", "## Constraints", "## Skills", "## During work", "mom" + "_" + "record", "recording", "install"}
 	for _, f := range forbidden {
 		if strings.Contains(content, f) {
 			t.Errorf("minimal content must not contain %q", f)

--- a/cli/internal/cmd/central_cli_test.go
+++ b/cli/internal/cmd/central_cli_test.go
@@ -102,9 +102,14 @@ func TestStatusCmd_CentralShape(t *testing.T) {
 		t.Fatalf("runStatus: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"MOM", "vault", "memories", "types", "landmarks", "op events", "constraints", "skills"} {
+	for _, want := range []string{"MOM", "cwd", "vault", "memories", "types", "landmarks", "op events", "recording", "watcher"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("status output missing %q:\n%s", want, out)
+		}
+	}
+	for _, forbidden := range []string{"constraints", "skills"} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("status output should not include %q:\n%s", forbidden, out)
 		}
 	}
 }

--- a/cli/internal/cmd/ops.go
+++ b/cli/internal/cmd/ops.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/momhq/mom/cli/internal/adapters/storage"
 	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/daemon"
 	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/memory"
 	"github.com/momhq/mom/cli/internal/scope"
@@ -64,40 +65,36 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading op events: %w", err)
 	}
-	centralDir, err := centralvault.Dir()
+	cwd, err := os.Getwd()
 	if err != nil {
-		return err
+		return fmt.Errorf("getting working directory: %w", err)
 	}
-	constraints := countJSONFiles(filepath.Join(centralDir, "constraints"))
-	skills := countJSONFiles(filepath.Join(centralDir, "skills"))
 
 	p := ux.NewPrinter(cmd.OutOrStdout())
 	p.Bold("MOM")
+	p.KeyValue("cwd", cwd, 12)
 	p.KeyValue("vault", path, 12)
 	p.KeyValue("memories", fmt.Sprintf("total %d, curated %d, draft %d", len(memories), curated, draft), 12)
 	p.KeyValue("types", fmt.Sprintf("episodic %d, semantic %d, procedural %d, untyped %d", types["episodic"], types["semantic"], types["procedural"], types["untyped"]), 12)
 	p.KeyValue("landmarks", fmt.Sprintf("%d", len(landmarks)), 12)
 	p.KeyValue("op events", fmt.Sprintf("%d", len(opEvents)), 12)
-	p.KeyValue("constraints", fmt.Sprintf("%d", constraints), 12)
-	p.KeyValue("skills", fmt.Sprintf("%d", skills), 12)
+	p.KeyValue("recording", "continuous", 12)
+	p.KeyValue("watcher", cliWatcherState(), 12)
 	return nil
 }
 
-// printScopesSection prints the active scopes discovered by walk-up from cwd.
-func countJSONFiles(dir string) int {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return 0
+func cliWatcherState() string {
+	health, err := daemon.StatusGlobal()
+	if err != nil || len(health.Services) == 0 {
+		return "unknown"
 	}
-	n := 0
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
-			n++
-		}
+	if health.Services[0].DaemonRunning {
+		return "active"
 	}
-	return n
+	return "inactive"
 }
 
+// printScopesSection prints the active scopes discovered by walk-up from cwd.
 func printScopesSection(p *ux.Printer, cwd string) {
 	scopes := scope.Walk(cwd)
 	if len(scopes) == 0 {

--- a/cli/internal/cmd/ops_test.go
+++ b/cli/internal/cmd/ops_test.go
@@ -55,9 +55,14 @@ func TestStatusCmd_ShowsCentralShape(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"MOM", "vault", "memories", "types", "landmarks", "op events", "constraints", "skills"} {
+	for _, want := range []string{"MOM", "cwd", "vault", "memories", "types", "landmarks", "op events", "recording", "watcher"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+	for _, forbidden := range []string{"constraints", "skills"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("did not expect %q in output, got:\n%s", forbidden, out)
 		}
 	}
 }

--- a/cli/internal/mcp/status.go
+++ b/cli/internal/mcp/status.go
@@ -3,79 +3,72 @@ package mcp
 import (
 	"encoding/json"
 	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/momhq/mom/cli/internal/adapters/harness"
 	"github.com/momhq/mom/cli/internal/centralvault"
-	"github.com/momhq/mom/cli/internal/config"
+	"github.com/momhq/mom/cli/internal/daemon"
 	"github.com/momhq/mom/cli/internal/librarian"
 )
 
-// statusPayload defines the mom_status response with explicit field ordering.
+// statusPayload defines the compact mom_status response.
 type statusPayload struct {
-	ProjectDir     string                    `json:"project_dir"`
-	Identity       statusIdentityBlock       `json:"identity"`
-	OperatingRules statusOperatingRulesBlock `json:"operating_rules"`
-	Boundaries     []string                  `json:"boundaries"`
-	Tools          statusToolsBlock          `json:"tools"`
-	Constraints    []docSummary              `json:"constraints"`
-	Skills         []docSummary              `json:"skills"`
-	Modes          statusModesBlock          `json:"modes"`
-	VaultState     statusVaultStateBlock     `json:"vault_state"`
-	DocSchema      string                    `json:"doc_schema"`
+	Identity   statusIdentityBlock   `json:"identity"`
+	Health     statusHealthBlock     `json:"health"`
+	Routing    statusRoutingBlock    `json:"routing"`
+	Session    statusSessionBlock    `json:"session"`
+	VaultState statusVaultStateBlock `json:"vault_state"`
+	Skills     []statusSkillBlock    `json:"skills"`
 }
 
 type statusIdentityBlock struct {
-	Name      string `json:"name"`
-	Expansion string `json:"expansion"`
-	Tagline   string `json:"tagline"`
-	Role      string `json:"role"`
-	Voice     string `json:"voice"`
-	Stance    string `json:"stance"`
+	Name    string `json:"name"`
+	Tagline string `json:"tagline"`
 }
 
-type statusOperatingRulesBlock struct {
-	OnStart   string `json:"on_start"`
-	Recall    string `json:"recall"`
-	Recording string `json:"recording"`
-	WrapUp    string `json:"wrap_up"`
+type statusHealthBlock struct {
+	Status string `json:"status"`
 }
 
-type statusToolsBlock struct {
-	MomStatus    string `json:"mom_status"`
-	MomRecall    string `json:"mom_recall"`
-	MomGet       string `json:"mom_get"`
-	MomLandmarks string `json:"mom_landmarks"`
-	MomRecord    string `json:"mom_record"`
+type statusRoutingBlock struct {
+	Startup   string `json:"startup"`
+	Preferred string `json:"preferred"`
+	MCP       string `json:"mcp"`
 }
 
-type statusModesBlock struct {
-	Language      string `json:"language"`
-	Communication string `json:"communication"`
-	Autonomy      string `json:"autonomy"`
+type statusSessionBlock struct {
+	CWD string `json:"cwd"`
 }
 
 type statusVaultStateBlock struct {
-	Scopes        []scopeVaultEntry `json:"scopes"`
-	TotalMemories int               `json:"total_memories"`
-	Landmarks     int               `json:"landmarks"`
-	RecordMode    string            `json:"record_mode"`
+	Path          string `json:"path"`
+	TotalMemories int    `json:"total_memories"`
+	Landmarks     int    `json:"landmarks"`
+	RecordMode    string `json:"record_mode"`
+	Watcher       string `json:"watcher"`
 }
 
-// toolMomStatus returns MOM's full behavioral protocol as a JSON payload.
+type statusSkillBlock struct {
+	Command string `json:"command"`
+	Purpose string `json:"purpose"`
+}
+
+// toolMomStatus returns MOM's startup handshake as a compact JSON payload.
 func (s *Server) toolMomStatus() (toolCallResult, error) {
 	payload := statusPayload{
-		ProjectDir:     filepath.Dir(s.momDir),
-		Identity:       statusIdentity(),
-		OperatingRules: statusOperatingRules(),
-		Boundaries:     statusBoundaries(),
-		Tools:          statusTools(),
-		Constraints:    s.statusConstraints(),
-		Skills:         s.statusSkills(),
-		Modes:          s.statusModes(),
-		VaultState:     s.statusVaultState(),
-		DocSchema:      "Central v0.30 SQLite schema: memories, tags, entities, memory_tags, memory_entities, op_events, filter_audit.",
+		Identity: statusIdentity(),
+		Health: statusHealthBlock{
+			Status: "ok",
+		},
+		Routing: statusRoutingBlock{
+			Startup:   "Call mom_status at session start. After this, prefer MOM skills and CLI.",
+			Preferred: "Use /mom-status, /mom-recall, /mom-wrap-up, and mom CLI commands first.",
+			MCP:       "Fallback for discovery, startup handshake, or when CLI skills are unavailable.",
+		},
+		Session:    statusSession(),
+		VaultState: s.statusVaultState(),
+		Skills:     statusSkills(),
+	}
+	if payload.VaultState.Path == "" {
+		payload.Health.Status = "degraded"
 	}
 
 	text, err := json.MarshalIndent(payload, "", "  ")
@@ -85,168 +78,53 @@ func (s *Server) toolMomStatus() (toolCallResult, error) {
 	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
 }
 
-// statusIdentity returns the static identity block.
 func statusIdentity() statusIdentityBlock {
 	return statusIdentityBlock{
-		Name:      "MOM",
-		Expansion: "Memory Oriented Machine",
-		Tagline:   "She remembers, so you don't have to_",
-		Role:      "I am the persistent memory layer for AI agents. I surface decisions, patterns, facts, and context across sessions and runtimes.",
-		Voice:     "A mom who happens to be a machine. Direct, warm, lightly playful. No marketing-speak. No emoji.",
-		Stance:    "I remember, I don't instruct. I cite sources on every recall. The user decides the what and why — I provide what they already know, not what I think they should know.",
+		Name:    "MOM",
+		Tagline: "Memory Oriented Machine — she remembers, so you don't have to_",
 	}
 }
 
-// statusOperatingRules returns the static operating rules block.
-func statusOperatingRules() statusOperatingRulesBlock {
-	return statusOperatingRulesBlock{
-		OnStart:   "After receiving this protocol, call mom_recall with context relevant to the user's current request to surface prior work.",
-		Recall:    "Call mom_recall before answering from memory or asserting past decisions. Cite source memory IDs in every answer drawn from recall.",
-		Recording: "Continuous recording is active — your conversation is automatically persisted by the watcher daemon. No action needed from you.",
-		WrapUp:    "User-invoked only. Run the session-wrap-up skill only when the user explicitly asks.",
+func statusSession() statusSessionBlock {
+	cwd, _ := os.Getwd()
+	return statusSessionBlock{CWD: cwd}
+}
+
+func statusSkills() []statusSkillBlock {
+	return []statusSkillBlock{
+		{Command: "/mom-status", Purpose: "Show MOM health and vault state via mom status."},
+		{Command: "/mom-recall", Purpose: "Search persistent memory with mom recall."},
+		{Command: "/mom-wrap-up", Purpose: "Curate recent drafts with mom drafts and mom curate."},
 	}
 }
 
-// statusBoundaries returns the static boundaries list.
-func statusBoundaries() []string {
-	return []string{
-		"Never fabricate memories. If it's not stored, say so plainly.",
-		"Never prescribe actions. Surface context, let the user decide.",
-		"Never skip citations. Every recall names its source memory.",
-		"Never access memories outside the user's clearance.",
-	}
-}
-
-// statusTools returns the static tools block.
-func statusTools() statusToolsBlock {
-	return statusToolsBlock{
-		MomStatus:    "Returns this protocol. Call at session start.",
-		MomRecall:    "Search memories by query. Use before asserting past context.",
-		MomGet:       "Retrieve a memory by ID.",
-		MomLandmarks: "List landmark memories ordered by centrality score.",
-		MomRecord:    "Explicit-write path: intentionally save a memory mid-session. Bypasses Drafter's content filters per ADR 0014.",
-	}
-}
-
-// docSummary is a compact representation of a constraint or skill doc.
-type docSummary struct {
-	ID      string `json:"id"`
-	Summary string `json:"summary,omitempty"`
-	Path    string `json:"path"`
-}
-
-// scanDocDir scans dir/*.json and returns a slice of docSummary items.
-func scanDocDir(dir string) []docSummary {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	var result []docSummary
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
-		}
-		path := filepath.Join(dir, e.Name())
-		data, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		var raw map[string]any
-		if err := json.Unmarshal(data, &raw); err != nil {
-			continue
-		}
-		id, _ := raw["id"].(string)
-		if id == "" {
-			id = strings.TrimSuffix(e.Name(), ".json")
-		}
-		summary, _ := raw["summary"].(string)
-		result = append(result, docSummary{ID: id, Summary: summary, Path: path})
-	}
-	return result
-}
-
-// statusConstraints loads constraint summaries from the central generated
-// $HOME/.mom/constraints directory (or MOM_VAULT's parent directory when set).
-func (s *Server) statusConstraints() []docSummary {
-	dir, err := centralvault.Dir()
-	if err != nil {
-		return []docSummary{}
-	}
-	out := scanDocDir(filepath.Join(dir, "constraints"))
-	if out == nil {
-		return []docSummary{}
-	}
-	return out
-}
-
-// statusSkills loads skill summaries from the central generated
-// $HOME/.mom/skills directory (or MOM_VAULT's parent directory when set).
-func (s *Server) statusSkills() []docSummary {
-	dir, err := centralvault.Dir()
-	if err != nil {
-		return []docSummary{}
-	}
-	out := scanDocDir(filepath.Join(dir, "skills"))
-	if out == nil {
-		return []docSummary{}
-	}
-	return out
-}
-
-// statusModes returns language/communication/autonomy from config, falling back
-// to sensible defaults when config is unavailable. Each field contains the full
-// behavioral rules, not just the mode label — so the agent receives concrete
-// instructions via MCP without needing a context file.
-func (s *Server) statusModes() statusModesBlock {
-	lang := "en"
-	commMode := "concise"
-	autoMode := "balanced"
-
-	cfg, err := config.Load(s.momDir)
-	if err == nil {
-		if cfg.User.Language != "" {
-			lang = cfg.User.Language
-		}
-		if cfg.Communication.Mode != "" {
-			commMode = cfg.Communication.Mode
-		}
-	}
-
-	return statusModesBlock{
-		Language:      harness.LanguageInstructions(lang),
-		Communication: harness.CommunicationModeInstructions(commMode),
-		Autonomy:      harness.AutonomyInstructions(autoMode),
-	}
-}
-
-// scopeVaultEntry is one entry in vault_state.scopes.
-type scopeVaultEntry struct {
-	Label       string `json:"label"`
-	Path        string `json:"path"`
-	MemoryCount int    `json:"memory_count"`
-}
-
-// statusVaultState builds the central v0.30 vault_state block.
 func (s *Server) statusVaultState() statusVaultStateBlock {
 	path, _ := centralvault.Path()
-	entry := scopeVaultEntry{Label: "central", Path: path}
+	state := statusVaultStateBlock{
+		Path:       path,
+		RecordMode: "continuous",
+		Watcher:    watcherState(),
+	}
 
 	lib, err := s.requireLibrarian()
 	if err != nil {
-		return statusVaultStateBlock{
-			Scopes:     []scopeVaultEntry{entry},
-			RecordMode: "continuous",
-		}
+		return state
 	}
 
 	memories, _ := lib.SearchMemories(librarian.SearchFilter{Limit: 1_000_000})
 	landmarks, _ := lib.Landmarks(1_000_000)
-	entry.MemoryCount = len(memories)
+	state.TotalMemories = len(memories)
+	state.Landmarks = len(landmarks)
+	return state
+}
 
-	return statusVaultStateBlock{
-		Scopes:        []scopeVaultEntry{entry},
-		TotalMemories: len(memories),
-		Landmarks:     len(landmarks),
-		RecordMode:    "continuous",
+func watcherState() string {
+	health, err := daemon.StatusGlobal()
+	if err != nil || len(health.Services) == 0 {
+		return "unknown"
 	}
+	if health.Services[0].DaemonRunning {
+		return "active"
+	}
+	return "inactive"
 }

--- a/cli/internal/mcp/status_test.go
+++ b/cli/internal/mcp/status_test.go
@@ -6,36 +6,22 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/momhq/mom/cli/internal/centralvault"
 )
 
-// newStatusTestDir creates a temp .mom/ dir with constraints, skills, and config
-// set up for mom_status tests.
+// newStatusTestDir creates a temp .mom/ dir with config set up for mom_status tests.
 func newStatusTestDir(t *testing.T) string {
 	t.Helper()
-	vaultPath := setCentralVault(t)
-	centralDir := filepath.Dir(vaultPath)
+	setCentralVault(t)
 	dir := t.TempDir()
 	leoDir := filepath.Join(dir, ".mom")
 
-	// Required dirs.
-	for _, sub := range []string{"memory"} {
-		if err := os.MkdirAll(filepath.Join(leoDir, sub), 0755); err != nil {
-			t.Fatal(err)
-		}
-	}
-	for _, sub := range []string{"constraints", "skills"} {
-		if err := os.MkdirAll(filepath.Join(centralDir, sub), 0755); err != nil {
-			t.Fatal(err)
-		}
+	if err := os.MkdirAll(filepath.Join(leoDir, "memory"), 0755); err != nil {
+		t.Fatal(err)
 	}
 
-	// config.yaml with language and communication mode.
 	cfg := `version: "1"
 scope: repo
-runtimes:
+harnesses:
   claude:
     enabled: true
 user:
@@ -47,73 +33,11 @@ communication:
 		t.Fatal(err)
 	}
 
-	// identity.json (required by newTestLeoDir pattern; not used by mom_status but
-	// keeps the server happy during optional identity resource reads).
-	identity := map[string]any{
-		"id":         "identity",
-		"type":       "identity",
-		"lifecycle":  "permanent",
-		"scope":      "project",
-		"tags":       []string{"identity"},
-		"created":    time.Now().Format(time.RFC3339),
-		"created_by": "test",
-		"updated":    time.Now().Format(time.RFC3339),
-		"updated_by": "test",
-		"content":    map[string]any{"name": "Test Project"},
-	}
-	writeJSON(t, filepath.Join(leoDir, "identity.json"), identity)
-
-	// Two constraint docs.
-	writeJSON(t, filepath.Join(centralDir, "constraints", "anti-hallucination.json"), map[string]any{
-		"id":         "anti-hallucination",
-		"type":       "constraint",
-		"lifecycle":  "permanent",
-		"scope":      "core",
-		"tags":       []string{"constraint"},
-		"summary":    "Never hallucinate",
-		"created":    time.Now().Format(time.RFC3339),
-		"created_by": "test",
-		"updated":    time.Now().Format(time.RFC3339),
-		"updated_by": "test",
-		"content":    map[string]any{"rule": "no hallucination"},
-	})
-	writeJSON(t, filepath.Join(centralDir, "constraints", "escalation-triggers.json"), map[string]any{
-		"id":         "escalation-triggers",
-		"type":       "constraint",
-		"lifecycle":  "permanent",
-		"scope":      "core",
-		"tags":       []string{"constraint"},
-		"summary":    "Stop and ask before destructive actions",
-		"created":    time.Now().Format(time.RFC3339),
-		"created_by": "test",
-		"updated":    time.Now().Format(time.RFC3339),
-		"updated_by": "test",
-		"content":    map[string]any{"rule": "escalate"},
-	})
-
-	// One skill doc.
-	writeJSON(t, filepath.Join(centralDir, "skills", "session-wrap-up.json"), map[string]any{
-		"id":         "session-wrap-up",
-		"type":       "skill",
-		"lifecycle":  "permanent",
-		"scope":      "core",
-		"tags":       []string{"skill"},
-		"summary":    "End-of-session knowledge propagation",
-		"created":    time.Now().Format(time.RFC3339),
-		"created_by": "test",
-		"updated":    time.Now().Format(time.RFC3339),
-		"updated_by": "test",
-		"content":    map[string]any{"steps": "inventory, classify, write, report"},
-	})
-
-	// One memory row to verify total_memories count.
 	insertCentralMemory(t, "A test memory", "detail x", []string{"test"})
-
 	return leoDir
 }
 
-// callMomStatus is a helper that sends the mom_status tool call and returns
-// the parsed text payload as a map.
+// callMomStatus sends the mom_status tool call and returns the parsed JSON payload.
 func callMomStatus(t *testing.T, leoDir string) map[string]any {
 	t.Helper()
 	inW, outR, _ := runServer(t, leoDir)
@@ -154,187 +78,99 @@ func callMomStatus(t *testing.T, leoDir string) map[string]any {
 	return payload
 }
 
-func TestMomStatusTopLevelKeys(t *testing.T) {
+func TestMomStatusCompactShape(t *testing.T) {
 	leoDir := newStatusTestDir(t)
 	payload := callMomStatus(t, leoDir)
 
-	requiredKeys := []string{
-		"identity",
-		"operating_rules",
-		"boundaries",
-		"tools",
-		"constraints",
-		"skills",
-		"modes",
-		"vault_state",
-		"doc_schema",
-	}
-	for _, k := range requiredKeys {
-		if _, ok := payload[k]; !ok {
-			t.Errorf("missing top-level key %q in mom_status response", k)
+	for _, key := range []string{"identity", "health", "routing", "session", "vault_state", "skills"} {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("missing top-level key %q in mom_status response", key)
 		}
 	}
-}
-
-func TestMomStatusIdentity(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
+	for _, key := range []string{"operating_rules", "boundaries", "tools", "constraints", "modes", "doc_schema"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("mom_status should not include legacy key %q", key)
+		}
+	}
 
 	identity, ok := payload["identity"].(map[string]any)
 	if !ok {
 		t.Fatalf("identity is not a map: %T", payload["identity"])
 	}
-	for _, field := range []string{"name", "expansion", "tagline", "role", "voice", "stance"} {
-		if v, ok := identity[field].(string); !ok || v == "" {
-			t.Errorf("identity.%s missing or empty", field)
-		}
-	}
 	if identity["name"] != "MOM" {
-		t.Errorf("identity.name = %q; want MOM", identity["name"])
+		t.Fatalf("identity.name = %q; want MOM", identity["name"])
 	}
-}
+	if _, ok := identity["tagline"].(string); !ok {
+		t.Fatal("identity.tagline missing")
+	}
+	for _, field := range []string{"role", "voice", "stance"} {
+		if _, ok := identity[field]; ok {
+			t.Fatalf("identity should not include %q", field)
+		}
+	}
 
-func TestMomStatusConstraintsLoaded(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
-
-	constraints, ok := payload["constraints"].([]any)
+	routing, ok := payload["routing"].(map[string]any)
 	if !ok {
-		t.Fatalf("constraints is not an array: %T", payload["constraints"])
+		t.Fatalf("routing is not a map: %T", payload["routing"])
 	}
-	if len(constraints) < 2 {
-		t.Errorf("expected at least 2 constraints, got %d", len(constraints))
-	}
-
-	ids := make(map[string]bool)
-	for _, raw := range constraints {
-		c, ok := raw.(map[string]any)
-		if !ok {
-			t.Fatal("constraint item not a map")
-		}
-		id, _ := c["id"].(string)
-		if id == "" {
-			t.Error("constraint item missing id")
-		}
-		ids[id] = true
-		if _, ok := c["summary"]; !ok {
-			t.Errorf("constraint %q missing summary field", id)
-		}
-		if _, ok := c["path"]; !ok {
-			t.Errorf("constraint %q missing path field", id)
-		}
+	joinedRouting := strings.ToLower(strings.Join([]string{
+		fmtString(routing["preferred"]),
+		fmtString(routing["mcp"]),
+	}, " "))
+	if !strings.Contains(joinedRouting, "cli") || !strings.Contains(joinedRouting, "skills") || !strings.Contains(joinedRouting, "fallback") {
+		t.Fatalf("routing should prefer skills/CLI and name MCP fallback: %#v", routing)
 	}
 
-	for _, expectedID := range []string{"anti-hallucination", "escalation-triggers"} {
-		if !ids[expectedID] {
-			t.Errorf("constraint %q not found in response", expectedID)
-		}
-	}
-}
-
-func TestMomStatusSkillsLoaded(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
-
-	skills, ok := payload["skills"].([]any)
+	session, ok := payload["session"].(map[string]any)
 	if !ok {
-		t.Fatalf("skills is not an array: %T", payload["skills"])
+		t.Fatalf("session is not a map: %T", payload["session"])
 	}
-	if len(skills) < 1 {
-		t.Errorf("expected at least 1 skill, got %d", len(skills))
+	if cwd, _ := session["cwd"].(string); cwd == "" {
+		t.Fatal("session.cwd missing")
 	}
-
-	found := false
-	for _, raw := range skills {
-		s, ok := raw.(map[string]any)
-		if !ok {
-			t.Fatal("skill item not a map")
-		}
-		id, _ := s["id"].(string)
-		if id == "" {
-			t.Error("skill item missing id")
-		}
-		if _, ok := s["summary"]; !ok {
-			t.Errorf("skill %q missing summary field", id)
-		}
-		if _, ok := s["path"]; !ok {
-			t.Errorf("skill %q missing path field", id)
-		}
-		if id == "session-wrap-up" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("skill session-wrap-up not found in response")
-	}
-}
-
-func TestMomStatusVaultState(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
 
 	vs, ok := payload["vault_state"].(map[string]any)
 	if !ok {
 		t.Fatalf("vault_state is not a map: %T", payload["vault_state"])
 	}
-
-	// scopes must be an array.
-	scopes, ok := vs["scopes"].([]any)
-	if !ok {
-		t.Fatalf("vault_state.scopes is not an array: %T", vs["scopes"])
+	for _, key := range []string{"path", "total_memories", "landmarks", "record_mode", "watcher"} {
+		if _, ok := vs[key]; !ok {
+			t.Fatalf("vault_state.%s missing", key)
+		}
 	}
-	if len(scopes) == 0 {
-		t.Error("vault_state.scopes is empty")
-	}
-
-	// total_memories must be >= 1 (we wrote one memory doc in setup).
-	totalRaw, ok := vs["total_memories"]
-	if !ok {
-		t.Fatal("vault_state.total_memories missing")
-	}
-	total, ok := totalRaw.(float64)
-	if !ok {
-		t.Fatalf("vault_state.total_memories not a number: %T", totalRaw)
-	}
-	if total < 1 {
-		t.Errorf("vault_state.total_memories = %v; want >= 1", total)
-	}
-
-	// record_mode must be "continuous".
 	if vs["record_mode"] != "continuous" {
-		t.Errorf("vault_state.record_mode = %v; want continuous", vs["record_mode"])
+		t.Fatalf("vault_state.record_mode = %v; want continuous", vs["record_mode"])
+	}
+
+	skills, ok := payload["skills"].([]any)
+	if !ok {
+		t.Fatalf("skills is not an array: %T", payload["skills"])
+	}
+	seen := map[string]bool{}
+	for _, raw := range skills {
+		s, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("skill item not a map: %T", raw)
+		}
+		name, _ := s["command"].(string)
+		seen[name] = true
+	}
+	for _, want := range []string{"/mom-status", "/mom-recall", "/mom-wrap-up"} {
+		if !seen[want] {
+			t.Fatalf("mom_status skills missing %s: %#v", want, skills)
+		}
+	}
+
+	text, _ := json.Marshal(payload)
+	legacyWriteTool := "mom" + "_" + "record"
+	if strings.Contains(string(text), legacyWriteTool) {
+		t.Fatalf("mom_status should not mention %s", legacyWriteTool)
 	}
 }
 
-func TestMomStatusModes(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
-
-	modes, ok := payload["modes"].(map[string]any)
-	if !ok {
-		t.Fatalf("modes is not a map: %T", payload["modes"])
-	}
-	lang, _ := modes["language"].(string)
-	if lang == "" {
-		t.Error("modes.language missing or empty")
-	}
-	if !strings.Contains(lang, "## Language:") {
-		t.Errorf("modes.language should contain full rules, got: %s", lang[:min(len(lang), 80)])
-	}
-	comm, _ := modes["communication"].(string)
-	if comm == "" {
-		t.Error("modes.communication missing or empty")
-	}
-	if !strings.Contains(comm, "## Communication mode:") {
-		t.Errorf("modes.communication should contain full rules, got: %s", comm[:min(len(comm), 80)])
-	}
-	auto, _ := modes["autonomy"].(string)
-	if auto == "" {
-		t.Error("modes.autonomy missing or empty")
-	}
-	if !strings.Contains(auto, "## Autonomy level:") {
-		t.Errorf("modes.autonomy should contain full rules, got: %s", auto[:min(len(auto), 80)])
-	}
+func fmtString(v any) string {
+	s, _ := v.(string)
+	return s
 }
 
 func TestMomStatusInToolsList(t *testing.T) {
@@ -360,110 +196,5 @@ func TestMomStatusInToolsList(t *testing.T) {
 	}
 	if !found {
 		t.Error("mom_status not found in tools/list")
-	}
-}
-
-func TestMomStatusOperatingRules(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
-
-	rules, ok := payload["operating_rules"].(map[string]any)
-	if !ok {
-		t.Fatalf("operating_rules is not a map: %T", payload["operating_rules"])
-	}
-	for _, field := range []string{"on_start", "recall", "recording", "wrap_up"} {
-		if v, _ := rules[field].(string); v == "" {
-			t.Errorf("operating_rules.%s missing or empty", field)
-		}
-	}
-}
-
-func TestMomStatusBoundaries(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
-
-	boundaries, ok := payload["boundaries"].([]any)
-	if !ok {
-		t.Fatalf("boundaries is not an array: %T", payload["boundaries"])
-	}
-	if len(boundaries) == 0 {
-		t.Error("boundaries array is empty")
-	}
-}
-
-func TestMomStatusDocSchema(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
-
-	schema, ok := payload["doc_schema"].(string)
-	if !ok || schema == "" {
-		t.Errorf("doc_schema missing or not a string: %T %v", payload["doc_schema"], payload["doc_schema"])
-	}
-}
-
-func TestMomStatusNoConstraintsDir(t *testing.T) {
-	// mom_status must not fail when central constraints/ is absent.
-	leoDir := newStatusTestDir(t)
-	centralDir, err := centralvault.Dir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.RemoveAll(filepath.Join(centralDir, "constraints")); err != nil {
-		t.Fatal(err)
-	}
-
-	payload := callMomStatus(t, leoDir)
-
-	constraints, ok := payload["constraints"].([]any)
-	if !ok {
-		t.Fatalf("constraints is not an array: %T", payload["constraints"])
-	}
-	// No constraints dir → empty array is fine.
-	_ = constraints
-}
-
-func TestMomStatusNoSkillsDir(t *testing.T) {
-	// mom_status must not fail when central skills/ is absent.
-	leoDir := newStatusTestDir(t)
-	centralDir, err := centralvault.Dir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.RemoveAll(filepath.Join(centralDir, "skills")); err != nil {
-		t.Fatal(err)
-	}
-
-	payload := callMomStatus(t, leoDir)
-
-	skills, ok := payload["skills"].([]any)
-	if !ok {
-		t.Fatalf("skills is not an array: %T", payload["skills"])
-	}
-	_ = skills
-}
-
-func TestMomStatusTextContainsRequiredStrings(t *testing.T) {
-	leoDir := newStatusTestDir(t)
-	inW, outR, _ := runServer(t, leoDir)
-	defer inW.Close()
-
-	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
-	readResponse(t, outR)
-
-	sendRequest(t, inW, "tools/call", 2, map[string]any{
-		"name":      "mom_status",
-		"arguments": map[string]any{},
-	})
-	resp := readResponse(t, outR)
-
-	result, _ := resp["result"].(map[string]any)
-	content, _ := result["content"].([]any)
-	first, _ := content[0].(map[string]any)
-	text, _ := first["text"].(string)
-
-	for _, want := range []string{"MOM", "Memory Oriented Machine", "continuous"} {
-		if !strings.Contains(text, want) {
-			t.Errorf("mom_status text does not contain %q", want)
-		}
 	}
 }


### PR DESCRIPTION
## Summary
- shrink `mom_status` to a compact startup handshake
- align `mom status` with central vault status and watcher state
- update generated context files to prefer skills/CLI with MCP fallback
- remove legacy constraints/skills/modes/tool descriptions from status output

## Validation
- `/tdd` red-green-refactor loop
- review/refactor pass
- security review: no high-confidence findings
- `go test ./...`
- manual smoke: local status + MCP `mom_status`