### PR TITLE
Print record CLI rejection errors

### DIFF
--- a/cli/internal/cmd/record.go
+++ b/cli/internal/cmd/record.go
@@ -38,9 +38,8 @@ human-driven path for recording a memory from a shell pipeline:
 Hook-friendly behaviour: legacy hook configs that pipe JSON to this
 command silently exit 0 — the JSON shape is detected and discarded
 rather than persisted as memory text.`,
-	RunE:          runRecord,
-	SilenceUsage:  true,
-	SilenceErrors: true,
+	RunE:         runRecord,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cli/internal/cmd/record_test.go
+++ b/cli/internal/cmd/record_test.go
@@ -151,6 +151,12 @@ func TestRunRecord_UsesHarnessEnvSession(t *testing.T) {
 	}
 }
 
+func TestRecordCmd_DoesNotSilenceHumanPathErrors(t *testing.T) {
+	if recordCmd.SilenceErrors {
+		t.Fatal("mom record must print explicit-record rejections to stderr")
+	}
+}
+
 func TestRunRecord_MissingSessionRejectsRealText(t *testing.T) {
 	resetRecordFlags()
 	lib := openCentralVaultForTest(t)
@@ -170,6 +176,24 @@ func TestRunRecord_MissingSessionRejectsRealText(t *testing.T) {
 
 // TestRunRecord_EmptyStdin_SilentBail covers the third hook-friendly
 // shape — empty stdin must not write anything regardless of flags.
+func TestRunRecord_FakeSessionRejectsRealText(t *testing.T) {
+	resetRecordFlags()
+	lib := openCentralVaultForTest(t)
+
+	recordSession = "hidden-record-fake"
+	out, err := runRecordWithStdin(t, "some text with fake session")
+	if err == nil {
+		t.Fatalf("expected fake session error; output: %q", out)
+	}
+	if !strings.Contains(err.Error(), "do not invent") {
+		t.Fatalf("error = %v, want do not invent", err)
+	}
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{Limit: 10})
+	if len(rows) != 0 {
+		t.Errorf("got %d memories, want 0 (fake session must not persist)", len(rows))
+	}
+}
+
 func TestRunRecord_EmptyStdin_SilentBail(t *testing.T) {
 	resetRecordFlags()
 	lib := openCentralVaultForTest(t)


### PR DESCRIPTION
## Summary
- stop suppressing human-path `mom record` errors
- add coverage that explicit-record rejections are not silent
- add fake-session CLI-path regression coverage

## Why
Hidden command validation found fake `mom record --session hidden-record-fake` exited non-zero but printed no rejection text. Explicit record flows must reject fake session IDs clearly, not silently.

JSON-shaped legacy hook input still exits 0 without persisting, preserving hook cleanup behavior.

## Validation
- `go test ./internal/cmd ./internal/explicitrecord`
- `go test ./...`
