### PR TITLE
Canonicalize watcher project paths

### DIFF
--- a/cli/internal/cmd/watch_helpers.go
+++ b/cli/internal/cmd/watch_helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/momhq/mom/cli/internal/centralvault"
 	"github.com/momhq/mom/cli/internal/config"
 	"github.com/momhq/mom/cli/internal/daemon"
+	"github.com/momhq/mom/cli/internal/pathutil"
 	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/ux"
 	"github.com/momhq/mom/cli/internal/watcher"
@@ -31,6 +32,7 @@ func harnessTranscriptDir(name string) string {
 }
 
 func resolveMomContext(cwd string) (projectDir string, momDir string, err error) {
+	cwd = pathutil.CanonicalDir(cwd)
 	if sc, ok := scope.NearestWritable(cwd); ok {
 		return filepath.Dir(sc.Path), sc.Path, nil
 	}
@@ -48,6 +50,7 @@ func resolveMomContext(cwd string) (projectDir string, momDir string, err error)
 // ensures the single global daemon is running. Also cleans up legacy per-project agents.
 // Skipped when MOM_NO_DAEMON=1 or when running inside a test binary.
 func ensureGlobalDaemon(projectRoot, momDir string, runtimes []string) error {
+	projectRoot = pathutil.CanonicalDir(projectRoot)
 	if os.Getenv("MOM_NO_DAEMON") == "1" {
 		return nil
 	}
@@ -89,6 +92,7 @@ func ensureGlobalDaemon(projectRoot, momDir string, runtimes []string) error {
 // unregisterProject removes a project from the global watch registry,
 // cleans up legacy agents, and stops the global daemon if no projects remain.
 func unregisterProject(projectRoot, momDir string) error {
+	projectRoot = pathutil.CanonicalDir(projectRoot)
 	if err := daemon.UnregisterProject(projectRoot); err != nil {
 		return fmt.Errorf("unregistering project: %w", err)
 	}

--- a/cli/internal/cmd/watch_test.go
+++ b/cli/internal/cmd/watch_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/pathutil"
 )
 
 func resetWatchFlagsForTest(t *testing.T) {
@@ -78,6 +79,36 @@ func TestWatchStatusUsesCentralVaultWithoutProjectMom(t *testing.T) {
 	}
 }
 
+func TestResolveMomContextCanonicalizesSymlinkedCWD(t *testing.T) {
+	realProjectDir := filepath.Join(t.TempDir(), "real", "project")
+	if err := os.MkdirAll(realProjectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkProjectDir := filepath.Join(t.TempDir(), "link-project")
+	if err := os.Symlink(realProjectDir, linkProjectDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	centralDir := initTestCentralVault(t)
+	if err := os.MkdirAll(centralDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(centralDir, "config.yaml"), []byte("version: \"1\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectRoot, momDir, err := resolveMomContext(linkProjectDir)
+	if err != nil {
+		t.Fatalf("resolveMomContext: %v", err)
+	}
+	canonicalProjectDir := pathutil.CanonicalDir(realProjectDir)
+	if projectRoot != canonicalProjectDir {
+		t.Fatalf("projectRoot = %q, want canonical %q", projectRoot, canonicalProjectDir)
+	}
+	if momDir != centralDir {
+		t.Fatalf("momDir = %q, want %q", momDir, centralDir)
+	}
+}
+
 func TestResolveMomContextFallsBackToCentralVault(t *testing.T) {
 	projectDir := t.TempDir()
 	centralDir := initTestCentralVault(t)
@@ -92,8 +123,9 @@ func TestResolveMomContextFallsBackToCentralVault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveMomContext: %v", err)
 	}
-	if projectRoot != projectDir {
-		t.Fatalf("projectRoot = %q, want %q", projectRoot, projectDir)
+	canonicalProjectDir := pathutil.CanonicalDir(projectDir)
+	if projectRoot != canonicalProjectDir {
+		t.Fatalf("projectRoot = %q, want %q", projectRoot, canonicalProjectDir)
 	}
 	if momDir != centralDir {
 		t.Fatalf("momDir = %q, want %q", momDir, centralDir)

--- a/cli/internal/daemon/hash.go
+++ b/cli/internal/daemon/hash.go
@@ -3,11 +3,13 @@ package daemon
 import (
 	"crypto/sha256"
 	"fmt"
+
+	"github.com/momhq/mom/cli/internal/pathutil"
 )
 
 // ProjectHash returns a short deterministic hash of the project path.
 // Used to make service names unique per project.
 func ProjectHash(projectDir string) string {
-	h := sha256.Sum256([]byte(projectDir))
+	h := sha256.Sum256([]byte(pathutil.CanonicalDir(projectDir)))
 	return fmt.Sprintf("%x", h[:6]) // 12 hex chars
 }

--- a/cli/internal/daemon/registry.go
+++ b/cli/internal/daemon/registry.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/momhq/mom/cli/internal/pathutil"
 )
 
 // RegistryEntry describes a single MOM-enabled project in the global registry.
@@ -59,7 +61,15 @@ func LoadRegistry() (Registry, error) {
 	if reg == nil {
 		reg = make(Registry)
 	}
-	return reg, nil
+	return canonicalizeRegistry(reg), nil
+}
+
+func canonicalizeRegistry(reg Registry) Registry {
+	out := make(Registry, len(reg))
+	for projectDir, entry := range reg {
+		out[pathutil.CanonicalDir(projectDir)] = entry
+	}
+	return out
 }
 
 // SaveRegistry atomically writes the registry to disk (tmp + rename).
@@ -110,12 +120,18 @@ func withRegistryLock(fn func() error) error {
 
 // RegisterProject adds or updates a project in the registry (lock → load → upsert → save).
 func RegisterProject(projectDir, momDir string, runtimes []string) error {
+	canonicalProjectDir := pathutil.CanonicalDir(projectDir)
 	return withRegistryLock(func() error {
 		reg, err := LoadRegistry()
 		if err != nil {
 			return err
 		}
-		reg[projectDir] = RegistryEntry{
+		for existingProjectDir := range reg {
+			if pathutil.CanonicalDir(existingProjectDir) == canonicalProjectDir {
+				delete(reg, existingProjectDir)
+			}
+		}
+		reg[canonicalProjectDir] = RegistryEntry{
 			MomDir:   momDir,
 			Runtimes: runtimes,
 		}
@@ -126,12 +142,17 @@ func RegisterProject(projectDir, momDir string, runtimes []string) error {
 // UnregisterProject removes a project from the registry (lock → load → delete → save).
 // If the registry becomes empty, the file is deleted.
 func UnregisterProject(projectDir string) error {
+	canonicalProjectDir := pathutil.CanonicalDir(projectDir)
 	return withRegistryLock(func() error {
 		reg, err := LoadRegistry()
 		if err != nil {
 			return err
 		}
-		delete(reg, projectDir)
+		for existingProjectDir := range reg {
+			if existingProjectDir == projectDir || pathutil.CanonicalDir(existingProjectDir) == canonicalProjectDir {
+				delete(reg, existingProjectDir)
+			}
+		}
 		if len(reg) == 0 {
 			path, err := RegistryPath()
 			if err != nil {

--- a/cli/internal/daemon/registry_test.go
+++ b/cli/internal/daemon/registry_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/momhq/mom/cli/internal/pathutil"
 )
 
 func TestRegistryRoundTrip(t *testing.T) {
@@ -108,6 +110,70 @@ func TestRegisterUnregister(t *testing.T) {
 	}
 	if _, ok := reg["/proj/b"]; !ok {
 		t.Error("expected /proj/b to remain")
+	}
+}
+
+func TestLoadRegistryCanonicalizesSymlinkedProjectDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	realProjectDir := filepath.Join(t.TempDir(), "real", "project")
+	if err := os.MkdirAll(realProjectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkProjectDir := filepath.Join(t.TempDir(), "link-project")
+	if err := os.Symlink(realProjectDir, linkProjectDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	// Simulate an older registry entry written before canonicalization.
+	if err := SaveRegistry(Registry{
+		linkProjectDir: {MomDir: filepath.Join(linkProjectDir, ".mom"), Runtimes: []string{"claude"}},
+	}); err != nil {
+		t.Fatalf("SaveRegistry: %v", err)
+	}
+
+	reg, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	canonicalProjectDir := pathutil.CanonicalDir(realProjectDir)
+	if _, ok := reg[canonicalProjectDir]; !ok {
+		t.Fatalf("registry missing canonical key %q: %#v", canonicalProjectDir, reg)
+	}
+	if _, ok := reg[linkProjectDir]; ok {
+		t.Fatalf("registry retained symlink key %q: %#v", linkProjectDir, reg)
+	}
+}
+
+func TestRegisterUnregisterCanonicalizesSymlinkedProjectDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	realProjectDir := filepath.Join(t.TempDir(), "real", "project")
+	if err := os.MkdirAll(realProjectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkProjectDir := filepath.Join(t.TempDir(), "link-project")
+	if err := os.Symlink(realProjectDir, linkProjectDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if err := RegisterProject(linkProjectDir, filepath.Join(linkProjectDir, ".mom"), []string{"claude"}); err != nil {
+		t.Fatalf("RegisterProject: %v", err)
+	}
+	reg, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	canonicalProjectDir := pathutil.CanonicalDir(realProjectDir)
+	if _, ok := reg[canonicalProjectDir]; !ok {
+		t.Fatalf("registry missing canonical key %q: %#v", canonicalProjectDir, reg)
+	}
+
+	if err := UnregisterProject(linkProjectDir); err != nil {
+		t.Fatalf("UnregisterProject: %v", err)
+	}
+	if empty, err := IsRegistryEmpty(); err != nil || !empty {
+		t.Fatalf("registry empty = %v, err = %v", empty, err)
 	}
 }
 

--- a/cli/internal/pathutil/pathutil.go
+++ b/cli/internal/pathutil/pathutil.go
@@ -1,0 +1,20 @@
+package pathutil
+
+import "path/filepath"
+
+// CanonicalDir returns an absolute, symlink-resolved directory path when possible.
+// It falls back to the absolute path (or original input) so callers can use it
+// safely for paths that do not exist yet.
+func CanonicalDir(path string) string {
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		return real
+	}
+	return abs
+}

--- a/cli/internal/pathutil/pathutil_test.go
+++ b/cli/internal/pathutil/pathutil_test.go
@@ -1,0 +1,35 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCanonicalDirResolvesSymlinkedDirectory(t *testing.T) {
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real", "project")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(base, "link-project")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	want := CanonicalDir(realDir)
+	if got := CanonicalDir(linkDir); got != want {
+		t.Fatalf("CanonicalDir(%q) = %q, want %q", linkDir, got, want)
+	}
+}
+
+func TestCanonicalDirFallsBackForMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	want, err := filepath.Abs(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := CanonicalDir(missing); got != want {
+		t.Fatalf("CanonicalDir(%q) = %q, want %q", missing, got, want)
+	}
+}

--- a/cli/internal/watcher/watcher.go
+++ b/cli/internal/watcher/watcher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/pathutil"
 	"github.com/momhq/mom/cli/internal/ux"
 )
 
@@ -88,6 +89,11 @@ func New(cfg Config) (*Watcher, error) {
 	if cfg.DebounceMs == 0 {
 		cfg.DebounceMs = 300
 	}
+
+	// Normalize the project path before deriving harness transcript slugs. macOS
+	// commonly exposes /tmp as /private/tmp to child runtimes; resolving symlinks
+	// keeps watcher scoping aligned with where Pi/Claude write transcripts.
+	cfg.ProjectDir = pathutil.CanonicalDir(cfg.ProjectDir)
 
 	// Normalize sources: if Sources is empty, build from legacy single fields.
 	sources := cfg.Sources

--- a/cli/internal/watcher/watcher_test.go
+++ b/cli/internal/watcher/watcher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/momhq/mom/cli/internal/pathutil"
 )
 
 // mockAdapter records every call to ExtractTurn for inspection.
@@ -184,9 +185,9 @@ func TestIngestFile_NewSession(t *testing.T) {
 			Adapter:       &mockAdapter{},
 			DebounceMs:    300,
 		},
-		timers:  make(map[string]*time.Timer),
+		timers:    make(map[string]*time.Timer),
 		cursorDir: filepath.Join(momDir, "cache"),
-		logFile: filepath.Join(momDir, "watch.log"),
+		logFile:   filepath.Join(momDir, "watch.log"),
 	}
 	_ = os.MkdirAll(w.cursorDir, 0755)
 
@@ -235,9 +236,9 @@ func TestIngestFile_IncrementalRead(t *testing.T) {
 			Adapter:       adapter,
 			DebounceMs:    300,
 		},
-		timers:  make(map[string]*time.Timer),
+		timers:    make(map[string]*time.Timer),
 		cursorDir: filepath.Join(momDir, "cache"),
-		logFile: filepath.Join(momDir, "watch.log"),
+		logFile:   filepath.Join(momDir, "watch.log"),
 	}
 	_ = os.MkdirAll(w.cursorDir, 0755)
 
@@ -300,9 +301,9 @@ func TestIngestFile_TruncatedLine(t *testing.T) {
 			Adapter:       adapter,
 			DebounceMs:    300,
 		},
-		timers:  make(map[string]*time.Timer),
+		timers:    make(map[string]*time.Timer),
 		cursorDir: filepath.Join(momDir, "cache"),
-		logFile: filepath.Join(momDir, "watch.log"),
+		logFile:   filepath.Join(momDir, "watch.log"),
 	}
 	_ = os.MkdirAll(w.cursorDir, 0755)
 
@@ -361,9 +362,9 @@ func TestIngestFile_FileShrink(t *testing.T) {
 			Adapter:       adapter,
 			DebounceMs:    300,
 		},
-		timers:  make(map[string]*time.Timer),
+		timers:    make(map[string]*time.Timer),
 		cursorDir: filepath.Join(momDir, "cache"),
-		logFile: filepath.Join(momDir, "watch.log"),
+		logFile:   filepath.Join(momDir, "watch.log"),
 	}
 	_ = os.MkdirAll(w.cursorDir, 0755)
 
@@ -426,7 +427,7 @@ func mustMarshal(t *testing.T, v any) string {
 // "<path>" slug. This guards the privacy-bleed regression where a missing
 // scoper override caused pi sessions from OTHER projects to be ingested.
 func TestNew_ProjectScoping_PiUsesCustomSlug(t *testing.T) {
-	base := t.TempDir()                                 // simulated ~/.pi/agent/sessions
+	base := t.TempDir() // simulated ~/.pi/agent/sessions
 	momDir := filepath.Join(t.TempDir(), ".mom")
 	projectDir := "/Users/foo/proj"
 
@@ -459,6 +460,45 @@ func TestNew_ProjectScoping_PiUsesCustomSlug(t *testing.T) {
 	got := w.TranscriptDir()
 	if got != piSlugDir {
 		t.Errorf("expected scoped dir to be pi slug %q, got %q", piSlugDir, got)
+	}
+}
+
+// TestNew_ProjectScoping_ResolvesSymlinkedProjectDirBeforeSlugging guards the
+// macOS /tmp -> /private/tmp mismatch seen in live release validation.
+func TestNew_ProjectScoping_ResolvesSymlinkedProjectDirBeforeSlugging(t *testing.T) {
+	base := t.TempDir()
+	momDir := filepath.Join(t.TempDir(), ".mom")
+	realProjectDir := filepath.Join(t.TempDir(), "real", "project")
+	if err := os.MkdirAll(realProjectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkProjectDir := filepath.Join(t.TempDir(), "link-project")
+	if err := os.Symlink(realProjectDir, linkProjectDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	canonicalProjectDir := pathutil.CanonicalDir(realProjectDir)
+	realSlugDir := filepath.Join(base, projectSlug(canonicalProjectDir))
+	if err := os.MkdirAll(realSlugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := New(Config{
+		ProjectDir: linkProjectDir,
+		MomDir:     momDir,
+		Sources: []Source{{
+			Harness:       "claude",
+			TranscriptDir: base,
+			Adapter:       NewClaudeAdapter(),
+		}},
+		SweepOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if got := w.TranscriptDir(); got != realSlugDir {
+		t.Errorf("expected scoped dir to use canonical project slug %q, got %q", realSlugDir, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- canonicalize project dirs before watcher transcript slugging
- canonicalize global watch registry keys and project hash input
- canonicalize watch/serve context resolution so `/tmp` and `/private/tmp` map to the same project
- normalize stale registry keys on load

## Validation
- `go test ./internal/daemon ./internal/cmd ./internal/watcher ./internal/pathutil`
- `go test ./...`
- manual smoke: `/tmp` project ingested transcript written under `/private/tmp` slug via plain `mom watch --sweep`

## Release validation
Fixes Major 1 live validation gap where Pi/Claude wrote transcripts under `/private/tmp/...` while the watcher scoped to `/tmp/...`.
