### PR TITLE
Hide noisy skills install output

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -487,11 +487,8 @@ func installGlobalSkills(p *ux.Printer, harnesses []string) {
 			continue
 		}
 		args, command := skillsInstallCommand(agent)
-		if output, err := runExternalCommand("npx", args...); err != nil {
+		if _, err := runExternalCommand("npx", args...); err != nil {
 			p.Warnf("skills install %s → %s failed: %v", h, agent, err)
-			if len(output) > 0 {
-				p.Muted(strings.TrimSpace(string(output)))
-			}
 			p.Muted(fmt.Sprintf("Retry: mom init --force, or run: %s", command))
 			continue
 		}

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -354,6 +354,9 @@ func TestInitCmd_SkillsInstallFailureIsSoft(t *testing.T) {
 			t.Fatalf("output missing %q:\n%s", want, out)
 		}
 	}
+	if strings.Contains(out, "network unavailable") {
+		t.Fatalf("init output should hide noisy skills CLI output:\n%s", out)
+	}
 }
 
 func TestInitCmd_RuntimesFlagIsNotRegistered(t *testing.T) {

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -417,11 +417,8 @@ func installSkillsDuringUpgrade(harnesses []string, dryRun bool, addAction func(
 			addAction("+", "would run "+command)
 			continue
 		}
-		if output, err := runExternalCommand("npx", args...); err != nil {
+		if _, err := runExternalCommand("npx", args...); err != nil {
 			detail := fmt.Sprintf("skills install %s → %s failed: %v", h, agent, err)
-			if len(output) > 0 {
-				detail += ": " + strings.TrimSpace(string(output))
-			}
 			detail += fmt.Sprintf("; retry with mom upgrade, mom init --force, or run: %s", command)
 			addAction("⚠", detail)
 			continue

--- a/cli/internal/cmd/upgrade_test.go
+++ b/cli/internal/cmd/upgrade_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -994,6 +995,40 @@ func TestUpgradeCmd_RemovesDeadHookCommands(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "dead hook entries removed") {
 		t.Fatalf("upgrade output should mention dead hook cleanup:\n%s", buf.String())
+	}
+}
+
+func TestUpgradeCmd_SkillsInstallFailureHidesToolOutput(t *testing.T) {
+	resetUpgradeFlags(t)
+	dir := setupLegacyProject(t)
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	oldRunner := runExternalCommand
+	runExternalCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("npm warn exec installing skills\nSKILLS ASCII BANNER\nSource: https://github.com/momhq/mom.git"), fmt.Errorf("npx failed")
+	}
+	t.Cleanup(func() { runExternalCommand = oldRunner })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"upgrade"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("upgrade should soft-fail skills install, got: %v\noutput:\n%s", err, buf.String())
+	}
+	out := buf.String()
+	for _, want := range []string{"skills install", "mom upgrade", "mom init --force", "npx skills add momhq/mom -g -s '*' -a claude-code -y"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	for _, leak := range []string{"npm warn exec", "SKILLS ASCII BANNER", "Source: https://github.com/momhq/mom.git"} {
+		if strings.Contains(out, leak) {
+			t.Fatalf("upgrade output should hide noisy skills CLI output %q:\n%s", leak, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep skills install failures as soft failures
- hide captured `skills` CLI stdout/stderr on init/upgrade failure
- retain concise retry command output

## Validation
- go test ./internal/cmd
- go test ./...