### PR TITLE
Unify explicit record flow

### DIFF
--- a/cli/internal/adapters/harness/content.go
+++ b/cli/internal/adapters/harness/content.go
@@ -14,7 +14,7 @@ MOM remembers project decisions across sessions.
 
 At session start, call ` + "`mom_status`" + `.
 
-Prefer skills and CLI: /mom-status, /mom-recall, /mom-wrap-up. MCP fallback is for startup and discovery.
+Prefer skills and CLI: /mom-status, /mom-recall, /mom-wrap-up. For explicit "remember/save this" requests, pipe text to ` + "`mom record`" + ` through CLI; never invent session IDs, and omit ` + "`--session`" + ` unless you have a real runtime session ID. MCP fallback is for startup, discovery, or when CLI is unavailable.
 `
 }
 

--- a/cli/internal/adapters/harness/pi_assets/mom-tools.ts
+++ b/cli/internal/adapters/harness/pi_assets/mom-tools.ts
@@ -219,9 +219,15 @@ export default async function (pi: ExtensionAPI) {
 			label: name,
 			description: tool.description ?? `MOM tool: ${tool.name}`,
 			parameters: parameters as any,
-			async execute(_toolCallId, params) {
+			async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 				try {
-					const result = await client.callTool(tool.name, params ?? {});
+					const args = params ?? {};
+					if (tool.name === "mom_record") {
+						// Pi exposes the real runtime session ID to extensions. Always stamp it
+						// here so the model cannot accidentally invent a fake session_id.
+						args.session_id = ctx.sessionManager.getSessionId();
+					}
+					const result = await client.callTool(tool.name, args);
 					const text = extractText(result);
 					return {
 						content: [{ type: "text", text: text || "(empty result)" }],

--- a/cli/internal/adapters/harness/pi_test.go
+++ b/cli/internal/adapters/harness/pi_test.go
@@ -95,6 +95,7 @@ func TestPiAdapter_RegisterExtension_LaysDownExtension(t *testing.T) {
 		"export default",
 		"pi.registerTool",
 		"mom",
+		"ctx.sessionManager.getSessionId()",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("mom-tools.ts missing expected token %q", want)

--- a/cli/internal/cmd/record.go
+++ b/cli/internal/cmd/record.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/momhq/mom/cli/internal/centralvault"
-	"github.com/momhq/mom/cli/internal/librarian"
+	"github.com/momhq/mom/cli/internal/drafter"
+	"github.com/momhq/mom/cli/internal/explicitrecord"
+	"github.com/momhq/mom/cli/internal/herald"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +33,7 @@ This command is the CLI mirror of the mom_record MCP tool. It is the
 human-driven path for recording a memory from a shell pipeline:
 
   echo "decided to use Postgres for the canary deploy" | \
-    mom record --session "$SID" --tags decision,deploy
+    mom record --tags decision,deploy
 
 Hook-friendly behaviour: legacy hook configs that pipe JSON to this
 command silently exit 0 — the JSON shape is detected and discarded
@@ -43,7 +44,7 @@ rather than persisted as memory text.`,
 }
 
 func init() {
-	recordCmd.Flags().StringVar(&recordSession, "session", "", "Session ID this memory belongs to (required)")
+	recordCmd.Flags().StringVar(&recordSession, "session", "", "Real runtime session ID (optional; MOM also checks harness env vars)")
 	recordCmd.Flags().StringVar(&recordSummary, "summary", "", "One-line summary")
 	recordCmd.Flags().StringSliceVar(&recordTags, "tags", nil, "Tag names (comma-separated; normalised before insert)")
 	recordCmd.Flags().StringVar(&recordActor, "actor", "cli", "Calling agent / human label (defaults to 'cli')")
@@ -57,15 +58,9 @@ func runRecord(cmd *cobra.Command, _ []string) error {
 	}
 	text := strings.TrimSpace(string(data))
 
-	// Hook-friendly bail-outs: missing --session, empty input, or
-	// JSON-shaped input (legacy hook payload from old Claude/Codex
-	// configs) all exit 0 without writing. The CLI was previously
-	// the entry point for those hooks; old configs that still fire
-	// it must not pollute the vault with JSON-as-memory-text.
-	if recordSession == "" {
-		fmt.Fprintln(os.Stderr, "mom record: --session is required (skipping)")
-		return nil
-	}
+	// Hook-friendly bail-outs: empty input or JSON-shaped input (legacy hook
+	// payload from old Claude/Codex configs) exit 0 without writing. Missing
+	// session ID for real text is now an error: agents must not invent session IDs.
 	if text == "" {
 		return nil
 	}
@@ -74,53 +69,42 @@ func runRecord(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// From here on we are on the human path: --session was set, stdin
-	// is non-empty and non-JSON. Failures are real errors that should
-	// propagate to the user with a non-zero exit; they no longer fit
-	// the hook-friendly silent-bail contract.
-	tags, err := normaliseRecordTags(recordTags)
-	if err != nil {
-		return fmt.Errorf("mom record: %w", err)
-	}
-
+	// From here on we are on the human path: stdin is non-empty and non-JSON.
+	// Failures are real errors that should propagate to the user with a non-zero
+	// exit; they no longer fit the hook-friendly silent-bail contract.
 	lib, closeFn, err := centralvault.OpenLibrarian()
 	if err != nil {
 		return fmt.Errorf("mom record: %w", err)
 	}
 	defer func() { _ = closeFn() }()
 
-	contentBytes, err := json.Marshal(map[string]any{"text": text})
-	if err != nil {
-		return fmt.Errorf("mom record: marshal content: %w", err)
-	}
+	bus := herald.NewBus()
+	stopDrafter := drafter.New(lib).SubscribeAll(bus)
+	defer stopDrafter()
 
-	id, err := lib.InsertMemoryWithTags(librarian.InsertMemory{
-		Content:                string(contentBytes),
-		Summary:                recordSummary,
-		SessionID:              recordSession,
-		ProvenanceActor:        recordActor,
-		ProvenanceSourceType:   "manual-draft",
-		ProvenanceTriggerEvent: "record",
-	}, tags)
-	if err != nil {
-		return fmt.Errorf("mom record: insert: %w", err)
-	}
-
-	fmt.Fprintf(cmd.OutOrStdout(), "recorded: id=%s session=%s tags=%v\n", id, recordSession, tags)
-	return nil
-}
-
-// normaliseRecordTags mirrors mcp.normaliseTagsOrReject: every input
-// tag is normalised; if any normalises to empty the whole list is
-// rejected so we never persist a partial-tag memory.
-func normaliseRecordTags(raw []string) ([]string, error) {
-	out := make([]string, 0, len(raw))
-	for i, t := range raw {
-		n := librarian.NormalizeTagName(t)
-		if n == "" {
-			return nil, fmt.Errorf("tag %d (%q) normalises to empty; reject the request rather than persist a partial memory", i, t)
+	var memoryID string
+	stopCapture := bus.Subscribe(herald.OpMemoryCreated, func(e herald.Event) {
+		if id, _ := e.Payload["memory_id"].(string); id != "" {
+			memoryID = id
 		}
-		out = append(out, n)
+	})
+	defer stopCapture()
+
+	result, err := explicitrecord.Publish(bus, explicitrecord.Request{
+		SessionID: recordSession,
+		Summary:   recordSummary,
+		Tags:      recordTags,
+		Content:   map[string]any{"text": text},
+		Actor:     recordActor,
+	})
+	if err != nil {
+		return fmt.Errorf("mom record: %w", err)
 	}
-	return out, nil
+
+	if memoryID != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "recorded: id=%s session=%s tags=%v\n", memoryID, result.SessionID, result.Tags)
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "recorded: session=%s tags=%v\n", result.SessionID, result.Tags)
+	return nil
 }

--- a/cli/internal/cmd/record_test.go
+++ b/cli/internal/cmd/record_test.go
@@ -65,7 +65,7 @@ func TestRunRecord_PersistsToCentralVault(t *testing.T) {
 	resetRecordFlags()
 	lib := openCentralVaultForTest(t)
 
-	recordSession = "s-cli"
+	recordSession = "11111111-1111-4111-8111-111111111111"
 	recordSummary = "decision summary"
 	recordTags = []string{"deploy", "decision"}
 	recordActor = "vmarino"
@@ -78,7 +78,7 @@ func TestRunRecord_PersistsToCentralVault(t *testing.T) {
 		t.Errorf("expected 'recorded:' in stdout, got %q", out)
 	}
 
-	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "s-cli", Limit: 10})
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "11111111-1111-4111-8111-111111111111", Limit: 10})
 	if len(rows) != 1 {
 		t.Fatalf("got %d memories, want 1", len(rows))
 	}
@@ -119,7 +119,7 @@ func TestRunRecord_JSONInput_SilentBail(t *testing.T) {
 	resetRecordFlags()
 	lib := openCentralVaultForTest(t)
 
-	recordSession = "s-cli"
+	recordSession = "11111111-1111-4111-8111-111111111111"
 	out, err := runRecordWithStdin(t, `{"session_id":"abc","transcript_path":"/tmp/x"}`)
 	if err != nil {
 		t.Fatalf("runRecord should not error on JSON bail-out: %v", err)
@@ -127,25 +127,40 @@ func TestRunRecord_JSONInput_SilentBail(t *testing.T) {
 	if strings.Contains(out, "recorded:") {
 		t.Errorf("unexpected write on JSON input: %q", out)
 	}
-	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "s-cli", Limit: 10})
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "11111111-1111-4111-8111-111111111111", Limit: 10})
 	if len(rows) != 0 {
 		t.Errorf("got %d memories, want 0 (JSON bail-out must not persist)", len(rows))
 	}
 }
 
-// TestRunRecord_MissingSession_SilentBail locks the missing-flag
-// hook-friendly path. Old hook configs invoke `mom record` without
-// flags; this must exit 0 without writing.
-func TestRunRecord_MissingSession_SilentBail(t *testing.T) {
+func TestRunRecord_UsesHarnessEnvSession(t *testing.T) {
+	resetRecordFlags()
+	lib := openCentralVaultForTest(t)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "s-env")
+
+	out, err := runRecordWithStdin(t, "some text with env session")
+	if err != nil {
+		t.Fatalf("runRecord: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "session=s-env") {
+		t.Fatalf("output = %q, want session=s-env", out)
+	}
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "s-env", Limit: 10})
+	if len(rows) != 1 {
+		t.Fatalf("got %d memories, want 1", len(rows))
+	}
+}
+
+func TestRunRecord_MissingSessionRejectsRealText(t *testing.T) {
 	resetRecordFlags()
 	lib := openCentralVaultForTest(t)
 
 	out, err := runRecordWithStdin(t, "some text without a session flag")
-	if err != nil {
-		t.Fatalf("runRecord should not error on missing session: %v", err)
+	if err == nil {
+		t.Fatalf("expected missing session error; output: %q", out)
 	}
-	if strings.Contains(out, "recorded:") {
-		t.Errorf("unexpected write on missing session: %q", out)
+	if !strings.Contains(err.Error(), "session_id") {
+		t.Fatalf("error = %v, want session_id", err)
 	}
 	rows, _ := lib.SearchMemories(librarian.SearchFilter{Limit: 10})
 	if len(rows) != 0 {
@@ -159,7 +174,7 @@ func TestRunRecord_EmptyStdin_SilentBail(t *testing.T) {
 	resetRecordFlags()
 	lib := openCentralVaultForTest(t)
 
-	recordSession = "s-cli"
+	recordSession = "11111111-1111-4111-8111-111111111111"
 	out, err := runRecordWithStdin(t, "")
 	if err != nil {
 		t.Fatalf("runRecord should not error on empty stdin: %v", err)
@@ -167,7 +182,7 @@ func TestRunRecord_EmptyStdin_SilentBail(t *testing.T) {
 	if strings.Contains(out, "recorded:") {
 		t.Errorf("unexpected write on empty stdin: %q", out)
 	}
-	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "s-cli", Limit: 10})
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "11111111-1111-4111-8111-111111111111", Limit: 10})
 	if len(rows) != 0 {
 		t.Errorf("got %d memories, want 0 (empty stdin must not persist)", len(rows))
 	}
@@ -182,7 +197,7 @@ func TestRunRecord_RejectsEmptyNormalisedTag(t *testing.T) {
 	resetRecordFlags()
 	lib := openCentralVaultForTest(t)
 
-	recordSession = "s-cli"
+	recordSession = "11111111-1111-4111-8111-111111111111"
 	recordTags = []string{"valid", "!!!"} // second normalises to empty
 	out, err := runRecordWithStdin(t, "some real memory text")
 	if err == nil {
@@ -191,7 +206,7 @@ func TestRunRecord_RejectsEmptyNormalisedTag(t *testing.T) {
 	if !strings.Contains(err.Error(), "normalises to empty") {
 		t.Errorf("error = %v, want 'normalises to empty'", err)
 	}
-	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "s-cli", Limit: 10})
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "11111111-1111-4111-8111-111111111111", Limit: 10})
 	if len(rows) != 0 {
 		t.Errorf("got %d memories, want 0 (rejection must not persist)", len(rows))
 	}

--- a/cli/internal/explicitrecord/explicitrecord.go
+++ b/cli/internal/explicitrecord/explicitrecord.go
@@ -1,0 +1,132 @@
+package explicitrecord
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+
+	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/librarian"
+)
+
+var ErrMissingSessionID = errors.New("session_id is required; do not invent one")
+
+var sessionEnvKeys = []string{
+	"CLAUDE_CODE_SESSION_ID",
+	"CLAUDE_SESSION_ID",
+	"CODEX_THREAD_ID",
+	"CODEX_SESSION_ID",
+	"WINDSURF_TRAJECTORY_ID",
+}
+
+// Request is the shared explicit-write contract for `mom record` and
+// `mom_record`. The caller may provide SessionID when it is a real runtime ID;
+// otherwise ResolveSessionID checks known harness environment variables.
+type Request struct {
+	SessionID string
+	Summary   string
+	Tags      []string
+	Content   map[string]any
+	Actor     string
+}
+
+type Result struct {
+	SessionID string
+	Summary   string
+	Tags      []string
+	Actor     string
+}
+
+func Publish(bus *herald.Bus, req Request) (Result, error) {
+	if bus == nil {
+		return Result{}, errors.New("event bus is required")
+	}
+	if len(req.Content) == 0 {
+		return Result{}, errors.New("content cannot be empty (must contain at least one field)")
+	}
+	sessionID, err := ResolveSessionID(req.SessionID)
+	if err != nil {
+		return Result{}, err
+	}
+	tags, err := NormalizeTagsOrReject(req.Tags)
+	if err != nil {
+		return Result{}, err
+	}
+	actor := strings.TrimSpace(req.Actor)
+	if actor == "" {
+		actor = "mcp"
+	}
+
+	bus.Publish(herald.Event{
+		Type:      herald.MemoryRecord,
+		SessionID: sessionID,
+		Payload: map[string]any{
+			"content":                  req.Content,
+			"summary":                  req.Summary,
+			"tags":                     tags,
+			"provenance_actor":         actor,
+			"provenance_source_type":   "manual-draft",
+			"provenance_trigger_event": "record",
+		},
+	})
+
+	return Result{SessionID: sessionID, Summary: req.Summary, Tags: tags, Actor: actor}, nil
+}
+
+func LooksLikeRuntimeSessionID(sessionID string) bool {
+	s := strings.TrimSpace(sessionID)
+	if s == "" {
+		return false
+	}
+	// UUID/UUIDv7-shaped IDs are what Claude and Pi expose. Pi watcher cursor
+	// filenames may prefix the UUID with a timestamp and underscore, so validate
+	// the suffix in that case.
+	if idx := strings.LastIndex(s, "_"); idx >= 0 && idx+1 < len(s) {
+		s = s[idx+1:]
+	}
+	if len(s) != 36 {
+		return false
+	}
+	for i, r := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !unicode.IsDigit(r) && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func ResolveSessionID(explicit string) (string, error) {
+	if s := strings.TrimSpace(explicit); s != "" {
+		if !LooksLikeRuntimeSessionID(s) {
+			return "", fmt.Errorf("session_id %q does not look like a runtime session ID; do not invent one", s)
+		}
+		return s, nil
+	}
+	for _, key := range sessionEnvKeys {
+		if s := strings.TrimSpace(os.Getenv(key)); s != "" {
+			return s, nil
+		}
+	}
+	return "", ErrMissingSessionID
+}
+
+func NormalizeTagsOrReject(raw []string) ([]string, error) {
+	out := make([]string, 0, len(raw))
+	for i, t := range raw {
+		n := librarian.NormalizeTagName(t)
+		if n == "" {
+			return nil, fmt.Errorf("tag %d (%q) normalises to empty; reject the request rather than persist a partial memory", i, t)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}

--- a/cli/internal/explicitrecord/explicitrecord_test.go
+++ b/cli/internal/explicitrecord/explicitrecord_test.go
@@ -1,0 +1,113 @@
+package explicitrecord
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/herald"
+)
+
+func TestLooksLikeRuntimeSessionID(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"11111111-1111-4111-8111-111111111111", true},
+		{"2026-05-07T20-00-00-000Z_11111111-1111-4111-8111-111111111111", true},
+		{"fresh-install-e2e", false},
+		{"2026-05-07-fresh-project", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := LooksLikeRuntimeSessionID(tc.id); got != tc.want {
+			t.Fatalf("LooksLikeRuntimeSessionID(%q) = %v, want %v", tc.id, got, tc.want)
+		}
+	}
+}
+
+func TestResolveSessionIDPrefersExplicit(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "env-session")
+	got, err := ResolveSessionID(" 11111111-1111-4111-8111-111111111111 ")
+	if err != nil {
+		t.Fatalf("ResolveSessionID: %v", err)
+	}
+	if got != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("got %q, want explicit runtime session", got)
+	}
+}
+
+func TestResolveSessionIDUsesHarnessEnv(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "claude-session")
+	got, err := ResolveSessionID("")
+	if err != nil {
+		t.Fatalf("ResolveSessionID: %v", err)
+	}
+	if got != "claude-session" {
+		t.Fatalf("got %q, want claude-session", got)
+	}
+}
+
+func TestResolveSessionIDRejectsInventedExplicit(t *testing.T) {
+	_, err := ResolveSessionID("fresh-install-e2e")
+	if err == nil {
+		t.Fatal("expected error for invented explicit session_id")
+	}
+}
+
+func TestResolveSessionIDRejectsMissing(t *testing.T) {
+	_, err := ResolveSessionID("")
+	if !errors.Is(err, ErrMissingSessionID) {
+		t.Fatalf("err = %v, want ErrMissingSessionID", err)
+	}
+}
+
+func TestPublishNormalizesAndPublishesMemoryRecord(t *testing.T) {
+	bus := herald.NewBus()
+	var got herald.Event
+	var count int
+	bus.Subscribe(herald.MemoryRecord, func(e herald.Event) {
+		got = e
+		count++
+	})
+
+	res, err := Publish(bus, Request{
+		SessionID: "11111111-1111-4111-8111-111111111111",
+		Summary:   "summary",
+		Content:   map[string]any{"text": "remember this"},
+		Tags:      []string{"MCP", "v0.30"},
+		Actor:     "pi",
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+	if got.Type != herald.MemoryRecord || got.SessionID != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("event = %+v", got)
+	}
+	if _, dup := got.Payload["session_id"]; dup {
+		t.Fatal("session_id must stay on the event envelope")
+	}
+	if res.SessionID != "11111111-1111-4111-8111-111111111111" || res.Actor != "pi" {
+		t.Fatalf("result = %+v", res)
+	}
+	tags, _ := got.Payload["tags"].([]string)
+	if len(tags) != 2 || tags[0] != "mcp" || tags[1] != "v0-30" {
+		t.Fatalf("tags = %v", tags)
+	}
+}
+
+func TestPublishRejectsMissingSessionWithoutPublishing(t *testing.T) {
+	bus := herald.NewBus()
+	var count int
+	bus.Subscribe(herald.MemoryRecord, func(e herald.Event) { count++ })
+
+	_, err := Publish(bus, Request{Content: map[string]any{"text": "x"}})
+	if !errors.Is(err, ErrMissingSessionID) {
+		t.Fatalf("err = %v, want ErrMissingSessionID", err)
+	}
+	if count != 0 {
+		t.Fatalf("published %d events, want 0", count)
+	}
+}

--- a/cli/internal/herald/herald.go
+++ b/cli/internal/herald/herald.go
@@ -66,8 +66,7 @@ const (
 // envelope.
 //
 // Payload carries per-event-type fields. The bus is type-agnostic; the
-// payload contract is defined by each producer/consumer pair (see
-// e.g. mcp.MemoryRecordPayload).
+// payload contract is defined by each producer/consumer pair.
 type Event struct {
 	Type      EventType
 	SessionID string

--- a/cli/internal/mcp/mom_record.go
+++ b/cli/internal/mcp/mom_record.go
@@ -1,12 +1,10 @@
 package mcp
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 
+	"github.com/momhq/mom/cli/internal/explicitrecord"
 	"github.com/momhq/mom/cli/internal/herald"
-	"github.com/momhq/mom/cli/internal/librarian"
 )
 
 // MemoryRecordEventType is re-exported from herald for backwards
@@ -18,31 +16,6 @@ import (
 // use herald.TurnObserved instead.
 var MemoryRecordEventType = herald.MemoryRecord
 
-// MemoryRecordPayload is the canonical payload shape for memory.record
-// events. Drafter reads these fields verbatim; nothing else inspects
-// the payload, so the contract is defined here.
-//
-// Provenance is filled in by the handler:
-//   - ProvenanceTriggerEvent = "record"
-//   - ProvenanceSourceType   = "manual-draft"
-//   - ProvenanceActor        = ActorAgent (claude-code, codex, …) or
-//     "mcp" when the caller did not announce.
-//
-// Tags are normalised via librarian.NormalizeTagName before publish;
-// every entry in Tags is the canonical form. If any input tag
-// normalised to empty the handler rejects the WHOLE request before
-// publishing — mirroring the lesson that prevented the orphan-row bug
-// in the previous attempt.
-type MemoryRecordPayload struct {
-	SessionID              string
-	Summary                string
-	Tags                   []string
-	Content                map[string]any
-	ProvenanceActor        string
-	ProvenanceSourceType   string
-	ProvenanceTriggerEvent string
-}
-
 // toolMomRecord is the MCP handler. It validates inputs, normalises
 // tags, then publishes the record event on the v0.30 bus. It does NOT
 // call Librarian directly — Drafter is the worker that subscribes to
@@ -50,7 +23,8 @@ type MemoryRecordPayload struct {
 //
 // Validation rules (locked):
 //   - content is required, must be an object/map (not empty).
-//   - session_id is required.
+//   - session_id must be real when supplied; otherwise MOM resolves known harness
+//     session env vars. If no real session is available, the record is rejected.
 //   - summary is optional.
 //   - tags is optional. Each tag is normalised; if any normalises to
 //     empty, the entire request is rejected with a clear error and no
@@ -60,65 +34,28 @@ func (s *Server) toolMomRecord(args map[string]any) (toolCallResult, error) {
 	if err != nil {
 		return toolCallResult{}, err
 	}
-	sessionID := stringArg(args, "session_id")
-	if strings.TrimSpace(sessionID) == "" {
-		return toolCallResult{}, errors.New("session_id is required")
-	}
-	summary := stringArg(args, "summary")
-
 	rawTags, err := optionalStringSliceArg(args, "tags")
 	if err != nil {
 		return toolCallResult{}, err
 	}
-	normalisedTags, err := normaliseTagsOrReject(rawTags)
+
+	result, err := explicitrecord.Publish(s.bus, explicitrecord.Request{
+		SessionID: stringArg(args, "session_id"),
+		Summary:   stringArg(args, "summary"),
+		Tags:      rawTags,
+		Content:   content,
+		Actor:     stringArg(args, "actor"),
+	})
 	if err != nil {
 		return toolCallResult{}, err
 	}
 
-	actor := stringArg(args, "actor")
-	if strings.TrimSpace(actor) == "" {
-		actor = "mcp"
-	}
-
-	payload := MemoryRecordPayload{
-		SessionID:              sessionID,
-		Summary:                summary,
-		Tags:                   normalisedTags,
-		Content:                content,
-		ProvenanceActor:        actor,
-		ProvenanceSourceType:   "manual-draft",
-		ProvenanceTriggerEvent: "record",
-	}
-
-	s.bus.Publish(herald.Event{
-		Type:      herald.MemoryRecord,
-		SessionID: payload.SessionID,
-		Payload:   payloadAsMap(payload),
-	})
-
 	return toolCallResult{
 		Content: []toolContent{{
 			Type: "text",
-			Text: fmt.Sprintf("recorded: session=%s tags=%v summary=%q", sessionID, normalisedTags, summary),
+			Text: fmt.Sprintf("recorded: session=%s tags=%v summary=%q", result.SessionID, result.Tags, result.Summary),
 		}},
 	}, nil
-}
-
-// normaliseTagsOrReject applies librarian.NormalizeTagName to every
-// input tag. If any tag normalises to empty (e.g., "!!!", "  "), the
-// whole slice is rejected with an error — the previous attempt's
-// orphan-row bug came from publishing the memory then failing later on
-// a per-tag UpsertTag("").
-func normaliseTagsOrReject(raw []string) ([]string, error) {
-	out := make([]string, 0, len(raw))
-	for i, t := range raw {
-		n := librarian.NormalizeTagName(t)
-		if n == "" {
-			return nil, fmt.Errorf("tag %d (%q) normalises to empty; reject the request rather than persist a partial memory", i, t)
-		}
-		out = append(out, n)
-	}
-	return out, nil
 }
 
 // requireMapArg returns the named argument as a map[string]any. Each
@@ -160,25 +97,4 @@ func optionalStringSliceArg(args map[string]any, key string) ([]string, error) {
 		out = append(out, s)
 	}
 	return out, nil
-}
-
-// payloadAsMap converts a MemoryRecordPayload to a map for the Herald
-// payload bag. SessionID is NOT included — it lives on the envelope
-// (herald.Event.SessionID), not in the bag. Including it here would
-// duplicate the contract and re-introduce the silent-drop class of
-// bug Theme A retired.
-func payloadAsMap(p MemoryRecordPayload) map[string]any {
-	m := map[string]any{
-		"content":                  p.Content,
-		"provenance_actor":         p.ProvenanceActor,
-		"provenance_source_type":   p.ProvenanceSourceType,
-		"provenance_trigger_event": p.ProvenanceTriggerEvent,
-	}
-	if p.Summary != "" {
-		m["summary"] = p.Summary
-	}
-	if len(p.Tags) > 0 {
-		m["tags"] = p.Tags
-	}
-	return m
 }

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -53,7 +53,7 @@ func TestMomRecord_PublishesEventWithNormalizedTags(t *testing.T) {
 	srv, rs := newSrvWithSubscriber(t)
 
 	res, err := srv.toolMomRecord(map[string]any{
-		"session_id": "s-1",
+		"session_id": "11111111-1111-4111-8111-111111111111",
 		"summary":    "deploy notes",
 		"content":    map[string]any{"text": "deploy postgres canary"},
 		"tags":       []any{"v0.30", "MCP"},
@@ -73,8 +73,8 @@ func TestMomRecord_PublishesEventWithNormalizedTags(t *testing.T) {
 	if got.Type != MemoryRecordEventType {
 		t.Errorf("event type = %q, want %q", got.Type, MemoryRecordEventType)
 	}
-	if got.SessionID != "s-1" {
-		t.Errorf("session_id = %q, want s-1", got.SessionID)
+	if got.SessionID != "11111111-1111-4111-8111-111111111111" {
+		t.Errorf("session_id = %q, want 11111111-1111-4111-8111-111111111111", got.SessionID)
 	}
 	if _, dup := got.Payload["session_id"]; dup {
 		t.Error("session_id was duplicated into payload bag; should live only on the envelope")
@@ -105,7 +105,7 @@ func TestMomRecord_PublishesEventWithNormalizedTags(t *testing.T) {
 func TestMomRecord_DefaultsActorToMCP(t *testing.T) {
 	srv, rs := newSrvWithSubscriber(t)
 	_, err := srv.toolMomRecord(map[string]any{
-		"session_id": "s",
+		"session_id": "22222222-2222-4222-8222-222222222222",
 		"content":    map[string]any{"text": "hi"},
 	})
 	if err != nil {
@@ -119,14 +119,49 @@ func TestMomRecord_DefaultsActorToMCP(t *testing.T) {
 
 // ── validation ────────────────────────────────────────────────────────────────
 
-func TestMomRecord_RejectsEmptySessionID(t *testing.T) {
+func TestMomRecord_UsesHarnessEnvSessionWhenOmitted(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "s-env")
+	_, err := srv.toolMomRecord(map[string]any{
+		"content": map[string]any{"text": "x"},
+	})
+	if err != nil {
+		t.Fatalf("toolMomRecord: %v", err)
+	}
+	got, ok := rs.get()
+	if !ok {
+		t.Fatal("no event published")
+	}
+	if got.SessionID != "s-env" {
+		t.Fatalf("session_id = %q, want s-env", got.SessionID)
+	}
+}
+
+func TestMomRecord_RejectsInventedSessionID(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	_, err := srv.toolMomRecord(map[string]any{
+		"session_id": "fresh-install-e2e",
+		"content":    map[string]any{"text": "x"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invented session_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "do not invent") {
+		t.Errorf("error %q should warn against invented session IDs", err)
+	}
+	if rs.count.Load() != 0 {
+		t.Errorf("event count = %d, want 0", rs.count.Load())
+	}
+}
+
+func TestMomRecord_RejectsMissingSessionID(t *testing.T) {
 	srv, rs := newSrvWithSubscriber(t)
 	_, err := srv.toolMomRecord(map[string]any{
 		"session_id": "",
 		"content":    map[string]any{"text": "x"},
 	})
 	if err == nil {
-		t.Fatal("expected error for empty session_id, got nil")
+		t.Fatal("expected error for missing session_id, got nil")
 	}
 	if !strings.Contains(err.Error(), "session_id") {
 		t.Errorf("error %q should mention session_id", err)
@@ -140,7 +175,7 @@ func TestMomRecord_RejectsEmptySessionID(t *testing.T) {
 func TestMomRecord_RejectsMissingContent(t *testing.T) {
 	srv, rs := newSrvWithSubscriber(t)
 	_, err := srv.toolMomRecord(map[string]any{
-		"session_id": "s",
+		"session_id": "22222222-2222-4222-8222-222222222222",
 	})
 	if err == nil {
 		t.Fatal("expected error for missing content")
@@ -153,7 +188,7 @@ func TestMomRecord_RejectsMissingContent(t *testing.T) {
 func TestMomRecord_RejectsEmptyContent(t *testing.T) {
 	srv, rs := newSrvWithSubscriber(t)
 	_, err := srv.toolMomRecord(map[string]any{
-		"session_id": "s",
+		"session_id": "22222222-2222-4222-8222-222222222222",
 		"content":    map[string]any{},
 	})
 	if err == nil {
@@ -172,7 +207,7 @@ func TestMomRecord_RejectsEmptyContent(t *testing.T) {
 func TestMomRecord_RejectsNonObjectContent(t *testing.T) {
 	srv, rs := newSrvWithSubscriber(t)
 	_, err := srv.toolMomRecord(map[string]any{
-		"session_id": "s",
+		"session_id": "22222222-2222-4222-8222-222222222222",
 		"content":    "this is a string, not an object",
 	})
 	if err == nil {
@@ -200,7 +235,7 @@ func TestMomRecord_RejectsTagsThatNormaliseToEmpty(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			srv, rs := newSrvWithSubscriber(t)
 			_, err := srv.toolMomRecord(map[string]any{
-				"session_id": "s",
+				"session_id": "22222222-2222-4222-8222-222222222222",
 				"content":    map[string]any{"text": "x"},
 				"tags":       c.tags,
 			})
@@ -221,7 +256,7 @@ func TestMomRecord_RejectsTagsThatNormaliseToEmpty(t *testing.T) {
 func TestMomRecord_RejectsMixedTypeTags(t *testing.T) {
 	srv, _ := newSrvWithSubscriber(t)
 	_, err := srv.toolMomRecord(map[string]any{
-		"session_id": "s",
+		"session_id": "22222222-2222-4222-8222-222222222222",
 		"content":    map[string]any{"text": "x"},
 		"tags":       []any{"deploy", 42},
 	})
@@ -275,7 +310,7 @@ func TestServer_SetBusReplacesTheBus(t *testing.T) {
 
 	// Publish via the handler — should hit ONLY the new bus.
 	if _, err := srv.toolMomRecord(map[string]any{
-		"session_id": "s",
+		"session_id": "22222222-2222-4222-8222-222222222222",
 		"content":    map[string]any{"text": "x"},
 	}); err != nil {
 		t.Fatalf("toolMomRecord: %v", err)

--- a/cli/internal/mcp/server.go
+++ b/cli/internal/mcp/server.go
@@ -209,7 +209,7 @@ func (s *Server) handleInitialize(_ json.RawMessage) (any, *rpcError) {
 			"name":    "mom-mcp-server",
 			"version": Version,
 		},
-		"instructions": "Use MOM for persistent memory. Available tools: mom_status, mom_recall, mom_get, mom_landmarks, mom_record. Call mom_recall before memory-derived claims and cite returned memory IDs.",
+		"instructions": "Use MOM for persistent memory. Prefer MOM skills and CLI; use MCP as fallback/startup. Call mom_recall before memory-derived claims and cite returned memory IDs. For explicit saves, prefer `mom record`; if using mom_record, never invent session_id.",
 	}, nil
 }
 

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -71,12 +71,12 @@ func allTools() []toolDef {
 		},
 		{
 			Name:        "mom_record",
-			Description: "Explicit-write path: intentionally save a memory mid-session. Bypasses Drafter's content filters (the user override) and stamps trigger_event='record', source_type='manual-draft'. Required: session_id, content. Optional: summary, tags, actor.",
+			Description: "Fallback explicit-write path: intentionally save a memory mid-session when CLI is unavailable. Bypasses Drafter's content filters and stamps trigger_event='record', source_type='manual-draft'. Required: content. Optional: session_id only when it is a real runtime session ID; never invent one. Optional: summary, tags, actor.",
 			InputSchema: map[string]any{
 				"type":     "object",
-				"required": []string{"session_id", "content"},
+				"required": []string{"content"},
 				"properties": map[string]any{
-					"session_id": map[string]any{"type": "string", "description": "Session ID this memory belongs to"},
+					"session_id": map[string]any{"type": "string", "description": "Real runtime session ID only. Omit when unavailable; MOM resolves known harness env vars or rejects."},
 					"summary":    map[string]any{"type": "string", "description": "One-line summary"},
 					"tags":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Tag names (will be normalised; empty after normalisation rejects the request)"},
 					"content":    map[string]any{"type": "object", "description": "Memory content (must include $.text for FTS)"},


### PR DESCRIPTION
## Summary
- route `mom record` through the same Herald/Drafter explicit-write path as `mom_record`
- reject invented explicit session IDs and require real runtime IDs or known harness env IDs
- stamp Pi `mom_record` calls with the real Pi session ID from the extension context
- update MCP/context guidance so explicit saves prefer CLI and never invent session IDs

## Validation
- `go test ./...` from `cli/`
- security review: no high-confidence vulnerabilities identified
