### PR TITLE
Tighten release issue cleanups

### DIFF
--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -227,6 +227,15 @@ func upgradeSingleDir(cmd *cobra.Command, projectRoot string, dryRun bool) error
 			addAction(action.symbol, action.desc)
 		}
 
+		cleanedHooks, err := removeDeadHookCommands(projectRoot, dryRun)
+		if err != nil {
+			phase1Err = err
+			return
+		}
+		for _, action := range cleanedHooks {
+			addAction(action.symbol, action.desc)
+		}
+
 		if showSpinner {
 			time.Sleep(500 * time.Millisecond)
 		}
@@ -509,6 +518,118 @@ func removeKnownGeneratedCentralDocs(leoDir string, dryRun bool) ([]upgradeActio
 		actions = append(actions, upgradeAction{"✔", fmt.Sprintf("generated %s %s removed", doc.Kind, doc.Name)})
 	}
 	return actions, nil
+}
+
+func removeDeadHookCommands(projectRoot string, dryRun bool) ([]upgradeAction, error) {
+	paths := []string{
+		filepath.Join(projectRoot, ".claude", "settings.json"),
+		filepath.Join(projectRoot, ".codex", "hooks.json"),
+		filepath.Join(projectRoot, ".windsurf", "hooks.json"),
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths,
+			filepath.Join(home, ".claude", "settings.json"),
+			filepath.Join(home, ".codex", "hooks.json"),
+			filepath.Join(home, ".codeium", "windsurf", "hooks.json"),
+		)
+	}
+
+	seen := map[string]bool{}
+	var actions []upgradeAction
+	for _, path := range paths {
+		clean := filepath.Clean(path)
+		if seen[clean] {
+			continue
+		}
+		seen[clean] = true
+		changed, err := removeDeadHookCommandsFromFile(clean, dryRun)
+		if err != nil {
+			actions = append(actions, upgradeAction{"⚠", fmt.Sprintf("dead hook cleanup skipped for %s: %v", clean, err)})
+			continue
+		}
+		if changed {
+			actions = append(actions, upgradeAction{"✔", fmt.Sprintf("dead hook entries removed from %s", clean)})
+		}
+	}
+	return actions, nil
+}
+
+func removeDeadHookCommandsFromFile(path string, dryRun bool) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading hook config %s: %w", path, err)
+	}
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false, fmt.Errorf("parsing hook config %s: %w", path, err)
+	}
+	cleaned, keep, changed := stripDeadHookEntries(root)
+	if !keep {
+		cleaned = map[string]any{}
+	}
+	if !changed {
+		return false, nil
+	}
+	if dryRun {
+		return true, nil
+	}
+	out, err := json.MarshalIndent(cleaned, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshaling hook config %s: %w", path, err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(path, out, 0644); err != nil {
+		return false, fmt.Errorf("writing hook config %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func stripDeadHookEntries(v any) (any, bool, bool) {
+	switch x := v.(type) {
+	case map[string]any:
+		if command, ok := x["command"].(string); ok && isDeadHookCommand(command) {
+			return nil, false, true
+		}
+		changed := false
+		for k, child := range x {
+			cleaned, keep, childChanged := stripDeadHookEntries(child)
+			if childChanged {
+				changed = true
+			}
+			if keep {
+				x[k] = cleaned
+			} else {
+				delete(x, k)
+			}
+		}
+		return x, true, changed
+	case []any:
+		out := make([]any, 0, len(x))
+		changed := false
+		for _, child := range x {
+			cleaned, keep, childChanged := stripDeadHookEntries(child)
+			if childChanged {
+				changed = true
+			}
+			if keep {
+				out = append(out, cleaned)
+			}
+		}
+		if len(out) != len(x) {
+			changed = true
+		}
+		return out, true, changed
+	default:
+		return v, true, false
+	}
+}
+
+func isDeadHookCommand(command string) bool {
+	fields := strings.Fields(command)
+	return len(fields) >= 2 && fields[0] == "mom" && (fields[1] == "draft" || fields[1] == "record")
 }
 
 // migrateKBLayout detects a legacy .mom/kb/ layout and promotes each subdirectory

--- a/cli/internal/cmd/upgrade_test.go
+++ b/cli/internal/cmd/upgrade_test.go
@@ -945,6 +945,58 @@ func TestUpgradeCmd_InstallsSkillsForConfiguredHarnesses(t *testing.T) {
 	}
 }
 
+func TestUpgradeCmd_RemovesDeadHookCommands(t *testing.T) {
+	resetUpgradeFlags(t)
+	dir := setupLegacyProject(t)
+
+	claudeSettings := filepath.Join(dir, ".claude", "settings.json")
+	codexHooks := filepath.Join(dir, ".codex", "hooks.json")
+	windsurfHooks := filepath.Join(dir, ".windsurf", "hooks.json")
+	for _, p := range []string{claudeSettings, codexHooks, windsurfHooks} {
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(claudeSettings, []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"mom draft"},{"type":"command","command":"mom watch --sweep"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"mom record"}]}]}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(codexHooks, []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"mom record --session old"},{"type":"command","command":"mom watch --sweep"}]}]}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(windsurfHooks, []byte(`{"hooks":{"post_cascade_response":[{"command":"mom draft"},{"command":"mom watch --sweep"}]}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"upgrade"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("upgrade failed: %v\noutput:\n%s", err, buf.String())
+	}
+	for _, path := range []string{claudeSettings, codexHooks, windsurfHooks} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		text := string(data)
+		if strings.Contains(text, "mom draft") || strings.Contains(text, "mom record") {
+			t.Fatalf("dead hook command survived in %s:\n%s", path, text)
+		}
+		if !strings.Contains(text, "mom watch --sweep") {
+			t.Fatalf("active watch hook was removed from %s:\n%s", path, text)
+		}
+	}
+	if !strings.Contains(buf.String(), "dead hook entries removed") {
+		t.Fatalf("upgrade output should mention dead hook cleanup:\n%s", buf.String())
+	}
+}
+
 func TestUpgradeCmd_DryRunPrintsPlannedSkillsInstallCommands(t *testing.T) {
 	resetUpgradeFlags(t)
 	dir := setupLegacyProject(t)

--- a/cli/internal/lens/server.go
+++ b/cli/internal/lens/server.go
@@ -112,6 +112,7 @@ type sessionBuild struct {
 	ended           time.Time
 	interactions    int
 	tools           map[string]int
+	toolDetails     map[string]map[string]int
 	totalTokens     int
 	costUSD         float64
 	provider        string
@@ -133,7 +134,7 @@ func (s *Server) loadSessionData() (map[string]sessionData, int, error) {
 	get := func(id string) *sessionBuild {
 		b := builds[id]
 		if b == nil {
-			b = &sessionBuild{id: id, tools: map[string]int{}}
+			b = &sessionBuild{id: id, tools: map[string]int{}, toolDetails: map[string]map[string]int{}}
 			builds[id] = b
 		}
 		return b
@@ -170,7 +171,7 @@ func (s *Server) loadSessionData() (map[string]sessionData, int, error) {
 		if memories == nil {
 			memories = []MemoryItem{}
 		}
-		toolCalls, toolsTotal := toolGroups(b.tools)
+		toolCalls, toolsTotal := toolGroups(b.tools, b.toolDetails)
 		curated := 0
 		for _, m := range memories {
 			if m.PromotionState == "curated" || m.Landmark {
@@ -242,6 +243,7 @@ func applyTurnObserved(b *sessionBuild, payload map[string]any) {
 	if !b.hasTurnObserved {
 		b.interactions = 0
 		b.tools = map[string]int{}
+		b.toolDetails = map[string]map[string]int{}
 		b.totalTokens = 0
 		b.costUSD = 0
 	}
@@ -255,9 +257,18 @@ func applyTurnObserved(b *sessionBuild, payload map[string]any) {
 	if provider, _ := payload["provider"].(string); provider != "" {
 		b.provider = provider
 	}
-	for _, cat := range stringSlice(payload["tool_categories"]) {
-		if cat != "" {
-			b.tools[cat]++
+	cats := stringSlice(payload["tool_categories"])
+	names := stringSlice(payload["tool_names"])
+	for i, cat := range cats {
+		if cat == "" {
+			continue
+		}
+		b.tools[cat]++
+		if i < len(names) && names[i] != "" {
+			if b.toolDetails[cat] == nil {
+				b.toolDetails[cat] = map[string]int{}
+			}
+			b.toolDetails[cat][names[i]]++
 		}
 	}
 	if usage, ok := payload["usage"].(map[string]any); ok {
@@ -347,14 +358,18 @@ func floatValue(v any) float64 {
 	}
 }
 
-func toolGroups(tools map[string]int) (map[string]ToolGroup, int) {
+func toolGroups(tools map[string]int, details map[string]map[string]int) (map[string]ToolGroup, int) {
 	out := map[string]ToolGroup{}
 	total := 0
 	for cat, n := range tools {
 		if n <= 0 {
 			continue
 		}
-		out[cat] = ToolGroup{Total: n, Detail: map[string]int{}}
+		detail := details[cat]
+		if detail == nil {
+			detail = map[string]int{}
+		}
+		out[cat] = ToolGroup{Total: n, Detail: detail}
 		total += n
 	}
 	return out, total

--- a/cli/internal/lens/server_test.go
+++ b/cli/internal/lens/server_test.go
@@ -113,7 +113,8 @@ func TestSessions_RenderFromCentralTurnObserved(t *testing.T) {
 	at := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 	insertTurn(t, lib, "s-new", "user", at, nil)
 	insertTurn(t, lib, "s-new", "assistant", at.Add(time.Minute), map[string]any{
-		"tool_categories": []any{"codebase_read", "system"},
+		"tool_categories": []any{"codebase_read", "mom_cli"},
+		"tool_names":      []any{"Read", "mom recall"},
 		"usage":           map[string]any{"total_tokens": float64(42), "cost_usd": 0.02},
 		"model":           "claude-sonnet",
 		"provider":        "anthropic",
@@ -125,6 +126,10 @@ func TestSessions_RenderFromCentralTurnObserved(t *testing.T) {
 	}
 	if got[0].SessionID != "s-new" || got[0].Interactions != 1 || got[0].ToolsTotal != 2 || got[0].TotalTokens != 42 || got[0].ScopeLabel != "central" {
 		t.Fatalf("summary = %+v", got[0])
+	}
+	detail := fetchDetail(t, newTestServer(t, lib).Handler(), "s-new")
+	if detail.ToolCalls["mom_cli"].Detail["mom recall"] != 1 || detail.ToolCalls["codebase_read"].Detail["Read"] != 1 {
+		t.Fatalf("tool detail missing safe tool names: %+v", detail.ToolCalls)
 	}
 }
 

--- a/cli/internal/logbook/turn_observed_test.go
+++ b/cli/internal/logbook/turn_observed_test.go
@@ -15,8 +15,8 @@ import (
 // TestSubscribeTurnObserved_PersistsMetadataProjection locks the
 // privacy contract: when a turn.observed event arrives with raw text
 // and tool inputs in the payload, the persisted op_events row contains
-// ONLY role, tool_categories, usage, model, provider. No text. No
-// tool_call inputs. No tool_call names.
+// ONLY role, tool_categories, privacy-safe tool_names, usage, model,
+// provider. No text. No tool_call inputs.
 //
 // This is the most important test in PR 1 — it's the lock that
 // prevents Drafter's redaction promise from being undone by the
@@ -47,14 +47,16 @@ func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
 			"text":       "I'll deploy now using AKIA1234567890ABCDEF",
 			"tool_calls": []map[string]any{
 				{
-					"name":     "Read",
-					"category": "codebase_read",
-					"input":    map[string]any{"file_path": "/Users/x/secrets.env"},
+					"name":      "Read",
+					"safe_name": "Read",
+					"category":  "codebase_read",
+					"input":     map[string]any{"file_path": "/Users/x/secrets.env"},
 				},
 				{
-					"name":     "Bash",
-					"category": "system",
-					"input":    map[string]any{"command": "echo AKIA1234567890ABCDEF"},
+					"name":      "Bash",
+					"safe_name": "mom recall",
+					"category":  "mom_cli",
+					"input":     map[string]any{"command": "mom recall AKIA1234567890ABCDEF"},
 				},
 			},
 			"usage": map[string]any{
@@ -112,11 +114,23 @@ func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
 	if len(cats) != 2 {
 		t.Errorf("tool_categories len = %d, want 2 (one per tool_call)", len(cats))
 	}
-	for i, want := range []string{"codebase_read", "system"} {
+	for i, want := range []string{"codebase_read", "mom_cli"} {
 		if i < len(cats) {
 			got, _ := cats[i].(string)
 			if got != want {
 				t.Errorf("tool_categories[%d] = %v, want %q", i, cats[i], want)
+			}
+		}
+	}
+	names, _ := row.Payload["tool_names"].([]any)
+	if len(names) != 2 {
+		t.Errorf("tool_names len = %d, want 2 (one per tool_call)", len(names))
+	}
+	for i, want := range []string{"Read", "mom recall"} {
+		if i < len(names) {
+			got, _ := names[i].(string)
+			if got != want {
+				t.Errorf("tool_names[%d] = %v, want %q", i, names[i], want)
 			}
 		}
 	}
@@ -138,7 +152,7 @@ func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
 		t.Errorf("payload leaked the Bash command:\n%s", dump)
 	}
 
-	// tool_calls and tool_call NAMES should NOT survive the projection.
+	// tool_calls should NOT survive the projection; only safe tool_names do.
 	if _, present := row.Payload["tool_calls"]; present {
 		t.Error("tool_calls should not appear in the projection")
 	}

--- a/cli/internal/logbook/worker.go
+++ b/cli/internal/logbook/worker.go
@@ -74,6 +74,7 @@ func (w *Worker) Subscribe(bus *herald.Bus, eventType herald.EventType) func() {
 //
 //	role             ("user" | "assistant")
 //	tool_categories  ([]string, derived from tool_calls[].category)
+//	tool_names       ([]string, privacy-safe tool names only, no args)
 //	usage            (token counts only, no text)
 //	model, provider, harness
 //
@@ -135,6 +136,9 @@ func projectTurnObserved(payload map[string]any) (map[string]any, time.Time) {
 	if cats := extractToolCategories(payload["tool_calls"]); len(cats) > 0 {
 		out["tool_categories"] = cats
 	}
+	if names := extractToolNames(payload["tool_calls"]); len(names) > 0 {
+		out["tool_names"] = names
+	}
 
 	// Usage map: keep numeric fields only.
 	if usage, ok := payload["usage"].(map[string]any); ok && usage != nil {
@@ -153,12 +157,20 @@ func projectTurnObserved(payload map[string]any) (map[string]any, time.Time) {
 }
 
 func extractToolCategories(v any) []string {
+	return extractToolStringField(v, "category")
+}
+
+func extractToolNames(v any) []string {
+	return extractToolStringField(v, "safe_name")
+}
+
+func extractToolStringField(v any, field string) []string {
 	switch tcs := v.(type) {
 	case []map[string]any:
 		out := make([]string, 0, len(tcs))
 		for _, tc := range tcs {
-			if cat, _ := tc["category"].(string); cat != "" {
-				out = append(out, cat)
+			if s, _ := tc[field].(string); s != "" {
+				out = append(out, s)
 			}
 		}
 		return out
@@ -169,8 +181,8 @@ func extractToolCategories(v any) []string {
 			if !ok {
 				continue
 			}
-			if cat, _ := tc["category"].(string); cat != "" {
-				out = append(out, cat)
+			if s, _ := tc[field].(string); s != "" {
+				out = append(out, s)
 			}
 		}
 		return out

--- a/cli/internal/logbook/worker.go
+++ b/cli/internal/logbook/worker.go
@@ -161,7 +161,7 @@ func extractToolCategories(v any) []string {
 }
 
 func extractToolNames(v any) []string {
-	return extractToolStringField(v, "safe_name")
+	return extractAlignedToolNames(v)
 }
 
 func extractToolStringField(v any, field string) []string {
@@ -186,6 +186,43 @@ func extractToolStringField(v any, field string) []string {
 			}
 		}
 		return out
+	}
+	return nil
+}
+
+func extractAlignedToolNames(v any) []string {
+	switch tcs := v.(type) {
+	case []map[string]any:
+		out := make([]string, 0, len(tcs))
+		hasAny := false
+		for _, tc := range tcs {
+			s, _ := tc["safe_name"].(string)
+			if s != "" {
+				hasAny = true
+			}
+			out = append(out, s)
+		}
+		if hasAny {
+			return out
+		}
+	case []any:
+		out := make([]string, 0, len(tcs))
+		hasAny := false
+		for _, item := range tcs {
+			tc, ok := item.(map[string]any)
+			if !ok {
+				out = append(out, "")
+				continue
+			}
+			s, _ := tc["safe_name"].(string)
+			if s != "" {
+				hasAny = true
+			}
+			out = append(out, s)
+		}
+		if hasAny {
+			return out
+		}
 	}
 	return nil
 }

--- a/cli/internal/mcp/server_test.go
+++ b/cli/internal/mcp/server_test.go
@@ -234,6 +234,44 @@ func TestToolsCallMomRecallUsesCentralFinder(t *testing.T) {
 	}
 }
 
+func TestToolsCallMomRecallReturnsCompactIndex(t *testing.T) {
+	leoDir := newTestLeoDir(t)
+	insertCentralMemory(t, "Authentication pattern for JWT", strings.Repeat("Use JWT with RS256. ", 30), []string{"auth", "security"})
+	inW, outR, _ := runServer(t, leoDir)
+	defer inW.Close()
+
+	sendRequest(t, inW, "initialize", 1, map[string]any{"protocolVersion": "2024-11-05"})
+	readResponse(t, outR)
+	sendRequest(t, inW, "tools/call", 2, map[string]any{"name": "mom_recall", "arguments": map[string]any{"query": "JWT"}})
+	resp := readResponse(t, outR)
+
+	result := resp["result"].(map[string]any)
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	if strings.Contains(text, "\n  ") {
+		t.Fatalf("mom_recall should return compact JSON, got: %s", text)
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(text), &rows); err != nil {
+		t.Fatalf("mom_recall JSON parse failed: %v\n%s", err, text)
+	}
+	if len(rows) == 0 {
+		t.Fatal("mom_recall returned no rows")
+	}
+	if _, ok := rows[0]["content"]; ok {
+		t.Fatalf("mom_recall compact index must not include full content: %#v", rows[0])
+	}
+	if _, ok := rows[0]["Content"]; ok {
+		t.Fatalf("mom_recall compact index must not include full Content: %#v", rows[0])
+	}
+	if rows[0]["summary"] == "" || rows[0]["snippet"] == "" || rows[0]["id"] == "" {
+		t.Fatalf("mom_recall compact row missing id/summary/snippet: %#v", rows[0])
+	}
+	if len([]rune(rows[0]["snippet"].(string))) > 161 {
+		t.Fatalf("snippet too long: %q", rows[0]["snippet"])
+	}
+}
+
 func TestToolsCallMomRecallRequiresQuery(t *testing.T) {
 	leoDir := newTestLeoDir(t)
 	inW, outR, _ := runServer(t, leoDir)

--- a/cli/internal/mcp/status.go
+++ b/cli/internal/mcp/status.go
@@ -71,7 +71,7 @@ func (s *Server) toolMomStatus() (toolCallResult, error) {
 		payload.Health.Status = "degraded"
 	}
 
-	text, err := json.MarshalIndent(payload, "", "  ")
+	text, err := json.Marshal(payload)
 	if err != nil {
 		return toolCallResult{}, err
 	}

--- a/cli/internal/mcp/status_test.go
+++ b/cli/internal/mcp/status_test.go
@@ -38,7 +38,7 @@ communication:
 }
 
 // callMomStatus sends the mom_status tool call and returns the parsed JSON payload.
-func callMomStatus(t *testing.T, leoDir string) map[string]any {
+func callMomStatusText(t *testing.T, leoDir string) string {
 	t.Helper()
 	inW, outR, _ := runServer(t, leoDir)
 	defer inW.Close()
@@ -71,6 +71,12 @@ func callMomStatus(t *testing.T, leoDir string) map[string]any {
 	if text == "" {
 		t.Fatal("text content is empty")
 	}
+	return text
+}
+
+func callMomStatus(t *testing.T, leoDir string) map[string]any {
+	t.Helper()
+	text := callMomStatusText(t, leoDir)
 	var payload map[string]any
 	if err := json.Unmarshal([]byte(text), &payload); err != nil {
 		t.Fatalf("parsing mom_status text as JSON: %v\ntext: %s", err, text)
@@ -80,7 +86,14 @@ func callMomStatus(t *testing.T, leoDir string) map[string]any {
 
 func TestMomStatusCompactShape(t *testing.T) {
 	leoDir := newStatusTestDir(t)
-	payload := callMomStatus(t, leoDir)
+	text := callMomStatusText(t, leoDir)
+	if strings.Contains(text, "\n  ") {
+		t.Fatalf("mom_status should return compact JSON, got: %s", text)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("parsing mom_status text as JSON: %v\ntext: %s", err, text)
+	}
 
 	for _, key := range []string{"identity", "health", "routing", "session", "vault_state", "skills"} {
 		if _, ok := payload[key]; !ok {
@@ -161,9 +174,9 @@ func TestMomStatusCompactShape(t *testing.T) {
 		}
 	}
 
-	text, _ := json.Marshal(payload)
+	payloadText, _ := json.Marshal(payload)
 	legacyWriteTool := "mom" + "_" + "record"
-	if strings.Contains(string(text), legacyWriteTool) {
+	if strings.Contains(string(payloadText), legacyWriteTool) {
 		t.Fatalf("mom_status should not mention %s", legacyWriteTool)
 	}
 }

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -161,7 +161,7 @@ func (s *Server) toolMomGet(args map[string]any) (toolCallResult, error) {
 	if err != nil {
 		return toolCallResult{}, fmt.Errorf("mom_get: %w", err)
 	}
-	text, _ := json.MarshalIndent(mem, "", "  ")
+	text, _ := json.Marshal(mem)
 	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
 }
 
@@ -178,7 +178,7 @@ func (s *Server) toolMomLandmarks(args map[string]any) (toolCallResult, error) {
 	if len(items) == 0 {
 		return toolCallResult{Content: []toolContent{{Type: "text", Text: "No landmarks found."}}}, nil
 	}
-	text, _ := json.MarshalIndent(items, "", "  ")
+	text, _ := json.Marshal(items)
 	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
 }
 
@@ -203,8 +203,50 @@ func (s *Server) toolMomRecall(args map[string]any) (toolCallResult, error) {
 	if len(results) == 0 {
 		return toolCallResult{Content: []toolContent{{Type: "text", Text: "No memories matched."}}}, nil
 	}
-	text, _ := json.MarshalIndent(results, "", "  ")
+	text, _ := json.Marshal(compactRecallResults(results))
 	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(text)}}}, nil
+}
+
+type recallIndexItem struct {
+	ID             string  `json:"id"`
+	Type           string  `json:"type"`
+	Summary        string  `json:"summary,omitempty"`
+	Snippet        string  `json:"snippet,omitempty"`
+	SessionID      string  `json:"session_id,omitempty"`
+	PromotionState string  `json:"promotion_state"`
+	Score          float64 `json:"score"`
+	Tier           string  `json:"tier"`
+}
+
+func compactRecallResults(results []finder.Result) []recallIndexItem {
+	items := make([]recallIndexItem, 0, len(results))
+	for _, r := range results {
+		items = append(items, recallIndexItem{
+			ID:             r.ID,
+			Type:           r.Type,
+			Summary:        r.Summary,
+			Snippet:        contentSnippet(r.Content, 160),
+			SessionID:      r.SessionID,
+			PromotionState: r.PromotionState,
+			Score:          r.Score,
+			Tier:           r.Tier,
+		})
+	}
+	return items
+}
+
+func contentSnippet(content string, limit int) string {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(content), &raw); err != nil {
+		return ""
+	}
+	text, _ := raw["text"].(string)
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return string(runes[:limit]) + "…"
 }
 
 // --- Argument helpers ---

--- a/cli/internal/watcher/adapter_claude.go
+++ b/cli/internal/watcher/adapter_claude.go
@@ -191,10 +191,12 @@ func walkClaudeContent(content any) (string, []ToolCall) {
 				continue
 			}
 			input, _ := m["input"].(map[string]any)
+			category, safeName := CategorizeObservedToolCall(name, input)
 			tcs = append(tcs, ToolCall{
 				Name:     name,
+				SafeName: safeName,
 				Input:    input,
-				Category: CategorizeToolCall(name),
+				Category: category,
 			})
 		}
 	}

--- a/cli/internal/watcher/categorize.go
+++ b/cli/internal/watcher/categorize.go
@@ -54,8 +54,49 @@ func isMemoryTool(name string) bool {
 		name == "mom_get" || name == "mom_landmarks" || name == "mom_status"
 }
 
+// CategorizeObservedToolCall returns the Lens category and privacy-safe name
+// for one observed tool call. It may inspect raw shell command input while the
+// event is still on the in-process bus, but it returns only coarse metadata.
+func CategorizeObservedToolCall(toolName string, input map[string]any) (category, safeName string) {
+	name := NormalizeToolName(toolName)
+	if isShellTool(name) {
+		if momName := safeMomCLIName(input); momName != "" {
+			return "mom_cli", momName
+		}
+	}
+	return CategorizeToolCall(name), name
+}
+
 func isMomCLI(name string) bool {
 	return name == "mom_draft" || name == "mom_log"
+}
+
+func isShellTool(name string) bool {
+	return name == "Bash" || name == "bash" || name == "Shell" || name == "shell"
+}
+
+func safeMomCLIName(input map[string]any) string {
+	if input == nil {
+		return ""
+	}
+	command, _ := input["command"].(string)
+	fields := strings.Fields(strings.TrimSpace(command))
+	for len(fields) > 0 && strings.Contains(fields[0], "=") && !strings.HasPrefix(fields[0], "-") {
+		fields = fields[1:]
+	}
+	if len(fields) == 0 || fields[0] != "mom" {
+		return ""
+	}
+	if len(fields) == 1 || strings.HasPrefix(fields[1], "-") {
+		return "mom"
+	}
+	sub := fields[1]
+	for _, r := range sub {
+		if (r < 'a' || r > 'z') && r != '-' {
+			return "mom"
+		}
+	}
+	return "mom " + sub
 }
 
 func isCodebaseRead(name string) bool {

--- a/cli/internal/watcher/categorize.go
+++ b/cli/internal/watcher/categorize.go
@@ -81,22 +81,69 @@ func safeMomCLIName(input map[string]any) string {
 	}
 	command, _ := input["command"].(string)
 	fields := strings.Fields(strings.TrimSpace(command))
-	for len(fields) > 0 && strings.Contains(fields[0], "=") && !strings.HasPrefix(fields[0], "-") {
-		fields = fields[1:]
-	}
-	if len(fields) == 0 || fields[0] != "mom" {
-		return ""
-	}
-	if len(fields) == 1 || strings.HasPrefix(fields[1], "-") {
-		return "mom"
-	}
-	sub := fields[1]
-	for _, r := range sub {
-		if (r < 'a' || r > 'z') && r != '-' {
+	atCommandStart := true
+	for i := 0; i < len(fields); i++ {
+		field := strings.Trim(fields[i], "'")
+		if isCommandSeparator(field) {
+			atCommandStart = true
+			continue
+		}
+		if !atCommandStart {
+			continue
+		}
+		if field == "env" {
+			continue
+		}
+		if isEnvAssignment(field) {
+			continue
+		}
+		if field != "mom" {
+			atCommandStart = false
+			continue
+		}
+		if i+1 >= len(fields) {
 			return "mom"
 		}
+		sub := strings.Trim(fields[i+1], "'")
+		if sub == "" || strings.HasPrefix(sub, "-") || isCommandSeparator(sub) {
+			return "mom"
+		}
+		return "mom " + safeSubcommandName(sub)
 	}
-	return "mom " + sub
+	return ""
+}
+
+func isCommandSeparator(field string) bool {
+	return field == "&&" || field == ";" || field == "||"
+}
+
+func isEnvAssignment(field string) bool {
+	if strings.HasPrefix(field, "-") {
+		return false
+	}
+	idx := strings.Index(field, "=")
+	if idx <= 0 {
+		return false
+	}
+	for _, r := range field[:idx] {
+		if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func safeSubcommandName(sub string) string {
+	var b strings.Builder
+	for _, r := range sub {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return "unknown"
+	}
+	return b.String()
 }
 
 func isCodebaseRead(name string) bool {

--- a/cli/internal/watcher/categorize_test.go
+++ b/cli/internal/watcher/categorize_test.go
@@ -46,8 +46,14 @@ func TestCategorizeObservedToolCall_DetectsMomCLI(t *testing.T) {
 		wantSafe string
 	}{
 		{"Bash", map[string]any{"command": "mom recall release blocker details"}, "mom_cli", "mom recall"},
+		{"Bash", map[string]any{"command": "mom status"}, "mom_cli", "mom status"},
+		{"Bash", map[string]any{"command": "mom curate abc --type semantic --summary secret details"}, "mom_cli", "mom curate"},
+		{"Bash", map[string]any{"command": "mom upgrade --dry-run"}, "mom_cli", "mom upgrade"},
+		{"Bash", map[string]any{"command": "mom --version"}, "mom_cli", "mom"},
 		{"Bash", map[string]any{"command": "MOM_VAULT=/tmp/mom.db mom drafts --since 1h"}, "mom_cli", "mom drafts"},
-		{"Bash", map[string]any{"command": "echo mom recall is not first"}, "system", "Bash"},
+		{"Bash", map[string]any{"command": "env MOM_VAULT=/tmp/mom.db mom lens"}, "mom_cli", "mom lens"},
+		{"Bash", map[string]any{"command": "cd /tmp && mom doctor"}, "mom_cli", "mom doctor"},
+		{"Bash", map[string]any{"command": "echo mom recall is not executed"}, "system", "Bash"},
 		{"Read", map[string]any{"file_path": "CONTEXT.md"}, "codebase_read", "Read"},
 	}
 	for _, tc := range cases {

--- a/cli/internal/watcher/categorize_test.go
+++ b/cli/internal/watcher/categorize_test.go
@@ -38,12 +38,34 @@ func TestCategorizeToolCall(t *testing.T) {
 	}
 }
 
+func TestCategorizeObservedToolCall_DetectsMomCLI(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    map[string]any
+		wantCat  string
+		wantSafe string
+	}{
+		{"Bash", map[string]any{"command": "mom recall release blocker details"}, "mom_cli", "mom recall"},
+		{"Bash", map[string]any{"command": "MOM_VAULT=/tmp/mom.db mom drafts --since 1h"}, "mom_cli", "mom drafts"},
+		{"Bash", map[string]any{"command": "echo mom recall is not first"}, "system", "Bash"},
+		{"Read", map[string]any{"file_path": "CONTEXT.md"}, "codebase_read", "Read"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"/"+tc.wantSafe, func(t *testing.T) {
+			gotCat, gotSafe := CategorizeObservedToolCall(tc.name, tc.input)
+			if gotCat != tc.wantCat || gotSafe != tc.wantSafe {
+				t.Fatalf("CategorizeObservedToolCall() = (%q, %q), want (%q, %q)", gotCat, gotSafe, tc.wantCat, tc.wantSafe)
+			}
+		})
+	}
+}
+
 func TestNormalizeToolName(t *testing.T) {
 	cases := map[string]string{
 		"Read":                 "Read",
 		"mcp__mom__mom_recall": "mom_recall",
 		"mcp__github__create":  "create",
-		"mcp__":                "mcp__",     // malformed: no second separator
+		"mcp__":                "mcp__", // malformed: no second separator
 		"":                     "",
 	}
 	for in, want := range cases {

--- a/cli/internal/watcher/turn.go
+++ b/cli/internal/watcher/turn.go
@@ -30,11 +30,12 @@ type Turn struct {
 
 // ToolCall is one tool invocation observed in an assistant turn.
 // `Input` carries the raw tool arguments (file paths, shell commands,
-// etc.) for Drafter's filter pipeline. `Category` is pre-computed by
-// the adapter using CategorizeToolCall so Logbook's projection does
-// not need to look at tool names.
+// etc.) for Drafter's filter pipeline. `Category` and SafeName are
+// pre-computed by the adapter so Logbook can persist a privacy-safe
+// metadata projection without inspecting raw inputs.
 type ToolCall struct {
 	Name     string
+	SafeName string
 	Input    map[string]any
 	Category string // "mom_memory" | "mom_cli" | "codebase_read" | "codebase_write" | "system"
 }
@@ -71,6 +72,9 @@ func (t Turn) ToPayload() map[string]any {
 			m := map[string]any{
 				"name":     tc.Name,
 				"category": tc.Category,
+			}
+			if tc.SafeName != "" {
+				m["safe_name"] = tc.SafeName
 			}
 			if tc.Input != nil {
 				m["input"] = tc.Input


### PR DESCRIPTION
## Summary
- compact MCP tool responses for recall/get/landmarks
- remove stale dead hook commands during upgrade
- persist privacy-safe tool names for Lens accounting
- recognize MOM CLI subcommands from shell tool usage without storing args

## Validation
- go test ./...

## Release issues
- Addresses #135
- Addresses #277
- Supports cleanup for #220, #221, #251