### PR TITLE
Handle stale scope paths during reindex

### DIFF
--- a/cli/internal/adapters/storage/indexed_test.go
+++ b/cli/internal/adapters/storage/indexed_test.go
@@ -134,6 +134,38 @@ func TestIndexedAdapter_Reindex(t *testing.T) {
 	}
 }
 
+func TestIndexedAdapter_ReindexRemovesStaleRowsForSameIDUnderOldScopePath(t *testing.T) {
+	a, momDir := setupIndexedAdapter(t)
+	doc := indexedTestDoc("stale-scope-id")
+	oldScopePath := momDir + "-before-canonicalization"
+
+	if err := a.idx.Upsert(doc, oldScopePath); err != nil {
+		t.Fatalf("seed stale index row: %v", err)
+	}
+	if err := a.json.Write(doc); err != nil {
+		t.Fatalf("write JSON source doc: %v", err)
+	}
+
+	if err := a.Reindex(); err != nil {
+		t.Fatalf("Reindex failed: %v", err)
+	}
+
+	oldCount, err := a.idx.CountByScope(oldScopePath)
+	if err != nil {
+		t.Fatalf("CountByScope old: %v", err)
+	}
+	if oldCount != 0 {
+		t.Fatalf("old scope count = %d, want 0", oldCount)
+	}
+	newCount, err := a.idx.CountByScope(momDir)
+	if err != nil {
+		t.Fatalf("CountByScope new: %v", err)
+	}
+	if newCount != 1 {
+		t.Fatalf("new scope count = %d, want 1", newCount)
+	}
+}
+
 func TestIndexedAdapter_ExcludeDrafts(t *testing.T) {
 	a, _ := setupIndexedAdapter(t)
 

--- a/cli/internal/adapters/storage/sqlite.go
+++ b/cli/internal/adapters/storage/sqlite.go
@@ -24,18 +24,18 @@ const (
 	dbFileName = "index.db"
 
 	// pragmas applied once after opening the DB.
-	pragmaWAL          = "PRAGMA journal_mode=WAL"
-	pragmaForeignKeys  = "PRAGMA foreign_keys=ON"
-	pragmaSynchronous  = "PRAGMA synchronous=NORMAL"
-	pragmaCacheSize    = "PRAGMA cache_size=-8000" // 8 MB page cache
+	pragmaWAL         = "PRAGMA journal_mode=WAL"
+	pragmaForeignKeys = "PRAGMA foreign_keys=ON"
+	pragmaSynchronous = "PRAGMA synchronous=NORMAL"
+	pragmaCacheSize   = "PRAGMA cache_size=-8000" // 8 MB page cache
 )
 
 // sqliteIndex wraps a SQLite database providing FTS5-backed search for
 // memory documents. All methods are safe for sequential use; concurrent
 // access is serialised by SQLite's WAL reader/writer locking.
 type sqliteIndex struct {
-	db      *sql.DB
-	dbPath  string
+	db     *sql.DB
+	dbPath string
 }
 
 // openSQLiteIndex opens (or creates) the SQLite index at
@@ -243,16 +243,16 @@ func boolToInt(b bool) int {
 
 // SearchResult is a result from the SQLite FTS5 search.
 type SearchResult struct {
-	ID             string
-	Summary        string
-	Tags           []string
-	Score          float64 // BM25 score from FTS5 (negative → higher is better after negation)
-	ScopePath      string
-	PromotionState string
-	Landmark       bool
+	ID              string
+	Summary         string
+	Tags            []string
+	Score           float64 // BM25 score from FTS5 (negative → higher is better after negation)
+	ScopePath       string
+	PromotionState  string
+	Landmark        bool
 	CentralityScore *float64
-	Created        string
-	SessionID      string
+	Created         string
+	SessionID       string
 }
 
 // QueryType controls FTS5 token matching behaviour.
@@ -515,9 +515,21 @@ func (idx *sqliteIndex) ReindexScope(scopePath string, docs []*Doc) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Delete stale records.
+	// Delete stale records for this scope. Then also delete each incoming ID
+	// regardless of scope_path so path canonicalization changes cannot leave an
+	// old row with the same primary key under a previous path spelling.
 	if _, err := tx.Exec(`DELETE FROM memories WHERE scope_path = ?`, scopePath); err != nil {
 		return fmt.Errorf("deleting scope records: %w", err)
+	}
+	deleteByID, err := tx.Prepare(`DELETE FROM memories WHERE id = ?`)
+	if err != nil {
+		return fmt.Errorf("preparing stale id delete: %w", err)
+	}
+	defer deleteByID.Close()
+	for _, doc := range docs {
+		if _, err := deleteByID.Exec(doc.ID); err != nil {
+			return fmt.Errorf("deleting stale row %q: %w", doc.ID, err)
+		}
 	}
 
 	stmt, err := tx.Prepare(`


### PR DESCRIPTION
## Summary
- delete incoming document IDs during scope reindex, not only rows matching the current scope path
- prevents stale cache rows from older path spellings from causing UNIQUE constraint failures
- adds regression coverage for a doc ID indexed under a pre-canonicalization scope path

## Why
Final CLI validation on the upgraded fixture showed `mom reindex` printing:

```text
inserting "2366d6c4-3a73-4445-b375-150a2c108149-001": constraint failed: UNIQUE constraint failed: memories.id
```

The cache could contain the same memory ID under an old scope path after path canonicalization. Reindex deleted only by current scope path, then reinserted and hit the primary key.

## Validation
- `go test ./internal/adapters/storage ./internal/cmd`
- `go test ./...`
