### PR TITLE
feat: project identity foundation (per ADR 0016)

### DIFF
--- a/adr/0011-substance-immutability-operational-mutability.md
+++ b/adr/0011-substance-immutability-operational-mutability.md
@@ -4,7 +4,7 @@ A memory row carries two kinds of fields. Some describe *what was captured* — 
 
 The schema enforces a hard boundary.
 
-**Substance fields are immutable after creation.** On `memories`: `id`, `content`, `summary`, `created_at`, `session_id`, `provenance_actor`, `provenance_trigger_event`, `provenance_source_type`. Once written, no code path updates these. Any change to substance is a new memory, not an edit.
+**Substance fields are immutable after creation.** On `memories`: `id`, `content`, `summary`, `created_at`, `session_id`, `project_id` (added by ADR 0016), `provenance_actor`, `provenance_trigger_event`, `provenance_source_type`. Once written, no code path updates these. Any change to substance is a new memory, not an edit.
 
 **Operational metadata is mutable.** On `memories`: `type` (ADR 0012), `promotion_state`, `landmark`, `centrality_score`. Off the row: edges in `memory_tags` and `memory_entities`. These can be set, changed, added, or removed freely as curation evolves.
 

--- a/cli/internal/cmd/central_cli_test.go
+++ b/cli/internal/cmd/central_cli_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -338,5 +339,153 @@ func TestCurateCmd_AlreadyCuratedErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "already curated") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ── ADR 0016: project-scoped recall ──────────────────────────────────────────
+
+// insertProjectMemory mints a curated memory with the given project_id.
+func insertProjectMemory(t *testing.T, lib *librarian.Librarian, summary, text, projectId string) string {
+	t.Helper()
+	content, _ := json.Marshal(map[string]any{"text": text})
+	id, err := lib.InsertMemoryWithTags(librarian.InsertMemory{
+		Type:                   "semantic",
+		Summary:                summary,
+		Content:                string(content),
+		SessionID:              "s-cli-test",
+		ProjectId:              projectId,
+		ProvenanceActor:        "test",
+		ProvenanceSourceType:   "test",
+		ProvenanceTriggerEvent: "test",
+	}, []string{"cli"})
+	if err != nil {
+		t.Fatalf("InsertMemoryWithTags: %v", err)
+	}
+	curated := "curated"
+	if err := lib.UpdateOperational(id, librarian.OperationalUpdate{PromotionState: &curated}); err != nil {
+		t.Fatalf("UpdateOperational: %v", err)
+	}
+	return id
+}
+
+// chdirToBoundDir creates a tempdir with .mom-project.yaml (id=projectId)
+// and chdirs into it for the duration of the test.
+func chdirToBoundDir(t *testing.T, projectId string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".mom-project.yaml"),
+		[]byte("version: \"1\"\nid: "+projectId+"\n"), 0o644); err != nil {
+		t.Fatalf("write bind file: %v", err)
+	}
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	return dir
+}
+
+func runRecallTest(t *testing.T, query string) string {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	recallCmd.SetOut(buf)
+	recallCmd.SetErr(buf)
+	if err := runRecall(recallCmd, []string{query}); err != nil {
+		t.Fatalf("runRecall: %v\noutput:\n%s", err, buf.String())
+	}
+	return buf.String()
+}
+
+// Default scope: cwd's project_id filters; other project's memories absent.
+func TestRecallCmd_DefaultScopesToCwdProject(t *testing.T) {
+	resetRecallFlags()
+	lib := openCentralTestLib(t)
+	alphaID := insertProjectMemory(t, lib, "alpha memory", "deploy alpha service", "alpha")
+	betaID := insertProjectMemory(t, lib, "beta memory", "deploy beta service", "beta")
+	chdirToBoundDir(t, "alpha")
+
+	out := runRecallTest(t, "deploy")
+	if !strings.Contains(out, alphaID) {
+		t.Errorf("expected alpha memory %s in output, got:\n%s", alphaID, out)
+	}
+	if strings.Contains(out, betaID) {
+		t.Errorf("beta memory %s should be scoped out, got:\n%s", betaID, out)
+	}
+}
+
+// --all disables scoping; both projects appear.
+func TestRecallCmd_AllFlagDisablesScope(t *testing.T) {
+	resetRecallFlags()
+	lib := openCentralTestLib(t)
+	alphaID := insertProjectMemory(t, lib, "alpha memory", "deploy alpha service", "alpha")
+	betaID := insertProjectMemory(t, lib, "beta memory", "deploy beta service", "beta")
+	chdirToBoundDir(t, "alpha")
+	recallAllProjects = true
+
+	out := runRecallTest(t, "deploy")
+	if !strings.Contains(out, alphaID) {
+		t.Errorf("--all should include alpha memory %s, got:\n%s", alphaID, out)
+	}
+	if !strings.Contains(out, betaID) {
+		t.Errorf("--all should include beta memory %s, got:\n%s", betaID, out)
+	}
+}
+
+// --project=foo overrides cwd resolution.
+func TestRecallCmd_ProjectFlagOverridesCwd(t *testing.T) {
+	resetRecallFlags()
+	lib := openCentralTestLib(t)
+	alphaID := insertProjectMemory(t, lib, "alpha memory", "deploy alpha service", "alpha")
+	betaID := insertProjectMemory(t, lib, "beta memory", "deploy beta service", "beta")
+	chdirToBoundDir(t, "alpha") // cwd says alpha
+	recallProject = "beta"      // but the flag wins
+
+	out := runRecallTest(t, "deploy")
+	if strings.Contains(out, alphaID) {
+		t.Errorf("--project=beta should exclude alpha %s, got:\n%s", alphaID, out)
+	}
+	if !strings.Contains(out, betaID) {
+		t.Errorf("--project=beta should include beta %s, got:\n%s", betaID, out)
+	}
+}
+
+// Unbound cwd → falls through to all-projects + prints stderr hint
+// mentioning /mom-project.
+func TestRecallCmd_UnboundCwdFallsThroughWithHint(t *testing.T) {
+	resetRecallFlags()
+	lib := openCentralTestLib(t)
+	alphaID := insertProjectMemory(t, lib, "alpha memory", "deploy alpha", "alpha")
+
+	dir := t.TempDir() // no bind file
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	out := runRecallTest(t, "deploy")
+	if !strings.Contains(out, alphaID) {
+		t.Errorf("unbound cwd should fall through and include alpha %s, got:\n%s", alphaID, out)
+	}
+	if !strings.Contains(out, "/mom-project") {
+		t.Errorf("expected stderr hint mentioning /mom-project, got:\n%s", out)
+	}
+}
+
+// --strict-project excludes NULL project_id rows.
+func TestRecallCmd_StrictProjectExcludesNull(t *testing.T) {
+	resetRecallFlags()
+	lib := openCentralTestLib(t)
+	alphaID := insertProjectMemory(t, lib, "alpha memory", "deploy alpha", "alpha")
+	legacyID := insertProjectMemory(t, lib, "legacy memory", "deploy legacy", "")
+	chdirToBoundDir(t, "alpha")
+	recallStrictProject = true
+
+	out := runRecallTest(t, "deploy")
+	if !strings.Contains(out, alphaID) {
+		t.Errorf("strict should include alpha %s, got:\n%s", alphaID, out)
+	}
+	if strings.Contains(out, legacyID) {
+		t.Errorf("strict should exclude NULL %s, got:\n%s", legacyID, out)
 	}
 }

--- a/cli/internal/cmd/recall.go
+++ b/cli/internal/cmd/recall.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"unicode"
@@ -79,7 +78,7 @@ func runRecall(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = closeFn() }()
 
-	scopedProjectId := resolveRecallScope(cmd, p)
+	scopedProjectId := resolveRecallScope(p)
 	results, err := finder.New(lib).Recall(finder.Options{
 		Query:         query,
 		Limit:         recallDefaultLimit,
@@ -126,19 +125,15 @@ func runRecall(cmd *cobra.Command, args []string) error {
 //  2. --project=<id>  → explicit override
 //  3. cwd-resolved via .mom-project.yaml  → scope to that project
 //  4. cwd unbound  → no filter + emit a one-line hint pointing at /mom-project
-func resolveRecallScope(cmd *cobra.Command, p *ux.Printer) string {
+func resolveRecallScope(p *ux.Printer) string {
 	if recallAllProjects {
 		return ""
 	}
 	if recallProject != "" {
 		return recallProject
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	id, _, found, err := project.ResolveProject(cwd)
-	if err != nil || !found {
+	id, found := project.IdForCwd()
+	if !found {
 		p.Muted("cwd not in a MOM project — searching all. Run /mom-project to bind this directory.")
 		return ""
 	}

--- a/cli/internal/cmd/recall.go
+++ b/cli/internal/cmd/recall.go
@@ -5,18 +5,26 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"unicode"
 
 	"github.com/momhq/mom/cli/internal/centralvault"
 	"github.com/momhq/mom/cli/internal/finder"
+	"github.com/momhq/mom/cli/internal/project"
 	"github.com/momhq/mom/cli/internal/ux"
 	"github.com/momhq/mom/cli/internal/vault"
 	"github.com/spf13/cobra"
 )
 
 const recallDefaultLimit = 10
+
+var (
+	recallAllProjects   bool
+	recallProject       string
+	recallStrictProject bool
+)
 
 var recallCmd = &cobra.Command{
 	Use:   "recall <query>",
@@ -26,11 +34,31 @@ var recallCmd = &cobra.Command{
 The query argument is required. It can be a natural-language search query
 or a read-only SQL SELECT/WITH query for power users.
 
+By default recall is scoped to the project that owns the current working
+directory (per ADR 0016 — the project is declared in .mom-project.yaml).
+Use --all to search across every project, --project to override the
+cwd-derived scope, or --strict-project to exclude legacy memories that
+have no project_id stamp.
+
 Examples:
   mom recall "aws deployment flow"
+  mom recall "aws deployment flow" --all
+  mom recall "aws deployment flow" --project pi-agents-cli
   mom recall "SELECT id, summary FROM memories WHERE promotion_state = 'curated'"`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRecall,
+}
+
+func init() {
+	recallCmd.Flags().BoolVar(&recallAllProjects, "all", false, "Search across all projects (disables cwd-based scoping)")
+	recallCmd.Flags().StringVar(&recallProject, "project", "", "Override scope to the named project_id")
+	recallCmd.Flags().BoolVar(&recallStrictProject, "strict-project", false, "Exclude memories with no project_id (legacy / unbound captures)")
+}
+
+func resetRecallFlags() {
+	recallAllProjects = false
+	recallProject = ""
+	recallStrictProject = false
 }
 
 func runRecall(cmd *cobra.Command, args []string) error {
@@ -51,7 +79,13 @@ func runRecall(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = closeFn() }()
 
-	results, err := finder.New(lib).Recall(finder.Options{Query: query, Limit: recallDefaultLimit})
+	scopedProjectId := resolveRecallScope(cmd, p)
+	results, err := finder.New(lib).Recall(finder.Options{
+		Query:         query,
+		Limit:         recallDefaultLimit,
+		ProjectId:     scopedProjectId,
+		StrictProject: recallStrictProject,
+	})
 	if err != nil {
 		if errors.Is(err, finder.ErrEmptyQuery) {
 			return fmt.Errorf("query is required")
@@ -82,6 +116,33 @@ func runRecall(cmd *cobra.Command, args []string) error {
 		)
 	}
 	return nil
+}
+
+// resolveRecallScope decides the project_id filter for a recall, per
+// ADR 0016. Returns "" to mean "no project filter — all projects".
+//
+// Resolution order:
+//  1. --all  → no filter
+//  2. --project=<id>  → explicit override
+//  3. cwd-resolved via .mom-project.yaml  → scope to that project
+//  4. cwd unbound  → no filter + emit a one-line hint pointing at /mom-project
+func resolveRecallScope(cmd *cobra.Command, p *ux.Printer) string {
+	if recallAllProjects {
+		return ""
+	}
+	if recallProject != "" {
+		return recallProject
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	id, _, found, err := project.ResolveProject(cwd)
+	if err != nil || !found {
+		p.Muted("cwd not in a MOM project — searching all. Run /mom-project to bind this directory.")
+		return ""
+	}
+	return id
 }
 
 func runRecallSQL(cmd *cobra.Command, query string) error {

--- a/cli/internal/cmd/record.go
+++ b/cli/internal/cmd/record.go
@@ -90,7 +90,7 @@ func runRecord(cmd *cobra.Command, _ []string) error {
 	})
 	defer stopCapture()
 
-	projectId := resolveProjectIdForCwd()
+	projectId, _ := project.IdForCwd()
 	result, err := explicitrecord.Publish(bus, explicitrecord.Request{
 		SessionID: recordSession,
 		Summary:   recordSummary,
@@ -111,17 +111,3 @@ func runRecord(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// resolveProjectIdForCwd resolves the declared project identity (ADR 0016)
-// from the current working directory. Returns "" on any error or when no
-// binding is found — the resulting memory will then carry NULL project_id.
-func resolveProjectIdForCwd() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	id, _, _, err := project.ResolveProject(cwd)
-	if err != nil {
-		return ""
-	}
-	return id
-}

--- a/cli/internal/cmd/record.go
+++ b/cli/internal/cmd/record.go
@@ -10,6 +10,7 @@ import (
 	"github.com/momhq/mom/cli/internal/drafter"
 	"github.com/momhq/mom/cli/internal/explicitrecord"
 	"github.com/momhq/mom/cli/internal/herald"
+	"github.com/momhq/mom/cli/internal/project"
 	"github.com/spf13/cobra"
 )
 
@@ -89,12 +90,14 @@ func runRecord(cmd *cobra.Command, _ []string) error {
 	})
 	defer stopCapture()
 
+	projectId := resolveProjectIdForCwd()
 	result, err := explicitrecord.Publish(bus, explicitrecord.Request{
 		SessionID: recordSession,
 		Summary:   recordSummary,
 		Tags:      recordTags,
 		Content:   map[string]any{"text": text},
 		Actor:     recordActor,
+		ProjectId: projectId,
 	})
 	if err != nil {
 		return fmt.Errorf("mom record: %w", err)
@@ -106,4 +109,19 @@ func runRecord(cmd *cobra.Command, _ []string) error {
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "recorded: session=%s tags=%v\n", result.SessionID, result.Tags)
 	return nil
+}
+
+// resolveProjectIdForCwd resolves the declared project identity (ADR 0016)
+// from the current working directory. Returns "" on any error or when no
+// binding is found — the resulting memory will then carry NULL project_id.
+func resolveProjectIdForCwd() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	id, _, _, err := project.ResolveProject(cwd)
+	if err != nil {
+		return ""
+	}
+	return id
 }

--- a/cli/internal/cmd/record_test.go
+++ b/cli/internal/cmd/record_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -233,5 +234,65 @@ func TestRunRecord_RejectsEmptyNormalisedTag(t *testing.T) {
 	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "11111111-1111-4111-8111-111111111111", Limit: 10})
 	if len(rows) != 0 {
 		t.Errorf("got %d memories, want 0 (rejection must not persist)", len(rows))
+	}
+}
+
+// TestRunRecord_StampsProjectIdFromBindFile locks ADR 0016 wiring on
+// the CLI explicit-record path: when cwd has a .mom-project.yaml, the
+// persisted memory carries the declared id.
+func TestRunRecord_StampsProjectIdFromBindFile(t *testing.T) {
+	resetRecordFlags()
+	lib := openCentralVaultForTest(t)
+
+	// Bind cwd to project "alpha".
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".mom-project.yaml"),
+		[]byte("version: \"1\"\nid: alpha\n"), 0o644); err != nil {
+		t.Fatalf("write bind file: %v", err)
+	}
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	recordSession = "11111111-1111-4111-8111-111111111111"
+	if _, err := runRecordWithStdin(t, "bound project capture"); err != nil {
+		t.Fatalf("runRecord: %v", err)
+	}
+
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "11111111-1111-4111-8111-111111111111", Limit: 10})
+	if len(rows) != 1 {
+		t.Fatalf("got %d memories, want 1", len(rows))
+	}
+	if rows[0].Memory.ProjectId != "alpha" {
+		t.Errorf("ProjectId = %q, want alpha", rows[0].Memory.ProjectId)
+	}
+}
+
+// TestRunRecord_NullProjectIdWhenCwdUnbound: capture from an unbound cwd
+// persists with empty ProjectId (ADR 0016 default).
+func TestRunRecord_NullProjectIdWhenCwdUnbound(t *testing.T) {
+	resetRecordFlags()
+	lib := openCentralVaultForTest(t)
+
+	projectDir := t.TempDir() // no .mom-project.yaml
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	recordSession = "22222222-2222-4222-8222-222222222222"
+	if _, err := runRecordWithStdin(t, "unbound capture"); err != nil {
+		t.Fatalf("runRecord: %v", err)
+	}
+
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "22222222-2222-4222-8222-222222222222", Limit: 10})
+	if len(rows) != 1 {
+		t.Fatalf("got %d memories, want 1", len(rows))
+	}
+	if rows[0].Memory.ProjectId != "" {
+		t.Errorf("ProjectId = %q, want empty (cwd unbound)", rows[0].Memory.ProjectId)
 	}
 }

--- a/cli/internal/drafter/clustering_test.go
+++ b/cli/internal/drafter/clustering_test.go
@@ -2,6 +2,7 @@ package drafter_test
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -20,6 +21,7 @@ func openDrafter(t *testing.T) (*drafter.Drafter, *librarian.Librarian) {
 	t.Helper()
 	dir := t.TempDir()
 	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
 	if err != nil {
 		t.Fatalf("vault.Open: %v", err)
@@ -424,5 +426,56 @@ func TestObserveTurn_BufferReCreatedAfterFlush(t *testing.T) {
 	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "s", Limit: 10})
 	if len(rows) != 2 {
 		t.Fatalf("got %d memories after two flush cycles, want 2", len(rows))
+	}
+}
+
+// TestFlushAll_PropagatesProjectIdFromPayload locks ADR 0016 wiring:
+// when a turn.observed event carries project_id, the persisted memory
+// row stamps it.
+func TestFlushAll_PropagatesProjectIdFromPayload(t *testing.T) {
+	d, lib := openDrafter(t)
+	bus := herald.NewBus()
+	defer d.SubscribeAll(bus)()
+
+	payload := substantiveTurn("decide on postgres for the canary", "claude-code")
+	payload["project_id"] = "alpha"
+
+	bus.Publish(herald.Event{
+		Type:      herald.TurnObserved,
+		SessionID: "s-alpha",
+		Payload:   payload,
+	})
+	d.FlushAll()
+
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "s-alpha", Limit: 10})
+	if len(rows) != 1 {
+		t.Fatalf("got %d memories, want 1", len(rows))
+	}
+	if rows[0].Memory.ProjectId != "alpha" {
+		t.Errorf("memory.ProjectId = %q, want alpha", rows[0].Memory.ProjectId)
+	}
+}
+
+// processRecord (memory.record events) honour project_id too.
+func TestProcessRecord_PropagatesProjectIdFromPayload(t *testing.T) {
+	d, lib := openDrafter(t)
+	bus := herald.NewBus()
+	defer d.SubscribeAll(bus)()
+
+	bus.Publish(herald.Event{
+		Type:      herald.MemoryRecord,
+		SessionID: "s-rec",
+		Payload: map[string]any{
+			"content":    map[string]any{"text": "manual note"},
+			"project_id": "alpha",
+		},
+	})
+	// FlushAll is for buffered turns; record path persists synchronously.
+	rows, _ := lib.SearchMemories(librarian.SearchFilter{SessionID: "s-rec", Limit: 10})
+	if len(rows) != 1 {
+		t.Fatalf("got %d memories, want 1", len(rows))
+	}
+	if rows[0].Memory.ProjectId != "alpha" {
+		t.Errorf("memory.ProjectId = %q, want alpha", rows[0].Memory.ProjectId)
 	}
 }

--- a/cli/internal/drafter/drafter.go
+++ b/cli/internal/drafter/drafter.go
@@ -87,6 +87,7 @@ type bufferedTurn struct {
 	harness   string
 	provider  string
 	model     string
+	projectId string // ADR 0016 — stamped at capture, copied to memory row at persist
 }
 
 // New returns a Drafter bound to the given Librarian, configured with
@@ -182,6 +183,7 @@ func (d *Drafter) observeTurn(bus *herald.Bus, e herald.Event) error {
 		}
 	}
 
+	projectId, _ := e.Payload["project_id"].(string)
 	bt := bufferedTurn{
 		timestamp: extractCreatedAt(e.Payload),
 		role:      role,
@@ -190,6 +192,7 @@ func (d *Drafter) observeTurn(bus *herald.Bus, e herald.Event) error {
 		harness:   harness,
 		provider:  provider,
 		model:     model,
+		projectId: projectId,
 	}
 	if bt.timestamp.IsZero() {
 		bt.timestamp = d.now()
@@ -320,6 +323,7 @@ func (d *Drafter) persistChunk(bus *herald.Bus, sessionID string, turns []buffer
 	id, err := d.lib.InsertMemoryWithTags(librarian.InsertMemory{
 		Content:                string(contentBytes),
 		SessionID:              sessionID,
+		ProjectId:              last.projectId,
 		ProvenanceActor:        actor,
 		ProvenanceSourceType:   "transcript-extraction",
 		ProvenanceTriggerEvent: "watcher",
@@ -396,10 +400,12 @@ func (d *Drafter) processRecord(bus *herald.Bus, e herald.Event) error {
 		trigger = "record"
 	}
 	tags := tagsFromPayload(e.Payload["tags"])
+	projectId, _ := e.Payload["project_id"].(string)
 	id, err := d.lib.InsertMemoryWithTags(librarian.InsertMemory{
 		Content:                string(contentBytes),
 		Summary:                summary,
 		SessionID:              e.SessionID,
+		ProjectId:              projectId,
 		ProvenanceActor:        actor,
 		ProvenanceSourceType:   source,
 		ProvenanceTriggerEvent: trigger,

--- a/cli/internal/explicitrecord/explicitrecord.go
+++ b/cli/internal/explicitrecord/explicitrecord.go
@@ -30,6 +30,11 @@ type Request struct {
 	Tags      []string
 	Content   map[string]any
 	Actor     string
+	// ProjectId is the declared project identity (ADR 0016). Empty
+	// when the caller could not resolve a binding (e.g. cwd is not in
+	// any .mom-project.yaml). The resulting memory will have NULL
+	// project_id in those cases.
+	ProjectId string
 }
 
 type Result struct {
@@ -59,17 +64,21 @@ func Publish(bus *herald.Bus, req Request) (Result, error) {
 		actor = "mcp"
 	}
 
+	payload := map[string]any{
+		"content":                  req.Content,
+		"summary":                  req.Summary,
+		"tags":                     tags,
+		"provenance_actor":         actor,
+		"provenance_source_type":   "manual-draft",
+		"provenance_trigger_event": "record",
+	}
+	if req.ProjectId != "" {
+		payload["project_id"] = req.ProjectId
+	}
 	bus.Publish(herald.Event{
 		Type:      herald.MemoryRecord,
 		SessionID: sessionID,
-		Payload: map[string]any{
-			"content":                  req.Content,
-			"summary":                  req.Summary,
-			"tags":                     tags,
-			"provenance_actor":         actor,
-			"provenance_source_type":   "manual-draft",
-			"provenance_trigger_event": "record",
-		},
+		Payload:   payload,
 	})
 
 	return Result{SessionID: sessionID, Summary: req.Summary, Tags: tags, Actor: actor}, nil

--- a/cli/internal/finder/finder.go
+++ b/cli/internal/finder/finder.go
@@ -44,6 +44,13 @@ type Options struct {
 	SessionID     string
 	IncludeDrafts bool // when false (default), Finder applies tier escalation
 	Limit         int
+
+	// ProjectId restricts results to the named project (ADR 0016).
+	// Empty disables the project filter — searches every project.
+	ProjectId string
+	// StrictProject excludes NULL project_id rows when ProjectId is set.
+	// Defaults to false (legacy memories remain findable in scoped queries).
+	StrictProject bool
 }
 
 // Tier names the escalation pass that surfaced a Result. The four
@@ -130,6 +137,8 @@ func (f *Finder) Recall(opts Options) ([]Result, error) {
 			SessionID:      opts.SessionID,
 			PromotionState: p.state,
 			Limit:          limit,
+			ProjectId:      opts.ProjectId,
+			StrictProject:  opts.StrictProject,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("Recall %s pass: %w", p.tier, err)

--- a/cli/internal/finder/finder_test.go
+++ b/cli/internal/finder/finder_test.go
@@ -3,6 +3,7 @@ package finder_test
 import (
 	"errors"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -19,7 +20,7 @@ import (
 func openFinder(t *testing.T) (*finder.Finder, *librarian.Librarian) {
 	t.Helper()
 	dir := t.TempDir()
-	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	migs := append(librarian.Migrations(), logbook.Migrations()...); sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
 	if err != nil {
 		t.Fatalf("vault.Open: %v", err)

--- a/cli/internal/librarian/librarian.go
+++ b/cli/internal/librarian/librarian.go
@@ -76,6 +76,7 @@ type Memory struct {
 	Content                string
 	CreatedAt              time.Time
 	SessionID              string
+	ProjectId              string // ADR 0016 — declared project identity ("" when unknown)
 	ProvenanceActor        string
 	ProvenanceSourceType   string
 	ProvenanceTriggerEvent string
@@ -94,6 +95,7 @@ type InsertMemory struct {
 	Content                string
 	CreatedAt              time.Time
 	SessionID              string
+	ProjectId              string // ADR 0016 — declared project identity ("" when unknown)
 	ProvenanceActor        string
 	ProvenanceSourceType   string
 	ProvenanceTriggerEvent string
@@ -194,10 +196,11 @@ func (l *Librarian) validateInsert(m *InsertMemory) (string, error) {
 func (l *Librarian) insertMemoryRow(tx *sql.Tx, id string, m InsertMemory) error {
 	_, err := tx.Exec(
 		`INSERT INTO memories
-		   (id, type, summary, content, created_at, session_id,
+		   (id, type, summary, content, created_at, session_id, project_id,
 		    provenance_actor, provenance_source_type, provenance_trigger_event)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, m.Type, m.Summary, m.Content, formatTime(m.CreatedAt), m.SessionID,
+		nullableStr(m.ProjectId),
 		nullableStr(m.ProvenanceActor),
 		nullableStr(m.ProvenanceSourceType),
 		nullableStr(m.ProvenanceTriggerEvent),
@@ -234,7 +237,7 @@ func (l *Librarian) Get(id string) (Memory, error) {
 	var scanErr error
 
 	err := l.v.Query(
-		`SELECT id, type, summary, content, created_at, session_id,
+		`SELECT id, type, summary, content, created_at, session_id, project_id,
 		        provenance_actor, provenance_source_type, provenance_trigger_event,
 		        promotion_state, landmark, centrality_score
 		 FROM memories WHERE id = ?`,
@@ -245,19 +248,20 @@ func (l *Librarian) Get(id string) (Memory, error) {
 			}
 			found = true
 			var (
-				summary, actor, sourceType, triggerEvent sql.NullString
-				createdAtStr                             string
-				landmarkInt                              int64
+				summary, projectId, actor, sourceType, triggerEvent sql.NullString
+				createdAtStr                                        string
+				landmarkInt                                         int64
 			)
 			if err := rs.Scan(
 				&m.ID, &m.Type, &summary, &m.Content, &createdAtStr, &m.SessionID,
-				&actor, &sourceType, &triggerEvent,
+				&projectId, &actor, &sourceType, &triggerEvent,
 				&m.PromotionState, &landmarkInt, &m.CentralityScore,
 			); err != nil {
 				scanErr = err
 				return err
 			}
 			m.Summary = summary.String
+			m.ProjectId = projectId.String
 			m.ProvenanceActor = actor.String
 			m.ProvenanceSourceType = sourceType.String
 			m.ProvenanceTriggerEvent = triggerEvent.String

--- a/cli/internal/librarian/librarian_test.go
+++ b/cli/internal/librarian/librarian_test.go
@@ -1,6 +1,7 @@
 package librarian_test
 
 import (
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"reflect"
@@ -300,5 +301,154 @@ func TestSubstanceImmutability_RoundTripDoesNotMutateSubstance(t *testing.T) {
 		got2.ProvenanceSourceType != got1.ProvenanceSourceType ||
 		got2.ProvenanceTriggerEvent != got1.ProvenanceTriggerEvent {
 		t.Error("Provenance changed despite only operational update")
+	}
+}
+
+// TestInsert_StampsProjectId verifies project_id round-trips through the
+// memories table (per ADR 0016).
+func TestInsert_StampsProjectId(t *testing.T) {
+	l := openLib(t)
+	m := validInsert()
+	m.ProjectId = "pi-agents-cli"
+
+	id, err := l.Insert(m)
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	got, err := l.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ProjectId != "pi-agents-cli" {
+		t.Errorf("ProjectId = %q, want pi-agents-cli", got.ProjectId)
+	}
+}
+
+// TestSearchMemories_FiltersByProjectId verifies the project_id scope
+// filter (ADR 0016).
+func TestSearchMemories_FiltersByProjectId(t *testing.T) {
+	l := openLib(t)
+	a := validInsert(); a.ProjectId = "alpha"; a.SessionID = "s-a"
+	b := validInsert(); b.ProjectId = "beta"; b.SessionID = "s-b"
+	c := validInsert(); c.ProjectId = ""; c.SessionID = "s-c" // NULL
+	idA, _ := l.Insert(a)
+	idB, _ := l.Insert(b)
+	idC, _ := l.Insert(c)
+
+	got, err := l.SearchMemories(librarian.SearchFilter{ProjectId: "alpha"})
+	if err != nil {
+		t.Fatalf("SearchMemories: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, m := range got {
+		ids[m.ID] = true
+	}
+	if !ids[idA] {
+		t.Errorf("expected alpha memory %s in results, got %v", idA, ids)
+	}
+	if ids[idB] {
+		t.Errorf("did NOT expect beta memory %s when scoped to alpha", idB)
+	}
+	// NULL row included by default — ADR 0016 "legacy memories remain findable".
+	if !ids[idC] {
+		t.Errorf("expected NULL-project memory %s to be included by default", idC)
+	}
+}
+
+// TestSearchMemories_StrictProjectExcludesNull confirms IncludeUnknownProject=false
+// drops NULL rows from a scoped query (ADR 0016 --strict-project semantics).
+func TestSearchMemories_StrictProjectExcludesNull(t *testing.T) {
+	l := openLib(t)
+	a := validInsert(); a.ProjectId = "alpha"; a.SessionID = "s-a"
+	c := validInsert(); c.ProjectId = ""; c.SessionID = "s-c"
+	idA, _ := l.Insert(a)
+	idC, _ := l.Insert(c)
+
+	got, err := l.SearchMemories(librarian.SearchFilter{
+		ProjectId:             "alpha",
+		StrictProject:        true,
+	})
+	if err != nil {
+		t.Fatalf("SearchMemories: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, m := range got {
+		ids[m.ID] = true
+	}
+	if !ids[idA] {
+		t.Errorf("expected alpha memory %s in strict results", idA)
+	}
+	if ids[idC] {
+		t.Errorf("strict mode must exclude NULL memory %s", idC)
+	}
+}
+
+// TestMigration_BackwardSafe_PreExistingRowsHaveNullProjectId verifies
+// that memories inserted before the v6 migration survive it with
+// project_id IS NULL (per ADR 0016 — legacy memories remain findable).
+func TestMigration_BackwardSafe_PreExistingRowsHaveNullProjectId(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "mom.db")
+
+	// Step 1: open the vault with ONLY the v2 migration applied
+	// (pre-ADR-0016 schema; no project_id column).
+	all := librarian.Migrations()
+	var preV6 []librarian.Migration
+	for _, m := range all {
+		if m.Version < 6 {
+			preV6 = append(preV6, m)
+		}
+	}
+	v, err := vault.Open(dbPath, preV6)
+	if err != nil {
+		t.Fatalf("vault.Open (pre-v6): %v", err)
+	}
+	// Insert via raw SQL using the pre-v6 column list so we are not
+	// coupled to the current Librarian INSERT (which assumes v6+).
+	id := "11111111-2222-3333-4444-555555555555"
+	if err := v.Tx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`INSERT INTO memories (id, type, content, created_at, session_id)
+			 VALUES (?, 'untyped', '{"text":"legacy memory"}', '2026-04-01T00:00:00.000000000Z', 's-legacy')`,
+			id,
+		)
+		return err
+	}); err != nil {
+		t.Fatalf("raw insert pre-v6: %v", err)
+	}
+	if err := v.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Step 2: reopen with the full migration set (includes v6).
+	v2, err := vault.Open(dbPath, librarian.Migrations())
+	if err != nil {
+		t.Fatalf("vault.Open (post-v6): %v", err)
+	}
+	t.Cleanup(func() { _ = v2.Close() })
+	l2 := librarian.New(v2)
+
+	got, err := l2.Get(id)
+	if err != nil {
+		t.Fatalf("Get post-migration: %v", err)
+	}
+	if got.ProjectId != "" {
+		t.Errorf("legacy memory must have empty ProjectId post-migration, got %q", got.ProjectId)
+	}
+	// And it should still be findable through scoped recall (NULL included by default).
+	results, err := l2.SearchMemories(librarian.SearchFilter{ProjectId: "any-project"})
+	if err != nil {
+		t.Fatalf("SearchMemories: %v", err)
+	}
+	found := false
+	for _, r := range results {
+		if r.ID == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("legacy memory %s should remain findable in scoped recall by default", id)
 	}
 }

--- a/cli/internal/librarian/migrations.go
+++ b/cli/internal/librarian/migrations.go
@@ -133,5 +133,15 @@ func Migrations() []vault.Migration {
 				END`,
 			},
 		},
+		{
+			// ADR 0016: project_id stamps the declared project identity
+			// (read from .mom-project.yaml). NULL = unknown/legacy.
+			// Substance-immutable per ADR 0011.
+			Version: 6,
+			Stmts: []string{
+				`ALTER TABLE memories ADD COLUMN project_id TEXT`,
+				`CREATE INDEX idx_memories_project ON memories(project_id)`,
+			},
+		},
 	}
 }

--- a/cli/internal/librarian/search.go
+++ b/cli/internal/librarian/search.go
@@ -25,6 +25,15 @@ type SearchFilter struct {
 	SessionID      string
 	PromotionState string
 	Limit          int
+
+	// ProjectId restricts results to the named project (per ADR 0016).
+	// Empty means no project filter — all projects are considered.
+	ProjectId string
+	// StrictProject controls handling of NULL project_id rows when
+	// ProjectId is set. Zero value (false) = NULL rows are INCLUDED (the
+	// ADR 0016 default; legacy memories remain findable). Setting true
+	// excludes NULL rows, used by `mom recall --strict-project`.
+	StrictProject bool
 }
 
 // SearchedMemory is a Memory plus the BM25 score from the matching
@@ -106,9 +115,22 @@ func (l *Librarian) SearchMemories(f SearchFilter) ([]SearchedMemory, error) {
 		wheres = append(wheres, "m.promotion_state = ?")
 		args = append(args, f.PromotionState)
 	}
+	if f.ProjectId != "" {
+		// ADR 0016: NULL project_id is "unknown / legacy". By default we
+		// include those rows in scoped queries so the foundation migration
+		// does not silently hide pre-existing memory. `StrictProject` flips
+		// to exclude.
+		if f.StrictProject {
+			wheres = append(wheres, "m.project_id = ?")
+			args = append(args, f.ProjectId)
+		} else {
+			wheres = append(wheres, "(m.project_id = ? OR m.project_id IS NULL)")
+			args = append(args, f.ProjectId)
+		}
+	}
 
 	sb.WriteString(`SELECT m.id, m.type, m.summary, m.content, m.created_at, m.session_id,
-		m.provenance_actor, m.provenance_source_type, m.provenance_trigger_event,
+		m.project_id, m.provenance_actor, m.provenance_source_type, m.provenance_trigger_event,
 		m.promotion_state, m.landmark, m.centrality_score`)
 	if hasFTS {
 		sb.WriteString(`, bm25(memories_fts, 0, 2, 10)`)
@@ -133,19 +155,20 @@ func (l *Librarian) SearchMemories(f SearchFilter) ([]SearchedMemory, error) {
 	err := l.v.Query(sb.String(), args, func(rs *sql.Rows) error {
 		for rs.Next() {
 			var (
-				sm                                       SearchedMemory
-				summary, actor, sourceType, triggerEvent sql.NullString
-				createdAtStr                             string
-				landmarkInt                              int64
+				sm                                                  SearchedMemory
+				summary, projectId, actor, sourceType, triggerEvent sql.NullString
+				createdAtStr                                        string
+				landmarkInt                                         int64
 			)
 			if err := rs.Scan(
 				&sm.ID, &sm.Type, &summary, &sm.Content, &createdAtStr, &sm.SessionID,
-				&actor, &sourceType, &triggerEvent,
+				&projectId, &actor, &sourceType, &triggerEvent,
 				&sm.PromotionState, &landmarkInt, &sm.CentralityScore, &sm.Score,
 			); err != nil {
 				return err
 			}
 			sm.Summary = summary.String
+			sm.ProjectId = projectId.String
 			sm.ProvenanceActor = actor.String
 			sm.ProvenanceSourceType = sourceType.String
 			sm.ProvenanceTriggerEvent = triggerEvent.String

--- a/cli/internal/logbook/op_events_test.go
+++ b/cli/internal/logbook/op_events_test.go
@@ -3,6 +3,7 @@ package logbook_test
 import (
 	"errors"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 func openLibWithLogbook(t *testing.T) *librarian.Librarian {
 	t.Helper()
 	dir := t.TempDir()
-	migrations := append(librarian.Migrations(), logbook.Migrations()...)
+	migrations := append(librarian.Migrations(), logbook.Migrations()...); sort.Slice(migrations, func(i, j int) bool { return migrations[i].Version < migrations[j].Version })
 	v, err := vault.Open(filepath.Join(dir, "mom.db"), migrations)
 	if err != nil {
 		t.Fatalf("vault.Open: %v", err)

--- a/cli/internal/logbook/stderr_capture_test.go
+++ b/cli/internal/logbook/stderr_capture_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -71,7 +72,7 @@ func TestWorker_Subscribe_LogsToStderr_OnEmptySessionID(t *testing.T) {
 // Librarian whose underlying vault was closed BEFORE the publish.
 func TestWorker_Subscribe_LogsToStderr_OnPersistFailure(t *testing.T) {
 	dir := t.TempDir()
-	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	migs := append(librarian.Migrations(), logbook.Migrations()...); sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
 	if err != nil {
 		t.Fatalf("vault.Open: %v", err)

--- a/cli/internal/logbook/turn_observed_test.go
+++ b/cli/internal/logbook/turn_observed_test.go
@@ -2,6 +2,7 @@ package logbook_test
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -23,7 +24,7 @@ import (
 // audit substrate.
 func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
 	dir := t.TempDir()
-	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	migs := append(librarian.Migrations(), logbook.Migrations()...); sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
 	if err != nil {
 		t.Fatalf("vault.Open: %v", err)
@@ -198,7 +199,7 @@ func toString(v any) string {
 
 func TestSubscribeTurnObserved_DropsEventsWithoutSessionID(t *testing.T) {
 	dir := t.TempDir()
-	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	migs := append(librarian.Migrations(), logbook.Migrations()...); sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	v, _ := vault.Open(filepath.Join(dir, "mom.db"), migs)
 	t.Cleanup(func() { _ = v.Close() })
 	lib := librarian.New(v)

--- a/cli/internal/logbook/worker_test.go
+++ b/cli/internal/logbook/worker_test.go
@@ -3,6 +3,7 @@ package logbook_test
 import (
 	"errors"
 	"path/filepath"
+	"sort"
 	"sync/atomic"
 	"testing"
 
@@ -18,7 +19,7 @@ import (
 func openWorker(t *testing.T) (*logbook.Worker, *librarian.Librarian) {
 	t.Helper()
 	dir := t.TempDir()
-	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	migs := append(librarian.Migrations(), logbook.Migrations()...); sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
 	if err != nil {
 		t.Fatalf("vault.Open: %v", err)

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -86,6 +86,29 @@ func readBindFile(path string) (string, error) {
 	return bf.ID, nil
 }
 
+// IdForCwd returns the declared project id for the caller's current
+// working directory by walking up the filesystem for .mom-project.yaml.
+// Returns ("", false) on any error or when no binding is found —
+// callers decide fallback behaviour (e.g. NULL stamp on capture; stderr
+// hint on recall).
+//
+// This is the standard CLI-side convenience over ResolveProject for
+// callers that only care about "give me the id, or nothing." The
+// long-form ResolveProject remains the right call when the caller
+// needs to distinguish "no file" from "malformed file" or surface the
+// source path.
+func IdForCwd() (id string, found bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	id, _, found, err = ResolveProject(cwd)
+	if err != nil {
+		return "", false
+	}
+	return id, found
+}
+
 // validateId is the lax sanity check on a project id. Per ADR 0016 the
 // data layer does not enforce a strict slug regex — users may choose
 // whatever string identifies their project (mixed case, spaces, emoji

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -1,0 +1,105 @@
+// Package project resolves the project identity for a working directory
+// by walking up the filesystem looking for a `.mom-project.yaml` file
+// (ADR 0016). The resolved `id` is what gets stamped on every captured
+// memory's `project_id` column.
+//
+// MOM does not warn or block based on nesting patterns. The resolver
+// simply returns the longest-ancestor match — users decide how to
+// organise their files.
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/momhq/mom/cli/internal/pathutil"
+	"gopkg.in/yaml.v3"
+)
+
+// BindFilename is the name of the project-binding file users check into
+// their repositories. The ADR-0016-locked filename.
+const BindFilename = ".mom-project.yaml"
+
+// MaxIdLength caps the id length to prevent pathological values. The
+// id is a user-chosen string, but unbounded length would be abuse.
+const MaxIdLength = 256
+
+// bindFile is the on-disk shape of .mom-project.yaml.
+type bindFile struct {
+	Version string `yaml:"version"`
+	ID      string `yaml:"id"`
+}
+
+// ResolveProject walks up from cwd looking for the nearest
+// .mom-project.yaml file and returns its declared id. Returns
+// (id, sourceFile, true, nil) on success.
+//
+// When no bind file exists in any ancestor, returns ("", "", false, nil)
+// — not an error. The caller decides fallback policy.
+//
+// Per ADR 0016 the resolver picks the LONGEST-ancestor match (the
+// nearest file to cwd). It does not validate, warn about, or block on
+// nesting patterns.
+//
+// Path canonicalisation (symlinks, /tmp ↔ /private/tmp on macOS) goes
+// through pathutil.CanonicalDir, matching the watcher and registry
+// invariants.
+//
+// Returns an error only for I/O problems other than not-found, malformed
+// YAML, or a non-pathological-id rule violation.
+func ResolveProject(cwd string) (id string, sourceFile string, found bool, err error) {
+	canonical := pathutil.CanonicalDir(cwd)
+	dir := canonical
+	for {
+		candidate := filepath.Join(dir, BindFilename)
+		info, statErr := os.Stat(candidate)
+		if statErr == nil && !info.IsDir() {
+			id, err = readBindFile(candidate)
+			if err != nil {
+				return "", "", false, err
+			}
+			return id, candidate, true, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", "", false, nil
+		}
+		dir = parent
+	}
+}
+
+// readBindFile parses the YAML and validates the id.
+func readBindFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	var bf bindFile
+	if err := yaml.Unmarshal(data, &bf); err != nil {
+		return "", fmt.Errorf("parse %s: %w", path, err)
+	}
+	if err := validateId(bf.ID); err != nil {
+		return "", fmt.Errorf("%s: %w", path, err)
+	}
+	return bf.ID, nil
+}
+
+// validateId is the lax sanity check on a project id. Per ADR 0016 the
+// data layer does not enforce a strict slug regex — users may choose
+// whatever string identifies their project (mixed case, spaces, emoji
+// all allowed). We reject only pathological values that would cause
+// data layer problems.
+func validateId(id string) error {
+	if strings.TrimSpace(id) == "" {
+		return fmt.Errorf("project id must not be empty")
+	}
+	if strings.ContainsAny(id, "\n\r\x00") {
+		return fmt.Errorf("project id must not contain newlines or NULL bytes")
+	}
+	if len(id) > MaxIdLength {
+		return fmt.Errorf("project id exceeds max length %d (got %d)", MaxIdLength, len(id))
+	}
+	return nil
+}

--- a/cli/internal/project/project_test.go
+++ b/cli/internal/project/project_test.go
@@ -1,0 +1,146 @@
+package project_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/momhq/mom/cli/internal/project"
+)
+
+// writeBindFile writes a minimal .mom-project.yaml in dir with the given id.
+func writeBindFile(t *testing.T, dir, id string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	body := []byte("version: \"1\"\nid: " + id + "\n")
+	if err := os.WriteFile(filepath.Join(dir, ".mom-project.yaml"), body, 0o644); err != nil {
+		t.Fatalf("write bind file: %v", err)
+	}
+}
+
+// Tracer bullet: ResolveProject finds .mom-project.yaml in the cwd itself.
+func TestResolveProject_FindsInCurrentDir(t *testing.T) {
+	dir := t.TempDir()
+	writeBindFile(t, dir, "alpha")
+
+	id, sourceFile, found, err := project.ResolveProject(dir)
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true with bind file present")
+	}
+	if id != "alpha" {
+		t.Errorf("id = %q, want alpha", id)
+	}
+	if !filepath.IsAbs(sourceFile) {
+		t.Errorf("sourceFile must be absolute, got %q", sourceFile)
+	}
+	if filepath.Base(sourceFile) != ".mom-project.yaml" {
+		t.Errorf("sourceFile basename = %q, want .mom-project.yaml", filepath.Base(sourceFile))
+	}
+}
+
+// Walks up from a subdirectory to find the bind file in an ancestor.
+func TestResolveProject_WalksUpFromSubdir(t *testing.T) {
+	root := t.TempDir()
+	writeBindFile(t, root, "outer")
+	sub := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	id, _, found, err := project.ResolveProject(sub)
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if !found || id != "outer" {
+		t.Errorf("ResolveProject(subdir) = (%q, %v), want (outer, true)", id, found)
+	}
+}
+
+// When ancestor and descendant both have bind files, the longest
+// (nearest) match wins (ADR 0016).
+func TestResolveProject_LongestAncestorWins(t *testing.T) {
+	root := t.TempDir()
+	writeBindFile(t, root, "outer")
+	inner := filepath.Join(root, "apps", "web")
+	writeBindFile(t, inner, "inner")
+	deep := filepath.Join(inner, "src", "components")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	id, _, _, err := project.ResolveProject(deep)
+	if err != nil {
+		t.Fatalf("ResolveProject: %v", err)
+	}
+	if id != "inner" {
+		t.Errorf("longest ancestor should win: id = %q, want inner", id)
+	}
+}
+
+// No bind file anywhere on the path → not-found, no error.
+func TestResolveProject_NoFileReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	id, sourceFile, found, err := project.ResolveProject(dir)
+	if err != nil {
+		t.Fatalf("ResolveProject must not error when no file exists, got: %v", err)
+	}
+	if found || id != "" || sourceFile != "" {
+		t.Errorf("expected zero-result, got id=%q file=%q found=%v", id, sourceFile, found)
+	}
+}
+
+// Malformed YAML returns an error (not a silent success).
+func TestResolveProject_RejectsMalformedYaml(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".mom-project.yaml"),
+		[]byte("not: valid: yaml: :"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, err := project.ResolveProject(dir)
+	if err == nil {
+		t.Errorf("expected error for malformed YAML")
+	}
+}
+
+// Lax id validation — pathological values rejected, everything else accepted.
+func TestResolveProject_IdValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{"valid lowercase", "foo", false},
+		{"valid with dash", "pi-agents-cli", false},
+		{"mixed case allowed", "MyService", false},
+		{"spaces allowed", "my service", false},
+		{"emoji allowed", "service 🚀", false},
+		{"empty rejected", "", true},
+		{"whitespace-only rejected", "   ", true},
+		{"null byte rejected", "foo\x00bar", true},
+		// Newline rejection is defense-in-depth — YAML normalises
+		// embedded newlines in regular quoted strings to spaces, so
+		// producing one without contrived block-scalar fixtures is
+		// impractical. validateId still rejects them if they arrive.
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := "version: \"1\"\nid: \"" + c.id + "\"\n"
+			if err := os.WriteFile(filepath.Join(dir, ".mom-project.yaml"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, _, _, err := project.ResolveProject(dir)
+			if c.wantErr && err == nil {
+				t.Errorf("expected error for id %q, got nil", c.id)
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("expected no error for id %q, got %v", c.id, err)
+			}
+		})
+	}
+}

--- a/cli/internal/watcher/turn.go
+++ b/cli/internal/watcher/turn.go
@@ -26,6 +26,10 @@ type Turn struct {
 	Model    string // "the model": e.g. "claude-sonnet-4-6", "gpt-4o"
 	Provider string // "provided by whom": model vendor — "anthropic", "openai", …
 	Harness  string // "used in which client": "claude-code", "codex", "windsurf", "pi"
+
+	// ProjectId carries the resolved project identity (ADR 0016).
+	// Empty means "unknown" — the resolver found no .mom-project.yaml.
+	ProjectId string
 }
 
 // ToolCall is one tool invocation observed in an assistant turn.
@@ -99,6 +103,9 @@ func (t Turn) ToPayload() map[string]any {
 	}
 	if t.Provider != "" {
 		out["provider"] = t.Provider
+	}
+	if t.ProjectId != "" {
+		out["project_id"] = t.ProjectId
 	}
 	return out
 }

--- a/cli/internal/watcher/turn_emit_test.go
+++ b/cli/internal/watcher/turn_emit_test.go
@@ -169,3 +169,125 @@ func TestIngestFile_PublishesOneEventPerTurn(t *testing.T) {
 		t.Errorf("turn.observed fired %d times, want 3 (one per turn)", got)
 	}
 }
+
+// TestTurn_ToPayload_EmitsProjectId verifies ProjectId rides on the
+// Herald payload when set (per ADR 0016).
+func TestTurn_ToPayload_EmitsProjectId(t *testing.T) {
+	turn := Turn{
+		SessionID: "s",
+		Role:      "user",
+		Text:      "hi",
+		ProjectId: "alpha",
+	}
+	p := turn.ToPayload()
+	if p["project_id"] != "alpha" {
+		t.Errorf("payload[project_id] = %v, want alpha", p["project_id"])
+	}
+}
+
+// When ProjectId is empty, the payload omits the key entirely (so
+// downstream consumers can tell "stamped as alpha" from "no stamp").
+func TestTurn_ToPayload_OmitsProjectIdWhenEmpty(t *testing.T) {
+	turn := Turn{SessionID: "s", Role: "user", Text: "hi"}
+	p := turn.ToPayload()
+	if _, ok := p["project_id"]; ok {
+		t.Errorf("payload should omit project_id when empty, got %v", p["project_id"])
+	}
+}
+
+// TestIngestFile_StampsProjectIdFromBindFile verifies that when the
+// watcher's ProjectDir contains a .mom-project.yaml, every published
+// Turn carries the resolved project_id (per ADR 0016).
+func TestIngestFile_StampsProjectIdFromBindFile(t *testing.T) {
+	transcriptDir := t.TempDir()
+	momDir := t.TempDir()
+	projectDir := t.TempDir()
+	// Write .mom-project.yaml at project root.
+	if err := os.WriteFile(filepath.Join(projectDir, ".mom-project.yaml"),
+		[]byte("version: \"1\"\nid: alpha\n"), 0o644); err != nil {
+		t.Fatalf("write bind file: %v", err)
+	}
+
+	bus := herald.NewBus()
+	var mu sync.Mutex
+	var captured []herald.Event
+	bus.Subscribe(herald.TurnObserved, func(e herald.Event) {
+		mu.Lock()
+		captured = append(captured, e)
+		mu.Unlock()
+	})
+
+	w := &Watcher{
+		cfg: Config{
+			TranscriptDir: transcriptDir,
+			ProjectDir:    projectDir,
+			MomDir:        momDir,
+			Adapter:       NewClaudeAdapter(),
+			Bus:           bus,
+		},
+		timers:    make(map[string]*time.Timer),
+		cursorDir: filepath.Join(momDir, "cache"),
+		logFile:   filepath.Join(momDir, "watch.log"),
+	}
+	_ = os.MkdirAll(w.cursorDir, 0755)
+
+	transcriptPath := filepath.Join(transcriptDir, "s-pid.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte(claudeUserTurn+"\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	w.ingestFile(transcriptPath)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("got %d events, want 1", len(captured))
+	}
+	got, _ := captured[0].Payload["project_id"].(string)
+	if got != "alpha" {
+		t.Errorf("payload project_id = %q, want alpha", got)
+	}
+}
+
+// When the watcher's ProjectDir has no bind file, payloads omit
+// project_id (NULL stamps downstream).
+func TestIngestFile_OmitsProjectIdWhenUnbound(t *testing.T) {
+	transcriptDir := t.TempDir()
+	momDir := t.TempDir()
+	projectDir := t.TempDir() // no .mom-project.yaml
+
+	bus := herald.NewBus()
+	var mu sync.Mutex
+	var captured []herald.Event
+	bus.Subscribe(herald.TurnObserved, func(e herald.Event) {
+		mu.Lock()
+		captured = append(captured, e)
+		mu.Unlock()
+	})
+
+	w := &Watcher{
+		cfg: Config{
+			TranscriptDir: transcriptDir,
+			ProjectDir:    projectDir,
+			MomDir:        momDir,
+			Adapter:       NewClaudeAdapter(),
+			Bus:           bus,
+		},
+		timers:    make(map[string]*time.Timer),
+		cursorDir: filepath.Join(momDir, "cache"),
+		logFile:   filepath.Join(momDir, "watch.log"),
+	}
+	_ = os.MkdirAll(w.cursorDir, 0755)
+
+	transcriptPath := filepath.Join(transcriptDir, "s-unbound.jsonl")
+	_ = os.WriteFile(transcriptPath, []byte(claudeUserTurn+"\n"), 0o644)
+	w.ingestFile(transcriptPath)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("got %d events, want 1", len(captured))
+	}
+	if _, ok := captured[0].Payload["project_id"]; ok {
+		t.Errorf("payload should omit project_id when unbound, got %v", captured[0].Payload["project_id"])
+	}
+}

--- a/cli/internal/watcher/watcher.go
+++ b/cli/internal/watcher/watcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/momhq/mom/cli/internal/herald"
 	"github.com/momhq/mom/cli/internal/pathutil"
+	"github.com/momhq/mom/cli/internal/project"
 	"github.com/momhq/mom/cli/internal/ux"
 )
 
@@ -69,6 +70,12 @@ type resolvedSource struct {
 	adapter Adapter
 }
 
+// projectIdCacheTTL bounds how stale the resolved project_id may be.
+// Per ADR 0016: resolution happens at publish-time with a short cache
+// so mid-session bindings (the user running /mom-project while a
+// session is active) take effect within a few captures.
+const projectIdCacheTTL = 5 * time.Second
+
 // Watcher tails Harness transcript directories with cursor-based
 // incremental reads and emits one turn.observed event per parsed
 // turn on the Herald bus.
@@ -82,6 +89,13 @@ type Watcher struct {
 	logFile    string
 	p          *ux.Printer
 	catchingUp bool // true during catchUp phase — suppresses per-file output
+
+	// projectIdCache stamps captured Turns with the resolved project
+	// identity. Cached briefly to keep the per-publish stat cost low
+	// while still picking up new bindings without a session restart.
+	projectIdMu    sync.Mutex
+	projectIdValue string
+	projectIdExp   time.Time
 }
 
 // New creates a Watcher. Call Run to start watching.
@@ -427,7 +441,11 @@ func (w *Watcher) ingestFile(path string) int {
 	// these for the filter + cluster + persist pipeline; Logbook
 	// projects to a privacy-safe metadata row.
 	if w.cfg.Bus != nil {
+		projectId := w.resolveProjectId()
 		for _, t := range turns {
+			if projectId != "" {
+				t.ProjectId = projectId
+			}
 			w.cfg.Bus.Publish(herald.Event{
 				Type:      herald.TurnObserved,
 				SessionID: t.SessionID,
@@ -437,6 +455,30 @@ func (w *Watcher) ingestFile(path string) int {
 	}
 
 	return len(turns)
+}
+
+// resolveProjectId returns the project_id for cfg.ProjectDir using a
+// short cache (ADR 0016 — mid-session bindings take effect on the next
+// re-resolve, without requiring a watcher restart). Returns "" when
+// no .mom-project.yaml is found or on resolution error.
+func (w *Watcher) resolveProjectId() string {
+	if w.cfg.ProjectDir == "" {
+		return ""
+	}
+	w.projectIdMu.Lock()
+	defer w.projectIdMu.Unlock()
+	if time.Now().Before(w.projectIdExp) {
+		return w.projectIdValue
+	}
+	id, _, _, err := project.ResolveProject(w.cfg.ProjectDir)
+	if err != nil {
+		// Malformed file: treat as unbound (best-effort). The CLI/skill
+		// surfaces the error to the user.
+		id = ""
+	}
+	w.projectIdValue = id
+	w.projectIdExp = time.Now().Add(projectIdCacheTTL)
+	return id
 }
 
 // addDir adds a directory and all its subdirectories to the fsnotify watcher.


### PR DESCRIPTION
## Summary

Lands the schema + capture + recall plumbing for \`project_id\`, per [ADR 0016](../blob/main/adr/0016-project-as-declared-first-class-identity.md). Memories captured in a directory with a checked-in \`.mom-project.yaml\` now stamp the declared \`id\`; recall scopes to the cwd-resolved project by default with \`--all\`, \`--project\`, \`--strict-project\` escape hatches.

Closes #331. The user-facing binding UX (\`/mom-project\` skill + \`mom project bind\` CLI) is the next PR (#332).

## What lands

- **Schema** — migration v6 adds \`project_id TEXT\` + index; ADR 0011 extended to list it as substance-immutable.
- **Librarian** — \`InsertMemory\` / \`Memory\` / \`SearchedMemory\` carry \`ProjectId\`; \`SearchFilter\` gains \`ProjectId\` + \`StrictProject\` with the ADR-locked semantics (NULL included by default in scoped queries).
- **\`cli/internal/project\` package (new)** — \`ResolveProject(cwd)\` walks up for \`.mom-project.yaml\`, longest-ancestor wins, lax id validation.
- **Capture** — \`Turn.ProjectId\` + payload key; watcher resolves at publish-time with 5s cache (mid-session bindings take effect without restart); Drafter propagates from event → memory row; \`mom record\` resolves from cwd.
- **Recall** — \`finder.Options\` gains \`ProjectId\` + \`StrictProject\`; \`mom recall\` flags \`--all\`, \`--project\`, \`--strict-project\`; default = cwd-resolved scope; unbound cwd falls through with a stderr hint pointing at \`/mom-project\`.

## Test plan

- [x] 16 new hermetic tests across librarian (round-trip, filter, strict-mode, migration backward-safety), project (find/walk-up/longest-ancestor/no-file/malformed/lax-validation), watcher (Turn payload, watcher stamping bound + unbound), drafter (FlushAll and processRecord propagation), cmd (mom record stamps + NULL when unbound), and recall (default scope, --all, --project override, unbound-hint, --strict-project).
- [x] 6 existing sibling test suites bulk-fixed to sort \`librarian+logbook\` migrations post-concat. Production composer in \`centralvault.Migrations()\` already sorted; this aligns tests.
- [x] Architecture guardrails GREEN.
- [x] Full \`go test ./...\` — only pre-existing session-id failures (\`TestRunRecord_MissingSessionRejectsRealText\`, \`TestResolveSessionIDRejectsMissing\`, etc.) remain. Unrelated to this PR.

## Notes

- \`IncludeUnknownProject\` was renamed to \`StrictProject\` (inverse polarity) so the zero-value semantic matches the ADR default (\"legacy memories remain findable in scoped queries\"). Issue body referenced \`IncludeUnknownProject\` — flagged here for transparency.
- The data-collection MCP path is unaffected — \`project_id\` rides on the existing \`turn.observed\` payload through the watcher pipeline. User-facing MCP tools (\`mom_recall\`, \`mom_record\`) are out of scope per the ADR's "CLI is the resolution surface" decision and being retired on a separate track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)