### PR TITLE
Quote natural recall queries for FTS

### DIFF
--- a/cli/internal/finder/finder.go
+++ b/cli/internal/finder/finder.go
@@ -99,7 +99,7 @@ func (f *Finder) WithThresholdLow(n int) *Finder {
 // Pipeline (each pass stops if it yields >= thresholdLow OR Limit):
 //  1. curated + AND  — most precise.
 //  2. curated + OR   — multi-token queries only; widen recall while
-//                      keeping the curated tier.
+//     keeping the curated tier.
 //  3. drafts + AND   — drop the curated gate.
 //  4. drafts + OR    — multi-token queries only; widest pass.
 //
@@ -203,11 +203,17 @@ func tokenCount(query string) int {
 	return len(tokens(query))
 }
 
-// normaliseFTSQuery returns the verbatim query for FTS5 MATCH. FTS5
-// defaults to AND between bare terms, so a trimmed query is already
-// the precise pass.
+// normaliseFTSQuery builds a safe FTS5 AND query from natural-language input.
+// Quoting every whitespace-delimited token preserves FTS5's default AND
+// semantics while preventing punctuation such as hyphens from being parsed as
+// operators or column selectors.
 func normaliseFTSQuery(query string) string {
-	return strings.TrimSpace(query)
+	tt := tokens(query)
+	parts := make([]string, len(tt))
+	for i, t := range tt {
+		parts[i] = quoteFTS(t)
+	}
+	return strings.Join(parts, " ")
 }
 
 // buildORQuery rewrites the query as an OR of its tokens. Each token
@@ -218,14 +224,15 @@ func buildORQuery(query string) string {
 	if len(tt) == 0 {
 		return ""
 	}
-	if len(tt) == 1 {
-		return tt[0]
-	}
 	parts := make([]string, len(tt))
 	for i, t := range tt {
-		parts[i] = `"` + escapeFTS(t) + `"`
+		parts[i] = quoteFTS(t)
 	}
 	return strings.Join(parts, " OR ")
+}
+
+func quoteFTS(s string) string {
+	return `"` + escapeFTS(s) + `"`
 }
 
 // escapeFTS doubles any embedded double-quote so the returned string

--- a/cli/internal/finder/finder_test.go
+++ b/cli/internal/finder/finder_test.go
@@ -88,6 +88,34 @@ func TestRecall_FindsByContent(t *testing.T) {
 	}
 }
 
+func TestRecall_TreatsHyphenatedQueryAsNaturalLanguage(t *testing.T) {
+	f, lib := openFinder(t)
+	id := insertMemory(t, lib, "s", "wrap up skill validation")
+	promote(t, lib, id)
+
+	got, err := f.Recall(finder.Options{Query: "wrap-up"})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != id {
+		t.Fatalf("got %v, want [%q]", got, id)
+	}
+}
+
+func TestRecall_TreatsFTSOperatorsAsNaturalLanguage(t *testing.T) {
+	f, lib := openFinder(t)
+	id := insertMemory(t, lib, "s", "literal OR operator note")
+	promote(t, lib, id)
+
+	got, err := f.Recall(finder.Options{Query: "literal OR operator"})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != id {
+		t.Fatalf("got %v, want [%q]", got, id)
+	}
+}
+
 func TestRecall_FindsBySummary(t *testing.T) {
 	f, lib := openFinder(t)
 	id, err := lib.Insert(librarian.InsertMemory{


### PR DESCRIPTION
## Summary
- treat `mom recall` input as natural language before passing it to SQLite FTS5
- quote whitespace-delimited terms for both AND and OR passes
- prevent hyphenated input like `wrap-up` from being parsed as FTS syntax

## Why
Major 4 skills validation found `mom recall "wrap-up"` failed with:

```text
SearchMemories: SQL logic error: no such column: up (1)
```

FTS5 interpreted the hyphen as query syntax. Skills require one natural-language query, so recall must accept normal punctuation safely.

## Validation
- `go test ./internal/finder ./internal/cmd`
- `go test ./...`
- rebuilt `/tmp/mom-release-test` locally
- verified:
  - `mom recall "wrap-up"`
  - `mom recall "Major four wrap-up skill validation"`
