### PR TITLE
Align Lens typography with MOM brand

### DIFF
--- a/cli/internal/lens/static/index.html
+++ b/cli/internal/lens/static/index.html
@@ -6,7 +6,7 @@
 <title>MOM — Sessions</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Lora:ital,wght@1,600&family=Plus+Jakarta+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&family=Lora:ital,wght@1,600&display=swap" rel="stylesheet">
 <style>
 /* ── Tokens ─────────────────────────────────────────────────────────────── */
 :root {
@@ -39,8 +39,9 @@ html, body { height: 100%; overflow: hidden; }
 body {
   background: var(--mantle);
   color: var(--paper);
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 1rem;
+  font-weight: 300;
   line-height: 1.65;
   -webkit-font-smoothing: antialiased;
   display: flex;
@@ -65,25 +66,31 @@ body {
 }
 
 .nav-wordmark {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 15px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  display: inline-flex;
+  align-items: baseline;
   color: var(--paper);
-  display: flex;
-  align-items: center;
+  line-height: 1;
+}
+
+.nav-wordmark-text {
+  font-family: 'Lora', Georgia, serif;
+  font-size: 18px;
+  font-style: italic;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .nav-cursor {
   display: inline-block;
-  width: 8px;
-  height: 14px;
-  background: var(--gold);
-  animation: blink 1.1s steps(2) infinite;
-  margin-left: 3px;
-  vertical-align: middle;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  color: var(--gold);
+  animation: blink 1.2s steps(2) infinite;
+  margin-left: 1px;
   position: relative;
-  top: -1px;
+  top: 1px;
 }
 
 .nav-meta {
@@ -325,8 +332,9 @@ body {
   color: var(--paper-20);
 }
 .empty-text {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 14px;
+  font-weight: 300;
   color: var(--paper-35);
   max-width: 44ch;
   line-height: 1.6;
@@ -545,10 +553,10 @@ body {
   background: var(--mantle-deep);
   border: 1px solid var(--paper-15);
   color: var(--paper-35);
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 12px;
-  font-style: italic;
-  font-weight: 400;
+  font-style: normal;
+  font-weight: 300;
   text-transform: none;
   letter-spacing: 0;
   line-height: 1.55;
@@ -615,8 +623,9 @@ body {
 .badge-draft    { background: var(--paper-10); color: var(--paper-35); }
 
 .memory-summary {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 13px;
+  font-weight: 300;
   color: var(--paper-35);
   line-height: 1.5;
   display: -webkit-box;
@@ -642,7 +651,7 @@ body {
 
 <!-- Nav -->
 <nav class="nav">
-  <div class="nav-wordmark">MOM<span class="nav-cursor"></span></div>
+  <div class="nav-wordmark" aria-label="mom"><span class="nav-wordmark-text">mom</span><span class="nav-cursor" aria-hidden="true">_</span></div>
   <div class="nav-meta" id="nav-vault">—</div>
 </nav>
 


### PR DESCRIPTION
## Summary
- align Lens font stack with MOM brand system
- remove Plus Jakarta Sans from Lens
- use IBM Plex Mono for product UI text/data
- render top-left lockup as Lora italic `mom` with gold Plex Mono `_` cursor

## Validation
- `go test ./internal/lens`
- `go test ./internal/cmd`
- rebuilt `/tmp/mom-release-test`
- root HTML contains brand font import and wordmark; no `Plus Jakarta` remains

## Notes
Functional Lens validation already passed. This is small v1 brand polish from `mom-brand` guidance.
