### PR TITLE
Fix lint after alpha command cleanup

### DIFF
--- a/cli/internal/cmd/export_test.go
+++ b/cli/internal/cmd/export_test.go
@@ -148,7 +148,7 @@ func TestImportCmd_LegacyMemoryJSONPathUsesUpgradeImportRoutine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchMemories: %v", err)
 	}
-	if len(rows) != 1 || !strings.Contains(rows[0].Memory.Content, "legacy import body") {
+	if len(rows) != 1 || !strings.Contains(rows[0].Content, "legacy import body") {
 		t.Fatalf("legacy import rows = %+v", rows)
 	}
 }

--- a/cli/internal/cmd/ops.go
+++ b/cli/internal/cmd/ops.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -217,35 +216,4 @@ func checkDirWritable(dir string) error {
 	os.Remove(tmp)
 
 	return nil
-}
-
-// readRawIndexInt reads a nested integer from the raw index JSON.
-func readRawIndexInt(leoDir string, keys ...string) int {
-	indexPath := filepath.Join(leoDir, "index.json")
-	data, err := os.ReadFile(indexPath)
-	if err != nil {
-		return 0
-	}
-
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return 0
-	}
-
-	var node any = raw
-	for _, key := range keys {
-		m, ok := node.(map[string]any)
-		if !ok {
-			return 0
-		}
-		node = m[key]
-	}
-
-	switch v := node.(type) {
-	case float64:
-		return int(v)
-	case int:
-		return v
-	}
-	return 0
 }

--- a/cli/internal/cmd/recall.go
+++ b/cli/internal/cmd/recall.go
@@ -164,7 +164,7 @@ func validateReadOnlySQL(query string) error {
 		return fmt.Errorf("SQL recall accepts one read-only statement")
 	}
 	upper := strings.ToUpper(strings.TrimLeftFunc(q, unicode.IsSpace))
-	if !(strings.HasPrefix(upper, "SELECT") || strings.HasPrefix(upper, "WITH")) {
+	if !strings.HasPrefix(upper, "SELECT") && !strings.HasPrefix(upper, "WITH") {
 		return fmt.Errorf("SQL recall only accepts SELECT/WITH queries")
 	}
 	if sqlForbidden.MatchString(q) {

--- a/cli/internal/cmd/sweep.go
+++ b/cli/internal/cmd/sweep.go
@@ -8,72 +8,7 @@ import (
 	"time"
 
 	"github.com/momhq/mom/cli/internal/config"
-	"github.com/momhq/mom/cli/internal/scope"
-	"github.com/momhq/mom/cli/internal/ux"
-	"github.com/spf13/cobra"
 )
-
-var sweepCmd = &cobra.Command{
-	Use:   "sweep",
-	Short: "Delete old raw JSONL recordings based on retention policy",
-	Long: `Scans .mom/raw/ and deletes .jsonl files whose modification time
-exceeds the configured retention period (default: 30 days).
-
-Never deletes the current day's files. Configurable via config.yaml:
-
-  raw_memories:
-    retention_days: 30
-    auto_clean: false`,
-	RunE:          runSweep,
-	SilenceUsage:  true,
-	SilenceErrors: true,
-}
-
-func runSweep(cmd *cobra.Command, _ []string) error {
-	cwd, _ := os.Getwd()
-	sc, ok := scope.NearestWritable(cwd)
-	if !ok {
-		return fmt.Errorf("no .mom/ found from %q", cwd)
-	}
-
-	cfg, err := config.Load(sc.Path)
-	if err != nil {
-		def := config.Default()
-		cfg = &def
-	}
-
-	p := ux.NewPrinter(os.Stderr)
-	p.Diamond("sweep")
-	p.Blank()
-
-	showSpinner := ux.IsTTY(os.Stderr)
-	var result SweepResult
-	doSweep := func() {
-		result = sweep(sc.Path, cfg.RawMemories)
-	}
-
-	if showSpinner {
-		sp := ux.NewSpinner(os.Stderr)
-		sp.Start("Scanning raw files")
-		doSweep()
-		sp.Stop()
-	} else {
-		doSweep()
-	}
-
-	switch {
-	case result.Errors > 0:
-		p.Warnf("deleted %d files, freed %.1f MB (%d errors)",
-			result.Deleted, float64(result.BytesFreed)/(1024*1024), result.Errors)
-	case result.Deleted > 0:
-		p.Checkf("deleted %d files, freed %.1f MB",
-			result.Deleted, float64(result.BytesFreed)/(1024*1024))
-	default:
-		p.Muted("nothing to clean")
-	}
-	p.Blank()
-	return nil
-}
 
 // SweepResult holds the outcome of a sweep operation.
 type SweepResult struct {

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -427,67 +427,6 @@ func installSkillsDuringUpgrade(harnesses []string, dryRun bool, addAction func(
 	}
 }
 
-// propagateUpgrade walks child directories and upgrades each legacy .mom/ found.
-// Org folders (containing repos) are upgraded and recursed into; repos (with
-// .git/) are upgraded.
-func propagateUpgrade(cmd *cobra.Command, rootDir string, dryRun bool) {
-	entries, err := os.ReadDir(rootDir)
-	if err != nil {
-		return
-	}
-
-	for _, e := range entries {
-		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
-			continue
-		}
-		childPath := filepath.Join(rootDir, e.Name())
-		childMom := filepath.Join(childPath, ".mom")
-
-		// Only upgrade dirs that have .mom/.
-		if _, statErr := os.Stat(childMom); statErr != nil {
-			continue
-		}
-		if !isMomProject(childMom) {
-			continue
-		}
-
-		if err := upgradeSingleDir(cmd, childPath, dryRun); err != nil {
-			home, _ := os.UserHomeDir()
-			display := childPath
-			if strings.HasPrefix(display, home) {
-				display = "~" + display[len(home):]
-			}
-			up := ux.NewPrinter(cmd.OutOrStdout())
-			up.Warnf("failed to upgrade %s: %v", display, err)
-			continue
-		}
-
-		// Recurse into org folders (dirs that contain repos).
-		if containsGitRepos(childPath) {
-			propagateUpgrade(cmd, childPath, dryRun)
-		}
-	}
-}
-
-// containsGitRepos returns true if dir has at least one immediate child
-// directory that itself contains a .git/ subdirectory.
-func containsGitRepos(dir string) bool {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		gitPath := filepath.Join(dir, e.Name(), ".git")
-		if info, err := os.Stat(gitPath); err == nil && info.IsDir() {
-			return true
-		}
-	}
-	return false
-}
-
 // fileChanged returns true if the file at path doesn't exist or differs from data.
 func fileChanged(path string, data []byte) bool {
 	existing, err := os.ReadFile(path)

--- a/cli/internal/cmd/watch_helpers.go
+++ b/cli/internal/cmd/watch_helpers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/momhq/mom/cli/internal/daemon"
 	"github.com/momhq/mom/cli/internal/pathutil"
 	"github.com/momhq/mom/cli/internal/scope"
-	"github.com/momhq/mom/cli/internal/ux"
 	"github.com/momhq/mom/cli/internal/watcher"
 )
 
@@ -109,49 +108,6 @@ func unregisterProject(projectRoot, momDir string) error {
 	return nil
 }
 
-// runWatchInstall handles `mom watch --install`.
-func runWatchInstall(projectRoot, momDir string, p *ux.Printer) error {
-	cfg, err := config.Load(momDir)
-	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
-	}
-
-	sp := ux.NewSpinner(os.Stderr)
-	sp.Start("Installing global watch daemon")
-	installErr := ensureGlobalDaemon(projectRoot, momDir, cfg.EnabledHarnesses())
-	if installErr != nil {
-		sp.StopFail()
-		return fmt.Errorf("installing daemon: %w", installErr)
-	}
-	sp.Stop()
-
-	runtimes := watcherRuntimes(cfg)
-	p.Check("global watch daemon installed")
-	p.Chevron(fmt.Sprintf("runtimes: %s", strings.Join(runtimes, ", ")))
-
-	h, err := daemon.StatusGlobal()
-	if err == nil && len(h.Services) > 0 {
-		p.Chevron(fmt.Sprintf("daemon: %s", h.Services[0].DaemonLabel))
-		p.Chevron(fmt.Sprintf("timer:  %s", h.Services[0].TimerLabel))
-	}
-	return nil
-}
-
-// runWatchUninstall handles `mom watch --uninstall`.
-func runWatchUninstall(projectRoot, momDir string, p *ux.Printer) error {
-	sp := ux.NewSpinner(os.Stderr)
-	sp.Start("Removing watch daemon")
-	uninstallErr := unregisterProject(projectRoot, momDir)
-	if uninstallErr != nil {
-		sp.StopFail()
-		return fmt.Errorf("uninstalling daemon: %w", uninstallErr)
-	}
-	sp.Stop()
-
-	p.Check("project unregistered from global watch daemon")
-	return nil
-}
-
 // sweepTranscripts runs a one-shot catch-up sweep for all watcher-capable
 // runtimes. Best-effort: errors are logged to stderr, never returned.
 func sweepTranscripts(projectDir, momDir string) {
@@ -219,18 +175,4 @@ func buildWatcherSources(cfg *config.Config, projectDir string) []watcher.Source
 		})
 	}
 	return sources
-}
-
-// watcherRuntimes returns the names of watcher-capable runtimes from config.
-func watcherRuntimes(cfg *config.Config) []string {
-	var rts []string
-	for _, rt := range cfg.EnabledHarnesses() {
-		if rt == "claude" || rt == "windsurf" {
-			rts = append(rts, rt)
-		}
-	}
-	if len(rts) == 0 {
-		return []string{"claude"}
-	}
-	return rts
 }

--- a/cli/internal/lens/server.go
+++ b/cli/internal/lens/server.go
@@ -434,7 +434,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
 	}
-	jsonResponse(w, SessionDetail{SessionSummary: d.SessionSummary, ToolCalls: d.ToolCalls, Memories: d.Memories})
+	jsonResponse(w, SessionDetail(d))
 }
 
 func jsonResponse(w http.ResponseWriter, v any) {

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -283,7 +283,8 @@ func TestServer_BusIsAccessibleAndDistinctPerInstance(t *testing.T) {
 	// across calls. A future refactor that allocates a fresh bus per
 	// call silently breaks every subscribe/publish test that uses
 	// srv.Bus() then publishes via toolMomRecord.
-	if a.Bus() != a.Bus() {
+	bus := a.Bus()
+	if bus != a.Bus() {
 		t.Fatal("Server.Bus() not idempotent on same instance")
 	}
 }

--- a/cli/internal/mcp/server_test.go
+++ b/cli/internal/mcp/server_test.go
@@ -63,13 +63,6 @@ func writeJSON(t *testing.T, path string, v any) {
 	}
 }
 
-func writeMemoryDoc(t *testing.T, leoDir string, doc map[string]any) {
-	t.Helper()
-	id, _ := doc["id"].(string)
-	path := filepath.Join(leoDir, "memory", id+".json")
-	writeJSON(t, path, doc)
-}
-
 func insertCentralMemory(t *testing.T, summary, text string, tags []string) string {
 	t.Helper()
 	lib, closeFn, err := centralvault.OpenLibrarian()

--- a/cli/internal/mcp/status_test.go
+++ b/cli/internal/mcp/status_test.go
@@ -74,16 +74,6 @@ func callMomStatusText(t *testing.T, leoDir string) string {
 	return text
 }
 
-func callMomStatus(t *testing.T, leoDir string) map[string]any {
-	t.Helper()
-	text := callMomStatusText(t, leoDir)
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(text), &payload); err != nil {
-		t.Fatalf("parsing mom_status text as JSON: %v\ntext: %s", err, text)
-	}
-	return payload
-}
-
 func TestMomStatusCompactShape(t *testing.T) {
 	leoDir := newStatusTestDir(t)
 	text := callMomStatusText(t, leoDir)

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -260,26 +260,6 @@ func stringArg(args map[string]any, key string) string {
 	return ""
 }
 
-func stringSliceArg(args map[string]any, key string) []string {
-	v, ok := args[key]
-	if !ok {
-		return nil
-	}
-	switch t := v.(type) {
-	case []string:
-		return t
-	case []any:
-		out := make([]string, 0, len(t))
-		for _, item := range t {
-			if s, ok := item.(string); ok {
-				out = append(out, s)
-			}
-		}
-		return out
-	}
-	return nil
-}
-
 func intArg(args map[string]any, key string, defaultVal int) int {
 	v, ok := args[key]
 	if !ok {

--- a/cli/internal/watcher/adapter_claude.go
+++ b/cli/internal/watcher/adapter_claude.go
@@ -47,42 +47,6 @@ type claudeUsage struct {
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }
 
-// extractClaudeContent converts message.content (string or []contentItem) to plain text.
-func extractClaudeContent(content any) string {
-	if content == nil {
-		return ""
-	}
-
-	// Fast path: plain string content.
-	if s, ok := content.(string); ok {
-		return strings.TrimSpace(s)
-	}
-
-	// Structured content: []{"type":"text","text":"..."}
-	// JSON unmarshal gives []interface{} for arrays.
-	items, ok := content.([]any)
-	if !ok {
-		return ""
-	}
-
-	var parts []string
-	for _, item := range items {
-		m, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		t, _ := m["type"].(string)
-		if t != "text" {
-			continue // skip tool_use, tool_result, image, etc.
-		}
-		if text, _ := m["text"].(string); text != "" {
-			parts = append(parts, text)
-		}
-	}
-
-	return strings.Join(parts, "\n")
-}
-
 // ExtractTurn implements Adapter. Returns the rich per-turn
 // shape Drafter and Logbook consume from `turn.observed` events. The
 // raw text and tool inputs ride on the bus only — Drafter applies


### PR DESCRIPTION
## Summary
Remove obsolete helpers left unused after the alpha command-surface cleanup and apply small staticcheck suggestions.

## Validation
- `cd cli && golangci-lint run ./...`
- `cd cli && go test ./...`
