### PR TITLE
Stabilize doctor scope test

### DIFF
--- a/cli/internal/cmd/ops_test.go
+++ b/cli/internal/cmd/ops_test.go
@@ -180,8 +180,9 @@ func TestDoctorCmd_ShowsScopesSection(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	// Set HOME to dir so scope.Walk finds the .mom/ there.
-	t.Setenv("HOME", dir)
+	// Set HOME to the parent so the project .mom/ is classified as repo,
+	// not as the special $HOME/.mom user scope.
+	t.Setenv("HOME", filepath.Dir(dir))
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)


### PR DESCRIPTION
## Summary
- set test HOME to the project parent in `TestDoctorCmd_ShowsScopesSection`
- keeps the fixture `.mom/` classified as `repo` instead of `$HOME/.mom` user scope

## Why
The v0.30.0-alpha release workflow failed on Linux because the test set HOME to the same directory containing `.mom/`, which correctly makes scope.Walk label it as `user`. Local cached tests missed it.

## Validation
- `go test ./internal/cmd -run TestDoctorCmd_ShowsScopesSection -count=1`
- `go test ./... -count=1`
