### PR TITLE
feat(watcher): Codex CLI transcript tail ingestion

### DIFF
--- a/cli/internal/adapters/harness/codex.go
+++ b/cli/internal/adapters/harness/codex.go
@@ -33,6 +33,16 @@ func (a *CodexAdapter) Tier() Tier {
 	return Fluent
 }
 
+// DefaultTranscriptDir returns Codex's session transcript directory.
+// Honors $CODEX_HOME when set (per Codex docs); otherwise falls back to
+// ~/.codex/sessions.
+func (a *CodexAdapter) DefaultTranscriptDir() string {
+	if home := os.Getenv("CODEX_HOME"); home != "" {
+		return filepath.Join(home, "sessions")
+	}
+	return "~/.codex/sessions"
+}
+
 func (a *CodexAdapter) GenerateContextFile(config Config, constraints []Constraint, skills []Skill, identity *Identity) error {
 	var body string
 	if config.Delivery == "context-file" {
@@ -238,6 +248,7 @@ func codexHomePath(parts ...string) (string, error) {
 }
 
 var (
-	_ GlobalAdapter = (*CodexAdapter)(nil)
-	_ HookInstaller = (*CodexAdapter)(nil)
+	_ GlobalAdapter    = (*CodexAdapter)(nil)
+	_ HookInstaller    = (*CodexAdapter)(nil)
+	_ TranscriptSource = (*CodexAdapter)(nil)
 )

--- a/cli/internal/adapters/harness/codex_test.go
+++ b/cli/internal/adapters/harness/codex_test.go
@@ -15,6 +15,26 @@ func TestCodexAdapter_Name(t *testing.T) {
 	}
 }
 
+func TestCodexAdapter_DefaultTranscriptDir(t *testing.T) {
+	t.Run("uses CODEX_HOME when set", func(t *testing.T) {
+		t.Setenv("CODEX_HOME", "/custom/codex")
+		a := NewCodexAdapter("/tmp")
+		got := a.DefaultTranscriptDir()
+		want := "/custom/codex/sessions"
+		if got != want {
+			t.Errorf("DefaultTranscriptDir = %q, want %q", got, want)
+		}
+	})
+	t.Run("falls back to ~/.codex/sessions when CODEX_HOME unset", func(t *testing.T) {
+		t.Setenv("CODEX_HOME", "")
+		a := NewCodexAdapter("/tmp")
+		got := a.DefaultTranscriptDir()
+		if got != "~/.codex/sessions" {
+			t.Errorf("DefaultTranscriptDir = %q, want ~/.codex/sessions", got)
+		}
+	})
+}
+
 func TestCodexAdapter_DetectHarness(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cli/internal/cmd/watch_codex_source_test.go
+++ b/cli/internal/cmd/watch_codex_source_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/config"
+)
+
+// When the codex harness is enabled, buildWatcherSources must return a
+// watcher.Source for it, wired to the CodexAdapter and using the harness's
+// DefaultTranscriptDir.
+func TestBuildWatcherSources_IncludesCodexWhenEnabled(t *testing.T) {
+	t.Setenv("CODEX_HOME", "")
+
+	cfg := config.Default()
+	cfg.Harnesses["codex"] = config.HarnessConfig{Enabled: true}
+
+	sources := buildWatcherSources(&cfg, "/tmp/project")
+
+	var got *struct {
+		dir string
+		adp string
+	}
+	for _, s := range sources {
+		if s.Harness == "codex" {
+			got = &struct {
+				dir string
+				adp string
+			}{s.TranscriptDir, s.Adapter.Name()}
+		}
+	}
+	if got == nil {
+		t.Fatalf("expected a codex source in buildWatcherSources, got %d sources (none codex)", len(sources))
+	}
+	if got.dir != "~/.codex/sessions" {
+		t.Errorf("codex source TranscriptDir = %q, want ~/.codex/sessions", got.dir)
+	}
+	if got.adp != "codex" {
+		t.Errorf("codex source Adapter.Name() = %q, want codex", got.adp)
+	}
+}
+
+// CodexTranscriptDir config override is honored when set.
+func TestBuildWatcherSources_CodexHonorsConfigOverride(t *testing.T) {
+	cfg := config.Default()
+	cfg.Harnesses["codex"] = config.HarnessConfig{Enabled: true}
+	cfg.Watcher.CodexTranscriptDir = "/custom/sessions"
+
+	sources := buildWatcherSources(&cfg, "/tmp/project")
+
+	for _, s := range sources {
+		if s.Harness == "codex" {
+			if s.TranscriptDir != "/custom/sessions" {
+				t.Errorf("override not honored: TranscriptDir = %q, want /custom/sessions", s.TranscriptDir)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected a codex source")
+}

--- a/cli/internal/cmd/watch_helpers.go
+++ b/cli/internal/cmd/watch_helpers.go
@@ -154,6 +154,9 @@ func buildWatcherSources(cfg *config.Config, projectDir string) []watcher.Source
 		case "pi":
 			override = cfg.Watcher.PiTranscriptDir
 			adapter = watcher.NewPiAdapter()
+		case "codex":
+			override = cfg.Watcher.CodexTranscriptDir
+			adapter = watcher.NewCodexAdapter()
 		default:
 			continue
 		}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -46,6 +46,9 @@ type WatcherConfig struct {
 	// PiTranscriptDir overrides the default pi session directory.
 	// Defaults to ~/.pi/agent/sessions/ when empty.
 	PiTranscriptDir string `yaml:"pi_transcript_dir,omitempty"`
+	// CodexTranscriptDir overrides the default Codex session directory.
+	// Defaults to $CODEX_HOME/sessions (or ~/.codex/sessions) when empty.
+	CodexTranscriptDir string `yaml:"codex_transcript_dir,omitempty"`
 	// DebounceMs is the debounce delay in milliseconds. Default: 300.
 	DebounceMs int `yaml:"debounce_ms,omitempty"`
 }

--- a/cli/internal/watcher/adapter_codex.go
+++ b/cli/internal/watcher/adapter_codex.go
@@ -1,0 +1,186 @@
+package watcher
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// CodexAdapter parses Codex CLI JSONL transcript lines.
+//
+// Each line is a JSON envelope:
+//
+//	{ "timestamp": "...", "type": "...", "payload": {...} }
+//
+// Only `response_item` lines produce Turns. Inside, payload.type selects
+// the shape — `message` for user/assistant text, `function_call` and
+// `custom_tool_call` for assistant tool invocations. Everything else is
+// dropped.
+type CodexAdapter struct{}
+
+// NewCodexAdapter returns a new CodexAdapter.
+func NewCodexAdapter() *CodexAdapter { return &CodexAdapter{} }
+
+func (a *CodexAdapter) Name() string { return "codex" }
+
+type codexEnvelope struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type codexMessagePayload struct {
+	Type    string              `json:"type"`
+	Role    string              `json:"role"`
+	Content []codexContentBlock `json:"content"`
+}
+
+type codexContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ExtractTurn implements Adapter.
+func (a *CodexAdapter) ExtractTurn(line []byte, sessionID string) (Turn, bool) {
+	line = trimLine(line)
+	if len(line) == 0 {
+		return Turn{}, false
+	}
+	var env codexEnvelope
+	if err := json.Unmarshal(line, &env); err != nil {
+		return Turn{}, false
+	}
+	if env.Type != "response_item" {
+		return Turn{}, false
+	}
+
+	var head struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(env.Payload, &head); err != nil {
+		return Turn{}, false
+	}
+
+	ts := parseCodexTimestamp(env.Timestamp)
+
+	var (
+		turn Turn
+		ok   bool
+	)
+	switch head.Type {
+	case "message":
+		turn, ok = a.extractMessage(env.Payload, sessionID)
+	case "function_call":
+		turn, ok = a.extractFunctionCall(env.Payload, sessionID)
+	case "custom_tool_call":
+		turn, ok = a.extractCustomToolCall(env.Payload, sessionID)
+	}
+	if !ok {
+		return Turn{}, false
+	}
+	if !ts.IsZero() {
+		turn.Timestamp = ts
+	} else {
+		turn.Timestamp = time.Now().UTC()
+	}
+	return turn, true
+}
+
+func parseCodexTimestamp(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	return time.Time{}
+}
+
+type codexFunctionCallPayload struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+	CallID    string `json:"call_id"`
+}
+
+func (a *CodexAdapter) extractFunctionCall(payload []byte, sessionID string) (Turn, bool) {
+	var fc codexFunctionCallPayload
+	if err := json.Unmarshal(payload, &fc); err != nil || fc.Name == "" {
+		return Turn{}, false
+	}
+	input := map[string]any{}
+	if fc.Arguments != "" {
+		_ = json.Unmarshal([]byte(fc.Arguments), &input)
+	}
+	category, safeName := CategorizeObservedToolCall(fc.Name, input)
+	return Turn{
+		SessionID: sessionID,
+		Role:      "assistant",
+		Provider:  "openai",
+		Harness:   "codex",
+		ToolCalls: []ToolCall{{
+			Name:     fc.Name,
+			SafeName: safeName,
+			Input:    input,
+			Category: category,
+		}},
+	}, true
+}
+
+type codexCustomToolCallPayload struct {
+	Name   string `json:"name"`
+	Input  string `json:"input"`
+	CallID string `json:"call_id"`
+}
+
+func (a *CodexAdapter) extractCustomToolCall(payload []byte, sessionID string) (Turn, bool) {
+	var ct codexCustomToolCallPayload
+	if err := json.Unmarshal(payload, &ct); err != nil || ct.Name == "" {
+		return Turn{}, false
+	}
+	// custom_tool_call.input is a raw string (e.g. a patch body), not JSON.
+	// Stash it under "raw" so downstream consumers have a stable key.
+	input := map[string]any{"raw": ct.Input}
+	category, safeName := CategorizeObservedToolCall(ct.Name, input)
+	return Turn{
+		SessionID: sessionID,
+		Role:      "assistant",
+		Provider:  "openai",
+		Harness:   "codex",
+		ToolCalls: []ToolCall{{
+			Name:     ct.Name,
+			SafeName: safeName,
+			Input:    input,
+			Category: category,
+		}},
+	}, true
+}
+
+func (a *CodexAdapter) extractMessage(payload []byte, sessionID string) (Turn, bool) {
+	var m codexMessagePayload
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return Turn{}, false
+	}
+	if m.Role != "user" && m.Role != "assistant" {
+		return Turn{}, false
+	}
+	var parts []string
+	for _, b := range m.Content {
+		if (b.Type == "input_text" || b.Type == "output_text") && b.Text != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	text := strings.Join(parts, "\n")
+	if text == "" {
+		return Turn{}, false
+	}
+	return Turn{
+		SessionID: sessionID,
+		Role:      m.Role,
+		Text:      text,
+		Provider:  "openai",
+		Harness:   "codex",
+	}, true
+}

--- a/cli/internal/watcher/adapter_codex_extract_test.go
+++ b/cli/internal/watcher/adapter_codex_extract_test.go
@@ -1,0 +1,150 @@
+package watcher
+
+import "testing"
+
+// Test fixtures: representative Codex CLI transcript JSONL lines.
+//
+// Codex writes one JSON object per line with a top-level envelope:
+//
+//	{ "timestamp": "...", "type": "session_meta"|"turn_context"|"response_item"|"event_msg", "payload": {...} }
+//
+// Only `response_item` lines produce Turns. Inside response_item, the
+// payload's own `type` determines what kind of turn (message, function_call,
+// custom_tool_call, etc.).
+const codexAssistantTextTurn = `{"timestamp":"2026-05-09T20:53:08.920Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello, world."}],"phase":"commentary"}}`
+
+const codexUserMultiBlockTurn = `{"timestamp":"2026-05-09T20:53:00.659Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"first block"},{"type":"input_text","text":"second block"}]}}`
+
+func TestCodexAdapter_ExtractTurn_UserMultiBlockText(t *testing.T) {
+	a := NewCodexAdapter()
+	turn, ok := a.ExtractTurn([]byte(codexUserMultiBlockTurn), "s-fallback")
+	if !ok {
+		t.Fatal("expected ok=true for user multi-block turn")
+	}
+	if turn.Role != "user" {
+		t.Errorf("Role = %q, want user", turn.Role)
+	}
+	want := "first block\nsecond block"
+	if turn.Text != want {
+		t.Errorf("Text = %q, want %q", turn.Text, want)
+	}
+}
+
+const codexFunctionCallTurn = `{"timestamp":"2026-05-09T20:53:08.920Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls -la\",\"workdir\":\"/tmp\"}","call_id":"call_abc"}}`
+
+func TestCodexAdapter_ExtractTurn_FunctionCall(t *testing.T) {
+	a := NewCodexAdapter()
+	turn, ok := a.ExtractTurn([]byte(codexFunctionCallTurn), "s-fallback")
+	if !ok {
+		t.Fatal("expected ok=true for function_call")
+	}
+	if turn.Role != "assistant" {
+		t.Errorf("Role = %q, want assistant", turn.Role)
+	}
+	if turn.Text != "" {
+		t.Errorf("Text should be empty for function_call, got %q", turn.Text)
+	}
+	if len(turn.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(turn.ToolCalls))
+	}
+	tc := turn.ToolCalls[0]
+	if tc.Name != "exec_command" {
+		t.Errorf("ToolCall.Name = %q, want exec_command", tc.Name)
+	}
+	if tc.Input["cmd"] != "ls -la" {
+		t.Errorf("ToolCall.Input[cmd] = %v, want ls -la", tc.Input["cmd"])
+	}
+	if tc.Input["workdir"] != "/tmp" {
+		t.Errorf("ToolCall.Input[workdir] = %v, want /tmp", tc.Input["workdir"])
+	}
+}
+
+const codexCustomToolCallTurn = `{"timestamp":"2026-05-09T20:54:35.460Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_xyz","name":"apply_patch","input":"*** Begin Patch\n*** Add File: foo.txt\n+hello\n*** End Patch\n"}}`
+
+func TestCodexAdapter_ExtractTurn_CustomToolCall(t *testing.T) {
+	a := NewCodexAdapter()
+	turn, ok := a.ExtractTurn([]byte(codexCustomToolCallTurn), "s-fallback")
+	if !ok {
+		t.Fatal("expected ok=true for custom_tool_call")
+	}
+	if turn.Role != "assistant" {
+		t.Errorf("Role = %q, want assistant", turn.Role)
+	}
+	if len(turn.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(turn.ToolCalls))
+	}
+	tc := turn.ToolCalls[0]
+	if tc.Name != "apply_patch" {
+		t.Errorf("ToolCall.Name = %q, want apply_patch", tc.Name)
+	}
+	// custom_tool_call.input is a raw string, not JSON. Stash it under a
+	// stable key so Drafter / Logbook can still inspect it.
+	if _, ok := tc.Input["raw"]; !ok {
+		t.Errorf("expected ToolCall.Input[\"raw\"] to be present, got %v", tc.Input)
+	}
+}
+
+func TestCodexAdapter_ExtractTurn_SkipsNonTurnLines(t *testing.T) {
+	a := NewCodexAdapter()
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"session_meta", `{"timestamp":"2026-05-09T20:53:00.657Z","type":"session_meta","payload":{"id":"019e0e83"}}`},
+		{"turn_context", `{"timestamp":"2026-05-09T20:53:00.659Z","type":"turn_context","payload":{"turn_id":"x","model":"gpt-5.5"}}`},
+		{"event_msg/token_count", `{"timestamp":"2026-05-09T20:53:01.055Z","type":"event_msg","payload":{"type":"token_count","info":null}}`},
+		{"response_item/reasoning", `{"timestamp":"2026-05-09T20:53:01.055Z","type":"response_item","payload":{"type":"reasoning","summary":[]}}`},
+		{"response_item/function_call_output", `{"timestamp":"2026-05-09T20:53:01.055Z","type":"response_item","payload":{"type":"function_call_output","call_id":"x","output":"y"}}`},
+		{"response_item/custom_tool_call_output", `{"timestamp":"2026-05-09T20:53:01.055Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"x","output":"y"}}`},
+		{"empty line", ``},
+		{"malformed json", `{not json}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			turn, ok := a.ExtractTurn([]byte(c.line), "s-fallback")
+			if ok {
+				t.Errorf("%s should be skipped, got turn: %+v", c.name, turn)
+			}
+		})
+	}
+}
+
+func TestCodexAdapter_ExtractTurn_ParsesTimestampAndUsesSessionFallback(t *testing.T) {
+	a := NewCodexAdapter()
+	turn, ok := a.ExtractTurn([]byte(codexAssistantTextTurn), "session-from-filename")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if turn.SessionID != "session-from-filename" {
+		t.Errorf("SessionID = %q, want session-from-filename (Codex lines don't carry session id, adapter must use fallback)", turn.SessionID)
+	}
+	wantTS := "2026-05-09T20:53:08.92Z"
+	if turn.Timestamp.UTC().Format("2006-01-02T15:04:05.999999999Z") != wantTS &&
+		turn.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z") != wantTS {
+		got := turn.Timestamp.UTC().Format("2006-01-02T15:04:05.999Z")
+		if got != wantTS {
+			t.Errorf("Timestamp = %s, want %s", got, wantTS)
+		}
+	}
+}
+
+func TestCodexAdapter_ExtractTurn_AssistantText(t *testing.T) {
+	a := NewCodexAdapter()
+	turn, ok := a.ExtractTurn([]byte(codexAssistantTextTurn), "s-fallback")
+	if !ok {
+		t.Fatal("expected ok=true for assistant text turn")
+	}
+	if turn.Role != "assistant" {
+		t.Errorf("Role = %q, want assistant", turn.Role)
+	}
+	if turn.Text != "Hello, world." {
+		t.Errorf("Text = %q, want %q", turn.Text, "Hello, world.")
+	}
+	if turn.Provider != "openai" {
+		t.Errorf("Provider = %q, want openai", turn.Provider)
+	}
+	if turn.Harness != "codex" {
+		t.Errorf("Harness = %q, want codex", turn.Harness)
+	}
+}


### PR DESCRIPTION
## Summary

Completes Codex on the watcher-first primary ingestion path (the harness adapter, MCP wiring, and AGENTS.md already shipped; this adds the missing watcher integration).

- New \`watcher.CodexAdapter\` parses Codex JSONL envelopes
  - \`response_item\` payload.type \`message\` → user/assistant text Turn (input_text/output_text concatenated)
  - \`response_item\` payload.type \`function_call\` → assistant Turn with one ToolCall (arguments JSON parsed)
  - \`response_item\` payload.type \`custom_tool_call\` → assistant Turn with one ToolCall (raw input under \`"raw"\`)
  - Skips \`session_meta\`, \`turn_context\`, \`event_msg\`, \`reasoning\`, \`*_output\`
- Codex harness adapter now implements \`TranscriptSource\` (\`DefaultTranscriptDir\` honors \`\$CODEX_HOME\`, falls back to \`~/.codex/sessions\`)
- \`buildWatcherSources\` gets a \`case "codex"\` arm + new \`WatcherConfig.CodexTranscriptDir\` override

Schema validated against real \`~/.codex/sessions\` JSONL files.

Closes #138.

## Test plan

- [x] 8 watcher adapter cycles: assistant text, user multi-block, function_call, custom_tool_call, non-turn skips, timestamp+sessionID
- [x] Harness adapter \`TranscriptSource\` test (CODEX_HOME and fallback)
- [x] \`buildWatcherSources\` test for codex source presence + config override
- [x] Architecture guardrails GREEN
- [x] Full \`go test ./...\` — only pre-existing session-id failures remain (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)