### PR TITLE
feat(uninstall): rewrite for global-vault structure

### DIFF
--- a/cli/internal/adapters/harness/global.go
+++ b/cli/internal/adapters/harness/global.go
@@ -96,6 +96,41 @@ func upsertManagedBlock(path, body string) error {
 	return os.WriteFile(path, []byte(updated), 0o644)
 }
 
+// RemoveManagedBlock strips the MOM-generated block from a global context
+// file (e.g. ~/.claude/CLAUDE.md), preserving any surrounding user content.
+// If the block is absent, the file is left untouched. If no other content
+// remains after removal, the file is deleted.
+func RemoveManagedBlock(path string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	content := string(existing)
+	start := strings.Index(content, momBlockStart)
+	end := strings.Index(content, momBlockEnd)
+	if start < 0 || end < 0 || end < start {
+		return nil
+	}
+	end += len(momBlockEnd)
+	head := strings.TrimRight(content[:start], "\n")
+	tail := strings.TrimLeft(content[end:], "\n")
+	var updated string
+	switch {
+	case head == "" && tail == "":
+		return os.Remove(path)
+	case head == "":
+		updated = tail
+	case tail == "":
+		updated = head + "\n"
+	default:
+		updated = head + "\n\n" + tail
+	}
+	return os.WriteFile(path, []byte(updated), 0o644)
+}
+
 func upsertClaudeUserMCP() error {
 	path, err := homePath(".claude.json")
 	if err != nil {

--- a/cli/internal/cmd/uninstall.go
+++ b/cli/internal/cmd/uninstall.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 
 	"github.com/momhq/mom/cli/internal/adapters/harness"
+	"github.com/momhq/mom/cli/internal/centralvault"
 	"github.com/momhq/mom/cli/internal/config"
+	"github.com/momhq/mom/cli/internal/daemon"
+	"github.com/momhq/mom/cli/internal/pathutil"
 	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/ux"
 	"github.com/spf13/cobra"
@@ -16,59 +19,278 @@ import (
 
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
-	Short: "Remove all MOM files from this project",
-	Long: `Removes .mom/ directory and any generated harness files (e.g. .claude/CLAUDE.md, AGENTS.md).
-Optionally backs up your memory before removal using the export command.`,
+	Short: "Remove MOM from this project or globally",
+	Long: `Interactively remove MOM.
+
+Two modes are offered:
+  1) Disconnect this project — remove harness files + watch registry entry; keep central vault
+  2) Full uninstall          — also remove global skills, harness context, watch daemon, central vault
+
+No flags. The command always prompts for confirmation.`,
 	RunE: runUninstall,
 }
 
-func init() {
-	uninstallCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
-	uninstallCmd.Flags().Bool("no-backup", false, "Skip backup prompt — delete without exporting")
-	uninstallCmd.Flags().Bool("force", false, "Force removal even if .mom/ is not found")
+func runUninstall(cmd *cobra.Command, args []string) error {
+	p := ux.NewPrinter(cmd.OutOrStdout())
+	in := bufio.NewScanner(cmd.InOrStdin())
+
+	switch promptTopMenu(p, in, cmd) {
+	case "1":
+		return runDisconnectProject(p, in, cmd)
+	case "2":
+		if !promptFullUninstallConfirmation(p, in, cmd) {
+			p.Muted("uninstall cancelled")
+			return nil
+		}
+		return runFullUninstall(p, cmd)
+	default:
+		p.Muted("uninstall cancelled")
+		return nil
+	}
 }
 
-func runUninstall(cmd *cobra.Command, args []string) error {
+func promptTopMenu(p *ux.Printer, in *bufio.Scanner, cmd *cobra.Command) string {
+	p.Diamond("MOM uninstall")
+	p.Blank()
+	p.Text("What do you want to remove?")
+	p.Chevron("1) Disconnect this project  (remove harness files + watch registry; keep central vault)")
+	p.Chevron("2) Full uninstall           (everything: project + global skills + central vault)")
+	p.Chevron("0) Cancel")
+	p.Blank()
+	fmt.Fprintf(cmd.OutOrStdout(), "Choose [0/1/2]: ")
+	if in.Scan() {
+		return strings.TrimSpace(in.Text())
+	}
+	return "0"
+}
+
+const fullUninstallPhrase = "delete everything"
+
+func promptFullUninstallConfirmation(p *ux.Printer, in *bufio.Scanner, cmd *cobra.Command) bool {
+	p.Blank()
+	p.Bold("Full uninstall")
+	p.Text("Will remove this project's MOM files, global skills, global harness context,")
+	p.Text("the global watch daemon, and the central vault at ~/.mom/mom.db")
+	p.Text("(ALL memory across ALL projects). This is irreversible.")
+	p.Text("To keep memory, export first with `mom export`.")
+	p.Blank()
+	fmt.Fprintf(cmd.OutOrStdout(), "Type %q to confirm: ", fullUninstallPhrase)
+	if !in.Scan() {
+		return false
+	}
+	return strings.TrimSpace(in.Text()) == fullUninstallPhrase
+}
+
+func runFullUninstall(p *ux.Printer, cmd *cobra.Command) error {
+	if err := removeGlobalWatchDaemon(p); err != nil {
+		p.Warnf("removing global watch daemon: %v", err)
+	}
+	if err := removeGlobalHarnessContext(p); err != nil {
+		p.Warnf("removing global harness context: %v", err)
+	}
+	if err := removeCentralVault(p); err != nil {
+		p.Warnf("removing central vault: %v", err)
+	}
+	p.Blank()
+	p.Text("MOM fully uninstalled.")
+	return nil
+}
+
+func removeGlobalWatchDaemon(p *ux.Printer) error {
+	// Tear down OS daemon/service files (launchd on macOS, systemd on linux).
+	if err := daemon.UninstallGlobal(); err != nil {
+		p.Warnf("daemon service teardown: %v", err)
+	} else {
+		p.Check("removed global watch daemon")
+	}
+
+	// Clear the watch registry by unregistering every entry.
+	reg, err := daemon.LoadRegistry()
+	if err != nil {
+		return err
+	}
+	for projectDir := range reg {
+		if err := daemon.UnregisterProject(projectDir); err != nil {
+			p.Warnf("unregistering %s: %v", projectDir, err)
+		}
+	}
+	return nil
+}
+
+func removeGlobalHarnessContext(p *ux.Printer) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	// Known global context files per registered harness.
+	paths := []string{
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".codex", "AGENTS.md"),
+	}
+	for _, path := range paths {
+		if err := harness.RemoveManagedBlock(path); err != nil {
+			p.Warnf("stripping MOM block from %s: %v", path, err)
+			continue
+		}
+		if _, statErr := os.Stat(path); statErr != nil {
+			p.Checkf("removed %s", path)
+		}
+	}
+	return nil
+}
+
+func removeCentralVault(p *ux.Printer) error {
+	path, err := centralvault.Path()
+	if err != nil {
+		return err
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		return nil
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	p.Checkf("removed central vault (%s)", path)
+	return nil
+}
+
+// findProjectRoot resolves the project root for the current working
+// directory. Strategy (per #303 design lock):
+//   1. Look up cwd (and its ancestors) in the global watch registry.
+//   2. Fall back to scope-walk for a project-local `.mom/` directory
+//      (transitional users with leftover dirs from pre-v0.30 installs).
+//
+// Returns the project root and a flag indicating whether a project-local
+// `.mom/` mirror was detected.
+func findProjectRoot(cwd string) (root string, hasLocalMom bool, ok bool) {
+	reg, err := daemon.LoadRegistry()
+	if err == nil {
+		canonicalCwd := pathutil.CanonicalDir(cwd)
+		for dir := canonicalCwd; ; {
+			if _, present := reg[dir]; present {
+				_, statErr := os.Stat(filepath.Join(dir, ".mom"))
+				return dir, statErr == nil, true
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+	if sc, ok := scope.NearestWritable(cwd); ok {
+		return filepath.Dir(sc.Path), true, true
+	}
+	return "", false, false
+}
+
+func runDisconnectProject(p *ux.Printer, in *bufio.Scanner, cmd *cobra.Command) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("getting cwd: %w", err)
 	}
 
-	// Find .mom/ via scope walk (works from any subdirectory).
-	var momDir string
-	hasLeoDir := false
-	if sc, ok := scope.NearestWritable(cwd); ok {
-		momDir = sc.Path
-		hasLeoDir = true
+	projectRoot, hasLocalMom, ok := findProjectRoot(cwd)
+	if !ok {
+		p.Warn("no MOM-connected project detected for this directory")
+		return nil
 	}
 
-	if !hasLeoDir {
-		force, _ := cmd.Flags().GetBool("force")
-		if !force {
-			return fmt.Errorf("no .mom/ directory found from %s", cwd)
+	adapters := resolveProjectAdapters(projectRoot, hasLocalMom)
+
+	p.Blank()
+	p.Textf("Project: %s", projectRoot)
+	p.Text("Will remove:")
+	if hasLocalMom {
+		p.Chevron(".mom/ (project-local memory mirror)")
+	}
+	seen := make(map[string]bool)
+	for _, a := range adapters {
+		for _, f := range a.GeneratedFiles() {
+			if !seen[f] {
+				seen[f] = true
+				p.Chevron(f)
+			}
 		}
-		momDir = filepath.Join(cwd, ".mom")
+	}
+	p.Chevron("watch registry entry")
+	p.Text("Central vault at ~/.mom/mom.db is NOT touched.")
+	p.Blank()
+	fmt.Fprintf(cmd.OutOrStdout(), "Proceed? [y/N]: ")
+	answer := ""
+	if in.Scan() {
+		answer = strings.TrimSpace(in.Text())
+	}
+	if strings.ToLower(answer) != "y" {
+		p.Muted("uninstall cancelled")
+		return nil
 	}
 
-	// Project root is the parent of .mom/.
-	projectRoot := filepath.Dir(momDir)
+	// Remove project-local .mom/ if present.
+	if hasLocalMom {
+		momDir := filepath.Join(projectRoot, ".mom")
+		if err := os.RemoveAll(momDir); err != nil {
+			p.Warnf("removing .mom/: %v", err)
+		} else {
+			p.Check("removed .mom/")
+		}
+	}
 
-	// Resolve adapters from config — use registry for all enabled harnesses.
+	// Remove adapter-generated files.
+	removed := make(map[string]bool)
+	for _, a := range adapters {
+		for _, rel := range a.GeneratedFiles() {
+			if removed[rel] {
+				continue
+			}
+			abs := filepath.Join(projectRoot, rel)
+			if _, err := os.Stat(abs); err == nil {
+				_ = os.Remove(abs)
+				p.Checkf("removed %s", rel)
+				removed[rel] = true
+			}
+		}
+		for _, relDir := range a.GeneratedDirs() {
+			absDir := filepath.Join(projectRoot, relDir)
+			if entries, err := os.ReadDir(absDir); err == nil && len(entries) == 0 {
+				_ = os.Remove(absDir)
+				p.Checkf("removed empty %s/", relDir)
+			}
+		}
+	}
+
+	// Unregister from global watch daemon.
+	if err := daemon.UnregisterProject(projectRoot); err != nil {
+		p.Warnf("watch registry removal: %v", err)
+	} else {
+		p.Check("removed from watch registry")
+	}
+
+	p.Blank()
+	p.Text("Project disconnected.")
+	return nil
+}
+
+// resolveProjectAdapters returns the set of harness adapters whose files
+// should be removed for this project. Strategy:
+//   1. If a project-local `.mom/config.yaml` exists, use its enabled
+//      harnesses (preserves legacy behavior for users mid-migration).
+//   2. Otherwise, return all adapters that have at least one generated
+//      file present on disk in the project root.
+func resolveProjectAdapters(projectRoot string, hasLocalMom bool) []harness.Adapter {
 	registry := harness.NewRegistry(projectRoot)
 	var adapters []harness.Adapter
 
-	if hasLeoDir {
-		cfg, err := config.Load(momDir)
-		if err == nil {
-			for _, rt := range cfg.EnabledHarnesses() {
-				if a, ok := registry.Get(rt); ok {
+	if hasLocalMom {
+		if cfg, err := config.Load(filepath.Join(projectRoot, ".mom")); err == nil {
+			for _, name := range cfg.EnabledHarnesses() {
+				if a, ok := registry.Get(name); ok {
 					adapters = append(adapters, a)
 				}
 			}
 		}
 	}
 
-	// Fallback: if no adapters resolved, try all known adapters that have files present.
 	if len(adapters) == 0 {
 		for _, a := range registry.All() {
 			for _, f := range a.GeneratedFiles() {
@@ -80,117 +302,5 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Last fallback: claude.
-	if len(adapters) == 0 {
-		if a, ok := registry.Get("claude"); ok {
-			adapters = append(adapters, a)
-		}
-	}
-
-	yes, _ := cmd.Flags().GetBool("yes")
-	noBackup, _ := cmd.Flags().GetBool("no-backup")
-
-	p := ux.NewPrinter(cmd.OutOrStdout())
-
-	// Confirm with user.
-	if !yes {
-		p.Diamond("uninstall")
-		p.Blank()
-		p.Text("This will remove all MOM files from this project:")
-		if hasLeoDir {
-			p.Chevron(".mom/ (config, memory, cache)")
-		}
-		// Deduplicate file paths across adapters.
-		seen := make(map[string]bool)
-		for _, adapter := range adapters {
-			for _, f := range adapter.GeneratedFiles() {
-				if !seen[f] {
-					seen[f] = true
-					p.Chevron(f)
-				}
-			}
-		}
-		p.Blank()
-		fmt.Fprintf(p.W, "Proceed? %s ", p.MutedText("[y/N]:"))
-
-		scanner := bufio.NewScanner(cmd.InOrStdin())
-		answer := ""
-		if scanner.Scan() {
-			answer = strings.TrimSpace(scanner.Text())
-		}
-		if strings.ToLower(answer) != "y" {
-			return fmt.Errorf("uninstall aborted")
-		}
-	}
-
-	// Offer backup.
-	if hasLeoDir && !noBackup {
-		doBackup := false
-		if yes {
-			doBackup = true
-		} else {
-			fmt.Fprintf(p.W, "  Back up memory before removing? %s ", p.MutedText("[Y/n]:"))
-			scanner := bufio.NewScanner(cmd.InOrStdin())
-			answer := ""
-			if scanner.Scan() {
-				answer = strings.TrimSpace(scanner.Text())
-			}
-			doBackup = answer == "" || strings.ToLower(answer) == "y"
-		}
-
-		if doBackup {
-			exportDir := filepath.Join(projectRoot, "mom-export")
-			p.Muted(fmt.Sprintf("exporting to %s...", exportDir))
-			exportCmd.Flags().Set("output", exportDir) //nolint:errcheck
-			if err := runExport(cmd, nil); err != nil {
-				return fmt.Errorf("backup failed: %w — aborting uninstall", err)
-			}
-			p.Checkf("backup complete")
-		}
-	}
-
-	// Unregister from global watch daemon.
-	if err := unregisterProject(projectRoot, momDir); err != nil {
-		p.Warnf("watch daemon removal: %v", err)
-	} else {
-		p.Check("watch daemon removed")
-	}
-
-	// Remove .mom/.
-	if hasLeoDir {
-		if err := os.RemoveAll(momDir); err != nil {
-			return fmt.Errorf("removing .mom/: %w", err)
-		}
-		p.Checkf("removed .mom/")
-	}
-
-	// Remove generated harness files via adapters (deduplicated).
-	removed := make(map[string]bool)
-	for _, adapter := range adapters {
-		for _, relPath := range adapter.GeneratedFiles() {
-			if removed[relPath] {
-				continue
-			}
-			absPath := filepath.Join(projectRoot, relPath)
-			if _, err := os.Stat(absPath); err == nil {
-				os.Remove(absPath)
-				p.Checkf("removed %s", relPath)
-				removed[relPath] = true
-			}
-		}
-
-		// Remove generated dirs if empty.
-		for _, relDir := range adapter.GeneratedDirs() {
-			absDir := filepath.Join(projectRoot, relDir)
-			entries, err := os.ReadDir(absDir)
-			if err == nil && len(entries) == 0 {
-				os.Remove(absDir)
-				p.Checkf("removed empty %s/", relDir)
-			}
-		}
-	}
-
-	p.Blank()
-	p.Text("MOM has been removed from this project.")
-	return nil
+	return adapters
 }

--- a/cli/internal/cmd/uninstall_test.go
+++ b/cli/internal/cmd/uninstall_test.go
@@ -1,0 +1,291 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/centralvault"
+	"github.com/momhq/mom/cli/internal/daemon"
+)
+
+// setupUninstallTestEnv isolates HOME and MOM_VAULT to temp dirs and changes
+// cwd to a fresh tempdir. Returns (home, cwd, vaultPath).
+func setupUninstallTestEnv(t *testing.T) (string, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MOM_VAULT", filepath.Join(home, ".mom", "central.db"))
+	vaultPath, err := centralvault.Path()
+	if err != nil {
+		t.Fatalf("centralvault.Path: %v", err)
+	}
+
+	cwd := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	return home, cwd, vaultPath
+}
+
+// runUninstallCmd invokes `mom uninstall` via rootCmd with the supplied stdin.
+func runUninstallCmd(t *testing.T, stdin string) (string, error) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetIn(strings.NewReader(stdin))
+	rootCmd.SetArgs([]string{"uninstall"})
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// Path 1 (disconnect this project): removes harness context files and the
+// project's watch-registry entry, but leaves the central vault untouched.
+func TestUninstall_DisconnectProject_RemovesHarnessFilesPreservesVault(t *testing.T) {
+	_, _, vaultPath := setupUninstallTestEnv(t)
+
+	// Pre-create central vault and assert its bytes survive.
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o755); err != nil {
+		t.Fatalf("mkdir vault: %v", err)
+	}
+	if err := os.WriteFile(vaultPath, []byte("vault-bytes"), 0o644); err != nil {
+		t.Fatalf("write vault: %v", err)
+	}
+
+	// Create a project root and chdir into it.
+	projectRoot := t.TempDir()
+	if err := os.Chdir(projectRoot); err != nil {
+		t.Fatalf("chdir project: %v", err)
+	}
+
+	// Pre-create claude harness files inside the project.
+	claudeMd := filepath.Join(projectRoot, ".claude", "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Dir(claudeMd), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.WriteFile(claudeMd, []byte("generated"), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+	mcpJSON := filepath.Join(projectRoot, ".mcp.json")
+	if err := os.WriteFile(mcpJSON, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write .mcp.json: %v", err)
+	}
+
+	// Register the project in the global watch registry.
+	if err := daemon.RegisterProject(projectRoot, filepath.Join(projectRoot, ".mom"), []string{"claude"}); err != nil {
+		t.Fatalf("register project: %v", err)
+	}
+
+	out, err := runUninstallCmd(t, "1\ny\n")
+	if err != nil {
+		t.Fatalf("disconnect returned error: %v\noutput:\n%s", err, out)
+	}
+
+	// Harness files removed.
+	if _, err := os.Stat(claudeMd); err == nil {
+		t.Errorf(".claude/CLAUDE.md should have been removed")
+	}
+	if _, err := os.Stat(mcpJSON); err == nil {
+		t.Errorf(".mcp.json should have been removed")
+	}
+
+	// Central vault preserved.
+	got, readErr := os.ReadFile(vaultPath)
+	if readErr != nil {
+		t.Fatalf("central vault must survive disconnect: %v", readErr)
+	}
+	if string(got) != "vault-bytes" {
+		t.Errorf("central vault bytes mutated; got %q", string(got))
+	}
+
+	// Project unregistered.
+	reg, regErr := daemon.LoadRegistry()
+	if regErr != nil {
+		t.Fatalf("load registry: %v", regErr)
+	}
+	for k := range reg {
+		if k == projectRoot {
+			t.Errorf("project still present in watch registry after disconnect")
+		}
+	}
+}
+
+// Full uninstall tears down the global watch daemon: clears all watch
+// registry entries and removes any installed daemon service files.
+func TestUninstall_FullUninstall_RemovesGlobalWatchDaemon(t *testing.T) {
+	home, _, _ := setupUninstallTestEnv(t)
+
+	// Register two projects in the global registry to prove the full
+	// uninstall clears everything, not just cwd.
+	p1 := t.TempDir()
+	p2 := t.TempDir()
+	if err := daemon.RegisterProject(p1, filepath.Join(p1, ".mom"), []string{"claude"}); err != nil {
+		t.Fatalf("register p1: %v", err)
+	}
+	if err := daemon.RegisterProject(p2, filepath.Join(p2, ".mom"), []string{"claude"}); err != nil {
+		t.Fatalf("register p2: %v", err)
+	}
+
+	// Pre-create a fake daemon service file under the isolated HOME.
+	// macOS: ~/Library/LaunchAgents/com.momhq.watch.plist
+	// linux: ~/.config/systemd/user/mom-watch.service
+	// We create both shapes; whichever the OS-specific UninstallGlobal
+	// targets will be removed; the other is harmless leftover.
+	macPlist := filepath.Join(home, "Library", "LaunchAgents", "com.momhq.watch.plist")
+	if err := os.MkdirAll(filepath.Dir(macPlist), 0o755); err != nil {
+		t.Fatalf("mkdir LaunchAgents: %v", err)
+	}
+	if err := os.WriteFile(macPlist, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatalf("write plist: %v", err)
+	}
+
+	out, err := runUninstallCmd(t, "2\ndelete everything\n")
+	if err != nil {
+		t.Fatalf("full uninstall returned error: %v\noutput:\n%s", err, out)
+	}
+
+	// Watch registry must be empty after full uninstall.
+	reg, regErr := daemon.LoadRegistry()
+	if regErr != nil {
+		t.Fatalf("load registry: %v", regErr)
+	}
+	if len(reg) != 0 {
+		t.Errorf("watch registry must be empty after full uninstall, got %d entries", len(reg))
+	}
+
+	// Daemon service file must be removed (macOS path).
+	if _, err := os.Stat(macPlist); err == nil {
+		t.Errorf("daemon plist must be removed by full uninstall on macOS")
+	}
+}
+
+// Full uninstall strips the MOM block from ~/.claude/CLAUDE.md while
+// preserving the user's surrounding content.
+func TestUninstall_FullUninstall_StripsGlobalHarnessContext(t *testing.T) {
+	home, _, _ := setupUninstallTestEnv(t)
+
+	claudeMd := filepath.Join(home, ".claude", "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Dir(claudeMd), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	content := "# My personal notes\n\nKeep me.\n\n" +
+		"<!-- BEGIN MOM GENERATED BLOCK -->\n" +
+		"mom-block-body\n" +
+		"<!-- END MOM GENERATED BLOCK -->\n\n" +
+		"More personal notes.\n"
+	if err := os.WriteFile(claudeMd, []byte(content), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	out, err := runUninstallCmd(t, "2\ndelete everything\n")
+	if err != nil {
+		t.Fatalf("full uninstall returned error: %v\noutput:\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(claudeMd)
+	if err != nil {
+		t.Fatalf("CLAUDE.md should still exist (only the MOM block is stripped): %v", err)
+	}
+	gotStr := string(got)
+	if strings.Contains(gotStr, "BEGIN MOM GENERATED BLOCK") || strings.Contains(gotStr, "mom-block-body") {
+		t.Errorf("MOM block must be removed from CLAUDE.md, got:\n%s", gotStr)
+	}
+	if !strings.Contains(gotStr, "My personal notes") || !strings.Contains(gotStr, "More personal notes.") {
+		t.Errorf("user content must be preserved, got:\n%s", gotStr)
+	}
+}
+
+// Path 2 + correct confirmation phrase deletes the central vault file.
+func TestUninstall_FullUninstall_CorrectPhraseRemovesVault(t *testing.T) {
+	_, _, vaultPath := setupUninstallTestEnv(t)
+
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o755); err != nil {
+		t.Fatalf("mkdir vault: %v", err)
+	}
+	if err := os.WriteFile(vaultPath, []byte("vault-bytes"), 0o644); err != nil {
+		t.Fatalf("write vault: %v", err)
+	}
+
+	out, err := runUninstallCmd(t, "2\ndelete everything\n")
+	if err != nil {
+		t.Fatalf("full uninstall returned error: %v\noutput:\n%s", err, out)
+	}
+
+	if _, err := os.Stat(vaultPath); err == nil {
+		t.Errorf("central vault must be deleted after full uninstall with correct phrase")
+	}
+}
+
+// Path 2 (full uninstall) requires typing the literal phrase "delete everything".
+// Any other input must abort with no filesystem changes — guards the central vault.
+func TestUninstall_FullUninstall_WrongPhraseAborts(t *testing.T) {
+	_, cwd, vaultPath := setupUninstallTestEnv(t)
+
+	// Pre-create a fake central vault file so we can verify it survives.
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o755); err != nil {
+		t.Fatalf("mkdir vault: %v", err)
+	}
+	if err := os.WriteFile(vaultPath, []byte("vault-bytes"), 0o644); err != nil {
+		t.Fatalf("write vault: %v", err)
+	}
+
+	out, err := runUninstallCmd(t, "2\nyes please\n")
+	if err != nil {
+		t.Fatalf("wrong-phrase abort returned error: %v\noutput:\n%s", err, out)
+	}
+
+	// Central vault must still exist with original bytes.
+	got, readErr := os.ReadFile(vaultPath)
+	if readErr != nil {
+		t.Fatalf("central vault must survive wrong-phrase abort: %v", readErr)
+	}
+	if string(got) != "vault-bytes" {
+		t.Errorf("central vault bytes mutated; got %q", string(got))
+	}
+	// cwd untouched.
+	entries, _ := os.ReadDir(cwd)
+	if len(entries) != 0 {
+		t.Errorf("cwd should be untouched on abort, got %d entries", len(entries))
+	}
+	// Output must prove the path-2 warning was shown (so we know the
+	// branch actually executed before the abort) AND that the run aborted.
+	lo := strings.ToLower(out)
+	if !strings.Contains(lo, "delete everything") {
+		t.Errorf("expected full-uninstall confirmation prompt mentioning 'delete everything', got:\n%s", out)
+	}
+	if !strings.Contains(lo, "cancel") && !strings.Contains(lo, "abort") {
+		t.Errorf("expected cancel/abort message, got:\n%s", out)
+	}
+}
+
+// Tracer bullet: choosing "0) Cancel" at the top menu exits cleanly and
+// touches no filesystem state.
+func TestUninstall_CancelAtTopMenu_NoFilesystemChanges(t *testing.T) {
+	home, cwd, _ := setupUninstallTestEnv(t)
+
+	out, err := runUninstallCmd(t, "0\n")
+	if err != nil {
+		t.Fatalf("cancel path returned error: %v\noutput:\n%s", err, out)
+	}
+
+	// Central vault directory must not have been created.
+	if _, err := os.Stat(filepath.Join(home, ".mom")); err == nil {
+		t.Errorf("HOME/.mom must not be created on cancel")
+	}
+	// Cwd must remain empty.
+	entries, _ := os.ReadDir(cwd)
+	if len(entries) != 0 {
+		t.Errorf("cwd should remain empty on cancel, got %d entries", len(entries))
+	}
+	// Output should clearly say it was cancelled.
+	lo := strings.ToLower(out)
+	if !strings.Contains(lo, "cancel") {
+		t.Errorf("expected output to mention cancellation, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Rewrites \`mom uninstall\` as an interactive command with no flags
- Two modes: **(1) Disconnect this project** or **(2) Full uninstall** (which requires typing \`delete everything\` to confirm)
- Project root resolution is registry-first (global watch registry) with scope-walk fallback for users mid-migration
- Full uninstall tears down the global watch daemon, clears the registry, strips the MOM-managed block from \`~/.claude/CLAUDE.md\` while preserving user content, and deletes the central vault

Closes #303.

## Test plan

- [x] \`go test ./internal/cmd/ -run TestUninstall_\` — all 6 tests GREEN
- [x] \`go test ./internal/centralvault/\` — guardrail tests GREEN
- [x] Full suite regression: only pre-existing session-id failures on \`v0.40-dev\` remain (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)