### PR TITLE
cleanup: complete harness terminology migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/adapter_proposal.yml
@@ -1,11 +1,11 @@
-name: Runtime Adapter Proposal
-description: Propose a new runtime adapter (Cursor, Windsurf, etc.)
+name: Harness Adapter Proposal
+description: Propose a new harness adapter (Cursor, Windsurf, etc.)
 labels: ["adapter"]
 body:
   - type: input
-    id: runtime
+    id: harness
     attributes:
-      label: Runtime name
+      label: Harness name
       placeholder: "e.g. Cursor, Windsurf"
     validations:
       required: true
@@ -20,4 +20,4 @@ body:
     id: approach
     attributes:
       label: Implementation approach
-      description: How would the adapter work? What files does the runtime use?
+      description: How would the adapter work? What files does the harness use?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,9 +28,9 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: runtime
+    id: harness
     attributes:
-      label: Runtime
+      label: Harness
       options:
         - Claude Code
         - Cursor

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Link to related issue: closes #
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Documentation
-- [ ] Runtime adapter
+- [ ] Harness adapter
 - [ ] Refactor
 
 ## Checklist

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ _Mom_ is local-first.
 - `MOM_VAULT=/path/to/mom.db` overrides the vault for tests or isolated runs.
 - Lens and operational logs use privacy-projected metadata.
 - Raw tool arguments, raw user text, shell command arguments, query strings, paths, and flags are not stored as operational log detail.
-- Explicit record flows reject invented session IDs; runtime session IDs must come from the harness.
+- Explicit record flows reject invented session IDs; harness session IDs must come from the harness.
 
 ## Troubleshooting
 
@@ -231,3 +231,4 @@ Skills install is a soft-fail step, so _mom_ can be usable even if the external 
 - [Latest release](https://github.com/momhq/mom/releases/latest)
 - [Issues](https://github.com/momhq/mom/issues)
 - [Homebrew tap](https://github.com/momhq/homebrew-tap)
+- [Privacy policy](https://github.com/momhq/mom/blob/main/PRIVACY.md)

--- a/cli/internal/cmd/core_memory.go
+++ b/cli/internal/cmd/core_memory.go
@@ -16,9 +16,9 @@ var knownGeneratedCentralDocs = []generatedCentralDoc{
 func defaultIdentity() string {
 	return `{
   "what": "MOM (Memory Oriented Machine) — a living knowledge infrastructure where humans and agents think, decide, and evolve together.",
-  "philosophy": "MOM is the memory and knowledge layer above any AI runtime. The runtime handles task execution; MOM handles persistence, governance, and organizational knowledge. What the runtime forgets, MOM remembers.",
+  "philosophy": "MOM is the memory and knowledge layer above any AI harness. The harness handles task execution; MOM handles persistence, governance, and organizational knowledge. What the harness forgets, MOM remembers.",
   "constraints": [
-    "All memory content is JSON — runtime files (CLAUDE.md, AGENTS.md) are generated artifacts",
+    "All memory content is JSON — harness files (CLAUDE.md, AGENTS.md) are generated artifacts",
     "Core artifacts are English only — interaction language is personal choice",
     "No rule change without explicit approval from the user",
     "Scripts must never require AI tokens — if it's deterministic, it's a script"

--- a/cli/internal/cmd/demo.go
+++ b/cli/internal/cmd/demo.go
@@ -71,7 +71,7 @@ var demoCmd = &cobra.Command{
 		p.Bold("Check List (mom doctor)")
 		p.Blank()
 		p.Check(".mom/ directory: exists and writable")
-		p.Check("config.yaml: valid (runtimes: claude)")
+		p.Check("config.yaml: valid (harnesses: claude)")
 		p.Check("memory/: exists")
 		p.Check("constraints/: exists")
 		p.Warn("skills/: not found")

--- a/cli/internal/cmd/harness_terminology_test.go
+++ b/cli/internal/cmd/harness_terminology_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUserFacingCommandTextUsesHarnessTerminology(t *testing.T) {
+	commands := map[string]string{
+		"watch short":    watchCmd.Short,
+		"watch long":     watchCmd.Long,
+		"record session": recordCmd.Flags().Lookup("session").Usage,
+		"uninstall long": uninstallCmd.Long,
+	}
+	for name, text := range commands {
+		if strings.Contains(strings.ToLower(text), "runtime") {
+			t.Fatalf("%s uses runtime terminology: %q", name, text)
+		}
+	}
+}

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -431,7 +431,7 @@ func runReinit(cmd *cobra.Command, cwd, momDir string, result OnboardingResult, 
 
 // buildRuntimeConfig converts a config.Config to a harness.Config.
 // Autonomy was retired from the persisted config; generated context files still
-// include the balanced default so the runtime retains the behavioral directive.
+// include the balanced default so the harness retains the behavioral directive.
 func buildRuntimeConfig(cfg *config.Config) harness.Config {
 	commMode := cfg.Communication.Mode
 	if commMode == "" {

--- a/cli/internal/cmd/onboarding.go
+++ b/cli/internal/cmd/onboarding.go
@@ -28,11 +28,11 @@ type OnboardingResult struct {
 // runOnboarding executes the interactive wizard and returns the chosen config.
 // r is the source of user input (os.Stdin in production, strings.Reader in tests).
 // w is the destination for wizard output (os.Stdout in production, bytes.Buffer in tests).
-// cwd is used for runtime auto-detection.
+// cwd is used for harness auto-detection.
 func runOnboarding(r io.Reader, w io.Writer, cwd string) (OnboardingResult, error) {
 	accessible := !isTerminalReader(r)
 
-	// ── Prepare runtime options ─────────────────────────────────────────────
+	// ── Prepare harness options ─────────────────────────────────────────────
 	registry := harness.NewRegistry(cwd)
 	allAdapters := registry.All()
 	detected := registry.DetectAll()
@@ -45,7 +45,7 @@ func runOnboarding(r io.Reader, w io.Writer, cwd string) (OnboardingResult, erro
 		detectedSet["claude"] = true
 	}
 
-	var runtimeOptions []huh.Option[string]
+	var harnessOptions []huh.Option[string]
 	for _, a := range allAdapters {
 		label := harnessLabel(a.Name())
 		if detectedSet[a.Name()] {
@@ -55,7 +55,7 @@ func runOnboarding(r io.Reader, w io.Writer, cwd string) (OnboardingResult, erro
 		if detectedSet[a.Name()] {
 			opt = opt.Selected(true)
 		}
-		runtimeOptions = append(runtimeOptions, opt)
+		harnessOptions = append(harnessOptions, opt)
 	}
 
 	// ── Bind variables ──────────────────────────────────────────────────────
@@ -94,8 +94,8 @@ func runOnboarding(r io.Reader, w io.Writer, cwd string) (OnboardingResult, erro
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Which AI Assistants do you want to enable?").
-				Options(runtimeOptions...).
-				Height(len(runtimeOptions)+2).
+				Options(harnessOptions...).
+				Height(len(harnessOptions)+2).
 				Value(&selectedHarnesses).
 				Validate(func(selected []string) error {
 					if len(selected) == 0 {
@@ -112,7 +112,7 @@ func runOnboarding(r io.Reader, w io.Writer, cwd string) (OnboardingResult, erro
 				Options(
 					huh.NewOption("Concise — direct, no filler, grammar intact (recommended)", "concise"),
 					huh.NewOption("Efficient — telegraphic, fragments OK, max token savings", "efficient"),
-					huh.NewOption("Default — no instructions, runtime decides", "default"),
+					huh.NewOption("Default — no instructions, harness decides", "default"),
 				).
 				Value(&mode),
 		),

--- a/cli/internal/cmd/onboarding_test.go
+++ b/cli/internal/cmd/onboarding_test.go
@@ -41,13 +41,13 @@ func isolateHarnessDetection(t *testing.T) {
 //   Confirm:     y/n, empty = default
 //
 // Form flow (bootstrap select removed alongside cartographer):
-//   Form 1: Note(welcome), MultiSelect(runtimes), Select(mode)
+//   Form 1: Note(welcome), MultiSelect(harnesses), Select(mode)
 //   Form 2: Note(summary), Confirm
 
 // TestOnboarding_DefaultSelections verifies that accepting all defaults works.
 func TestOnboarding_DefaultSelections(t *testing.T) {
 	isolateHarnessDetection(t)
-	// 0=confirm runtimes (claude pre-selected), then empty for mode, confirm.
+	// 0=confirm harnesses (claude pre-selected), then empty for mode, confirm.
 	input := testReader("0\n\n\n")
 	output := &bytes.Buffer{}
 
@@ -57,10 +57,10 @@ func TestOnboarding_DefaultSelections(t *testing.T) {
 	}
 
 	if len(result.Harnesses) == 0 {
-		t.Fatal("expected at least one runtime")
+		t.Fatal("expected at least one harness")
 	}
 	if result.Harnesses[0] != "claude" {
-		t.Errorf("expected first runtime=claude, got %q", result.Harnesses[0])
+		t.Errorf("expected first harness=claude, got %q", result.Harnesses[0])
 	}
 	if result.Language != "en" {
 		t.Errorf("expected language=en, got %q", result.Language)
@@ -91,10 +91,10 @@ func TestOnboarding_ExplicitSelections(t *testing.T) {
 		return false
 	}
 	if !hasRuntime("claude") {
-		t.Error("expected claude in runtimes")
+		t.Error("expected claude in harnesses")
 	}
 	if !hasRuntime("codex") {
-		t.Error("expected codex in runtimes")
+		t.Error("expected codex in harnesses")
 	}
 	if result.Language != "en" {
 		t.Errorf("expected language=en (fixed), got %q", result.Language)
@@ -139,7 +139,7 @@ func TestOnboarding_OutputContainsWelcome(t *testing.T) {
 }
 
 // TestOnboarding_OutputContainsSummary verifies the summary step renders.
-// Input: confirm runtimes, mode=2(efficient), confirm=y.
+// Input: confirm harnesses, mode=2(efficient), confirm=y.
 func TestOnboarding_OutputContainsSummary(t *testing.T) {
 	isolateHarnessDetection(t)
 	input := testReader("0\n2\ny\n")
@@ -164,8 +164,8 @@ func TestOnboarding_OutputContainsSummary(t *testing.T) {
 	}
 }
 
-// TestOnboarding_MultipleRuntimesSelected verifies toggling multiple runtimes.
-func TestOnboarding_MultipleRuntimesSelected(t *testing.T) {
+// TestOnboarding_MultipleHarnessesSelected verifies toggling multiple harnesses.
+func TestOnboarding_MultipleHarnessesSelected(t *testing.T) {
 	isolateHarnessDetection(t)
 	// Toggle codex (2) and windsurf (3), confirm (0), then defaults for mode and confirm.
 	input := testReader("2\n3\n0\n\n\n")
@@ -177,7 +177,7 @@ func TestOnboarding_MultipleRuntimesSelected(t *testing.T) {
 	}
 
 	if len(result.Harnesses) != 3 {
-		t.Fatalf("expected 3 runtimes, got %d: %v", len(result.Harnesses), result.Harnesses)
+		t.Fatalf("expected 3 harnesses, got %d: %v", len(result.Harnesses), result.Harnesses)
 	}
 }
 
@@ -186,7 +186,7 @@ func TestOnboarding_MultipleRuntimesSelected(t *testing.T) {
 func TestOnboarding_GlobalInitUsesCurrentDirForWatcher(t *testing.T) {
 	isolateHarnessDetection(t)
 	cwd := t.TempDir()
-	// 0=confirm runtimes, empty for mode, empty for confirm (default=yes).
+	// 0=confirm harnesses, empty for mode, empty for confirm (default=yes).
 	input := testReader("0\n\n\n")
 	output := &bytes.Buffer{}
 

--- a/cli/internal/cmd/ops_test.go
+++ b/cli/internal/cmd/ops_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // setupTestMemoryWithConfig creates a .mom/ with config.yaml and returns the temp dir.
-func setupTestMemoryWithConfig(t *testing.T, runtime string) string {
+func setupTestMemoryWithConfig(t *testing.T, harness string) string {
 	t.Helper()
 	dir := setupTestMemory(t) // reuse existing helper from memory_test.go (formerly kb_test.go)
 
@@ -21,10 +21,10 @@ func setupTestMemoryWithConfig(t *testing.T, runtime string) string {
 
 	// Write a real config.yaml.
 	cfg := config.Default()
-	// Default() already includes claude; if a different runtime is requested,
+	// Default() already includes claude; if a different harness is requested,
 	// add it (for test flexibility).
-	if runtime != "claude" {
-		cfg.Harnesses[runtime] = config.HarnessConfig{Enabled: true}
+	if harness != "claude" {
+		cfg.Harnesses[harness] = config.HarnessConfig{Enabled: true}
 	}
 	if err := config.Save(momDir, &cfg); err != nil {
 		t.Fatalf("writing test config: %v", err)

--- a/cli/internal/cmd/record.go
+++ b/cli/internal/cmd/record.go
@@ -43,7 +43,7 @@ rather than persisted as memory text.`,
 }
 
 func init() {
-	recordCmd.Flags().StringVar(&recordSession, "session", "", "Real runtime session ID (optional; MOM also checks harness env vars)")
+	recordCmd.Flags().StringVar(&recordSession, "session", "", "Real harness session ID (optional; MOM also checks harness env vars)")
 	recordCmd.Flags().StringVar(&recordSummary, "summary", "", "One-line summary")
 	recordCmd.Flags().StringSliceVar(&recordTags, "tags", nil, "Tag names (comma-separated; normalised before insert)")
 	recordCmd.Flags().StringVar(&recordActor, "actor", "cli", "Calling agent / human label (defaults to 'cli')")

--- a/cli/internal/cmd/serve.go
+++ b/cli/internal/cmd/serve.go
@@ -26,7 +26,7 @@ var serveMCPCmd = &cobra.Command{
 	Short: "Start the MCP stdio server",
 	Long: `Start the MOM MCP (Model Context Protocol) server on stdio.
 
-Any MCP-aware runtime (Claude Code, Cursor, Cline, …) can connect by adding
+Any MCP-aware harness (Claude Code, Cursor, Cline, …) can connect by adding
 this command to its MCP config:
 
   {
@@ -62,7 +62,7 @@ func runServeMCP(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
 
-	// Allow runtimes that don't set cwd (Windsurf, Cline VS Code) to specify
+	// Allow harnesses that do not set cwd (Windsurf, Cline VS Code) to specify
 	// the project directory via environment variable.
 	if envDir := os.Getenv("MOM_PROJECT_DIR"); envDir != "" {
 		cwd = envDir

--- a/cli/internal/cmd/uninstall.go
+++ b/cli/internal/cmd/uninstall.go
@@ -17,7 +17,7 @@ import (
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Remove all MOM files from this project",
-	Long: `Removes .mom/ directory and any generated runtime files (e.g. .claude/CLAUDE.md, AGENTS.md).
+	Long: `Removes .mom/ directory and any generated harness files (e.g. .claude/CLAUDE.md, AGENTS.md).
 Optionally backs up your memory before removal using the export command.`,
 	RunE: runUninstall,
 }
@@ -53,7 +53,7 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 	// Project root is the parent of .mom/.
 	projectRoot := filepath.Dir(momDir)
 
-	// Resolve adapters from config — use registry for all enabled runtimes.
+	// Resolve adapters from config — use registry for all enabled harnesses.
 	registry := harness.NewRegistry(projectRoot)
 	var adapters []harness.Adapter
 
@@ -164,7 +164,7 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 		p.Checkf("removed .mom/")
 	}
 
-	// Remove generated runtime files via adapters (deduplicated).
+	// Remove generated harness files via adapters (deduplicated).
 	removed := make(map[string]bool)
 	for _, adapter := range adapters {
 		for _, relPath := range adapter.GeneratedFiles() {

--- a/cli/internal/cmd/watch.go
+++ b/cli/internal/cmd/watch.go
@@ -31,12 +31,12 @@ var (
 
 var watchCmd = &cobra.Command{
 	Use:   "watch",
-	Short: "Watch runtime transcripts and ingest turns automatically",
-	Long: `Starts a filesystem watcher on a runtime transcript directory and
+	Short: "Watch harness transcripts and ingest turns automatically",
+	Long: `Starts a filesystem watcher on a harness transcript directory and
 ingests new conversation turns into the central vault at $HOME/.mom/mom.db
 without MCP calls or hook overhead.
 
-Supported runtimes:
+Supported harnesses:
   claude    — ~/.claude/projects/ (default)
   windsurf  — ~/.windsurf/transcripts/
   pi        — ~/.pi/agent/sessions/
@@ -95,7 +95,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 	}
 	sources := buildWatcherSources(momCfg, projectDir)
 	if len(sources) == 0 {
-		return fmt.Errorf("no watcher-capable runtimes enabled in config")
+		return fmt.Errorf("no watcher-capable harnesses enabled in config")
 	}
 
 	// Sweep mode: one-shot catch-up and exit.
@@ -508,7 +508,7 @@ func (cw centralWorkers) AttachToBus(bus *herald.Bus) {
 // the librarian/vault concurrency contract keep this safe across
 // goroutines.
 //
-// The vault stays open for the process's lifetime. The runtime owns
+// The vault stays open for the process's lifetime. The harness owns
 // the lifecycle; on shutdown the OS reclaims the handle. A future
 // refactor should plumb an explicit Close, but for alpha this is
 // acceptable.

--- a/cli/internal/cmd/watch_helpers.go
+++ b/cli/internal/cmd/watch_helpers.go
@@ -48,7 +48,7 @@ func resolveMomContext(cwd string) (projectDir string, momDir string, err error)
 // ensureGlobalDaemon registers the project in the global watch registry and
 // ensures the single global daemon is running. Also cleans up legacy per-project agents.
 // Skipped when MOM_NO_DAEMON=1 or when running inside a test binary.
-func ensureGlobalDaemon(projectRoot, momDir string, runtimes []string) error {
+func ensureGlobalDaemon(projectRoot, momDir string, harnesses []string) error {
 	projectRoot = pathutil.CanonicalDir(projectRoot)
 	if os.Getenv("MOM_NO_DAEMON") == "1" {
 		return nil
@@ -68,7 +68,7 @@ func ensureGlobalDaemon(projectRoot, momDir string, runtimes []string) error {
 	// brew upgrade / package updates are picked up on restart.
 
 	// Register this project in the global registry.
-	if err := daemon.RegisterProject(projectRoot, momDir, runtimes); err != nil {
+	if err := daemon.RegisterProject(projectRoot, momDir, harnesses); err != nil {
 		return fmt.Errorf("registering project: %w", err)
 	}
 
@@ -109,7 +109,7 @@ func unregisterProject(projectRoot, momDir string) error {
 }
 
 // sweepTranscripts runs a one-shot catch-up sweep for all watcher-capable
-// runtimes. Best-effort: errors are logged to stderr, never returned.
+// harnesses. Best-effort: errors are logged to stderr, never returned.
 func sweepTranscripts(projectDir, momDir string) {
 	cfg, err := config.Load(momDir)
 	if err != nil {

--- a/cli/internal/daemon/daemon.go
+++ b/cli/internal/daemon/daemon.go
@@ -19,8 +19,8 @@ type ServiceConfig struct {
 	ProjectDir string
 	// MomDir is the absolute path to the .mom/ directory.
 	MomDir string
-	// Runtimes is the list of enabled runtimes (kept for reference, not used by daemon).
-	Runtimes []string
+	// Harnesses is the list of enabled harnesses (kept for reference, not used by daemon).
+	Harnesses []string
 	// MomBinary is the absolute path to the mom binary.
 	MomBinary string
 }

--- a/cli/internal/daemon/harness_terminology_test.go
+++ b/cli/internal/daemon/harness_terminology_test.go
@@ -1,0 +1,18 @@
+package daemon_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/daemon"
+)
+
+func TestProjectRegistrationUsesHarnessesField(t *testing.T) {
+	typ := reflect.TypeOf(daemon.RegistryEntry{})
+	if _, ok := typ.FieldByName("Harnesses"); !ok {
+		t.Fatal("ProjectRegistration should expose Harnesses, not Runtimes")
+	}
+	if _, ok := typ.FieldByName("Runtimes"); ok {
+		t.Fatal("ProjectRegistration still exposes legacy Runtimes field")
+	}
+}

--- a/cli/internal/daemon/launchd.go
+++ b/cli/internal/daemon/launchd.go
@@ -81,7 +81,7 @@ func sweepLabel(hash string) string {
 }
 
 // Install creates and loads the Layer 0 daemon and Layer 1 sweep timer via launchd.
-// A single daemon watches all enabled runtimes (config-driven).
+// A single daemon watches all enabled harnesses (config-driven).
 func Install(cfg ServiceConfig) error {
 	hash := ProjectHash(cfg.ProjectDir)
 	agentsDir, err := launchAgentsDir()
@@ -97,7 +97,7 @@ func Install(cfg ServiceConfig) error {
 		return fmt.Errorf("parsing plist template: %w", err)
 	}
 
-	// Layer 0: persistent daemon — no --runtime flag, reads config for all runtimes.
+	// Layer 0: persistent daemon — no --harness flag, reads config for all harnesses.
 	dLabel := daemonLabel(hash)
 	dPath := filepath.Join(agentsDir, dLabel+".plist")
 	dData := plistData{
@@ -122,7 +122,7 @@ func Install(cfg ServiceConfig) error {
 		return fmt.Errorf("loading daemon: %w", err)
 	}
 
-	// Layer 1: periodic sweep timer — no --runtime flag, sweeps all runtimes.
+	// Layer 1: periodic sweep timer — no --harness flag, sweeps all harnesses.
 	sLabel := sweepLabel(hash)
 	sPath := filepath.Join(agentsDir, sLabel+".plist")
 	sData := plistData{
@@ -164,7 +164,7 @@ func Uninstall(cfg ServiceConfig) error {
 		// Current: com.momhq.watch-{hash}.plist, com.momhq.watch-sweep-{hash}.plist
 		"com.momhq.watch-" + hash + ".plist",
 		"com.momhq.watch-sweep-" + hash + ".plist",
-		// Legacy per-runtime: com.momhq.watch-{runtime}-{hash}.plist
+		// Legacy per-harness: com.momhq.watch-{harness}-{hash}.plist
 		"com.momhq.watch-*-" + hash + ".plist",
 	} {
 		found, _ := filepath.Glob(filepath.Join(agentsDir, pattern))

--- a/cli/internal/daemon/registry.go
+++ b/cli/internal/daemon/registry.go
@@ -12,8 +12,24 @@ import (
 
 // RegistryEntry describes a single MOM-enabled project in the global registry.
 type RegistryEntry struct {
-	MomDir   string   `json:"momDir"`
-	Runtimes []string `json:"runtimes"`
+	MomDir    string   `json:"momDir"`
+	Harnesses []string `json:"harnesses"`
+}
+
+func (e *RegistryEntry) UnmarshalJSON(data []byte) error {
+	type registryEntryAlias RegistryEntry
+	var raw struct {
+		registryEntryAlias
+		LegacyRuntimes []string `json:"runtimes"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*e = RegistryEntry(raw.registryEntryAlias)
+	if len(e.Harnesses) == 0 && len(raw.LegacyRuntimes) > 0 {
+		e.Harnesses = raw.LegacyRuntimes
+	}
+	return nil
 }
 
 // Registry maps absolute project directory paths to their entries.
@@ -119,7 +135,7 @@ func withRegistryLock(fn func() error) error {
 }
 
 // RegisterProject adds or updates a project in the registry (lock → load → upsert → save).
-func RegisterProject(projectDir, momDir string, runtimes []string) error {
+func RegisterProject(projectDir, momDir string, harnesses []string) error {
 	canonicalProjectDir := pathutil.CanonicalDir(projectDir)
 	return withRegistryLock(func() error {
 		reg, err := LoadRegistry()
@@ -132,8 +148,8 @@ func RegisterProject(projectDir, momDir string, runtimes []string) error {
 			}
 		}
 		reg[canonicalProjectDir] = RegistryEntry{
-			MomDir:   momDir,
-			Runtimes: runtimes,
+			MomDir:    momDir,
+			Harnesses: harnesses,
 		}
 		return SaveRegistry(reg)
 	})

--- a/cli/internal/daemon/registry_test.go
+++ b/cli/internal/daemon/registry_test.go
@@ -14,12 +14,12 @@ func TestRegistryRoundTrip(t *testing.T) {
 
 	reg := Registry{
 		"/home/user/project-a": RegistryEntry{
-			MomDir:   "/home/user/project-a/.mom",
-			Runtimes: []string{"claude"},
+			MomDir:    "/home/user/project-a/.mom",
+			Harnesses: []string{"claude"},
 		},
 		"/home/user/project-b": RegistryEntry{
-			MomDir:   "/home/user/project-b/.mom",
-			Runtimes: []string{"claude", "windsurf"},
+			MomDir:    "/home/user/project-b/.mom",
+			Harnesses: []string{"claude", "windsurf"},
 		},
 	}
 
@@ -39,8 +39,31 @@ func TestRegistryRoundTrip(t *testing.T) {
 	if entryA.MomDir != "/home/user/project-a/.mom" {
 		t.Errorf("unexpected momDir: %q", entryA.MomDir)
 	}
-	if len(entryA.Runtimes) != 1 || entryA.Runtimes[0] != "claude" {
-		t.Errorf("unexpected runtimes: %v", entryA.Runtimes)
+	if len(entryA.Harnesses) != 1 || entryA.Harnesses[0] != "claude" {
+		t.Errorf("unexpected harnesses: %v", entryA.Harnesses)
+	}
+}
+
+func TestLoadRegistry_PromotesLegacyRuntimesField(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	path, err := RegistryPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{
+  "/proj": {"momDir":"/proj/.mom", "runtimes":["claude"]}
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if got := reg["/proj"].Harnesses; len(got) != 1 || got[0] != "claude" {
+		t.Fatalf("Harnesses = %v, want legacy runtimes promoted", got)
 	}
 }
 
@@ -127,7 +150,7 @@ func TestLoadRegistryCanonicalizesSymlinkedProjectDir(t *testing.T) {
 
 	// Simulate an older registry entry written before canonicalization.
 	if err := SaveRegistry(Registry{
-		linkProjectDir: {MomDir: filepath.Join(linkProjectDir, ".mom"), Runtimes: []string{"claude"}},
+		linkProjectDir: {MomDir: filepath.Join(linkProjectDir, ".mom"), Harnesses: []string{"claude"}},
 	}); err != nil {
 		t.Fatalf("SaveRegistry: %v", err)
 	}

--- a/cli/internal/daemon/systemd.go
+++ b/cli/internal/daemon/systemd.go
@@ -35,7 +35,7 @@ func sweepTimerName(hash string) string {
 }
 
 // Install creates and enables the Layer 0 daemon service and Layer 1 sweep timer via systemd.
-// A single daemon watches all enabled runtimes (config-driven).
+// A single daemon watches all enabled harnesses (config-driven).
 func Install(cfg ServiceConfig) error {
 	hash := ProjectHash(cfg.ProjectDir)
 	unitDir, err := systemdUserDir()
@@ -46,7 +46,7 @@ func Install(cfg ServiceConfig) error {
 	logsDir := filepath.Join(cfg.MomDir, "logs")
 	_ = os.MkdirAll(logsDir, 0755)
 
-	// Layer 0: persistent daemon service — no --runtime, reads config.
+	// Layer 0: persistent daemon service — no --harness, reads config.
 	daemonUnit := fmt.Sprintf(`[Unit]
 Description=MOM watch daemon (%s)
 
@@ -70,7 +70,7 @@ WantedBy=default.target
 		return fmt.Errorf("writing daemon service: %w", err)
 	}
 
-	// Layer 1: one-shot sweep service — no --runtime, sweeps all.
+	// Layer 1: one-shot sweep service — no --harness, sweeps all.
 	sweepUnit := fmt.Sprintf(`[Unit]
 Description=MOM watch sweep (%s)
 
@@ -136,7 +136,7 @@ func Uninstall(cfg ServiceConfig) error {
 		"mom-watch-" + hash + ".service",
 		"mom-watch-sweep-" + hash + ".service",
 		"mom-watch-sweep-" + hash + ".timer",
-		// Legacy per-runtime names.
+		// Legacy per-harness names.
 		"mom-watch-*-" + hash + ".service",
 		"mom-watch-sweep-*-" + hash + ".service",
 		"mom-watch-sweep-*-" + hash + ".timer",

--- a/cli/internal/mcp/server.go
+++ b/cli/internal/mcp/server.go
@@ -1,6 +1,6 @@
 // Package mcp implements a minimal Model Context Protocol server over stdio.
 // It exposes MOM memories as MCP tools and resources, allowing any MCP-aware
-// runtime (Claude Code, Cursor, Cline, …) to query and write memories without
+// harness (Claude Code, Cursor, Cline, …) to query and write memories without
 // adapter code.
 //
 // Transport: JSON-RPC 2.0, newline-delimited, over stdin/stdout.

--- a/cli/internal/mcp/tools.go
+++ b/cli/internal/mcp/tools.go
@@ -71,12 +71,12 @@ func allTools() []toolDef {
 		},
 		{
 			Name:        "mom_record",
-			Description: "Fallback explicit-write path: intentionally save a memory mid-session when CLI is unavailable. Bypasses Drafter's content filters and stamps trigger_event='record', source_type='manual-draft'. Required: content. Optional: session_id only when it is a real runtime session ID; never invent one. Optional: summary, tags, actor.",
+			Description: "Fallback explicit-write path: intentionally save a memory mid-session when CLI is unavailable. Bypasses Drafter's content filters and stamps trigger_event='record', source_type='manual-draft'. Required: content. Optional: session_id only when it is a real harness session ID; never invent one. Optional: summary, tags, actor.",
 			InputSchema: map[string]any{
 				"type":     "object",
 				"required": []string{"content"},
 				"properties": map[string]any{
-					"session_id": map[string]any{"type": "string", "description": "Real runtime session ID only. Omit when unavailable; MOM resolves known harness env vars or rejects."},
+					"session_id": map[string]any{"type": "string", "description": "Real harness session ID only. Omit when unavailable; MOM resolves known harness env vars or rejects."},
 					"summary":    map[string]any{"type": "string", "description": "One-line summary"},
 					"tags":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Tag names (will be normalised; empty after normalisation rejects the request)"},
 					"content":    map[string]any{"type": "object", "description": "Memory content (must include $.text for FTS)"},


### PR DESCRIPTION
## Summary
- update user-facing command/help/MCP text from runtime to harness terminology
- rename daemon registry field from Runtimes to Harnesses
- update GitHub templates and tests/comments to use harness vocabulary
- add guard tests for public command text and daemon registry shape

Closes #312

## Tests
- cd cli && go test ./...
