### PR TITLE
Ignore local autoresearch artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ mom-export/
 # MOM (generated at runtime)
 .codex/
 .pi/
+
+# Autoresearch artifacts
+autoresearch.jsonl
+mom-autoresearch/


### PR DESCRIPTION
## Summary
Ignore local autoresearch output so experiment artifacts do not appear as release/code changes.

## Changes
- ignore `autoresearch.jsonl`
- ignore `mom-autoresearch/`
- `.codex/` was already ignored

## Validation
- Not run; `.gitignore` only.
