### PR TITLE
cleanup: drop scope-walk from resolveMomContext (part of #310)

### DIFF
--- a/cli/internal/cmd/watch_helpers.go
+++ b/cli/internal/cmd/watch_helpers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/momhq/mom/cli/internal/config"
 	"github.com/momhq/mom/cli/internal/daemon"
 	"github.com/momhq/mom/cli/internal/pathutil"
-	"github.com/momhq/mom/cli/internal/scope"
 	"github.com/momhq/mom/cli/internal/watcher"
 )
 
@@ -32,9 +31,6 @@ func harnessTranscriptDir(name string) string {
 
 func resolveMomContext(cwd string) (projectDir string, momDir string, err error) {
 	cwd = pathutil.CanonicalDir(cwd)
-	if sc, ok := scope.NearestWritable(cwd); ok {
-		return filepath.Dir(sc.Path), sc.Path, nil
-	}
 	centralDir, err := centralvault.Dir()
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
## Summary

- Removes the \`scope.NearestWritable\` fallback from \`resolveMomContext\` in \`cli/internal/cmd/watch_helpers.go\`
- Under the central-vault model (ADR 0009), \`mom watch\` and \`mom serve\` always operate against \`\$HOME/.mom\` — there is no per-project \`.mom/\` to discover
- Leaves \`scope.NearestWritable\` use in \`uninstall.go\` intact (legacy-cleanup fallback for users with leftover project-local \`.mom/\` dirs from earlier versions)
- Refs #310. Does not close it — \`mom map\` (cartographer) still uses scope; that's tracked separately

## Test plan

- [x] \`go test ./internal/cmd/ -run "TestResolveMomContext|TestWatch|TestUninstall"\` — GREEN
- [x] Full \`go test ./...\` regression — only pre-existing session-id failures remain (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)