### PR TITLE
Scope CLI binary ignore pattern

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -5,4 +5,4 @@
 CLAUDE.md
 
 # Build artifacts
-mom
+/mom


### PR DESCRIPTION
## Summary
Scope the CLI build-artifact ignore rule so it ignores only `cli/mom`, not the tracked `cli/cmd/mom/` source directory.

## Validation
- `git ls-files -ci --exclude-standard` is empty after this change.
