### PR TITLE
feat: project binding UX — /mom-project skill + mom project bind CLI

### DIFF
--- a/cli/internal/cmd/architecture_guardrails_test.go
+++ b/cli/internal/cmd/architecture_guardrails_test.go
@@ -36,6 +36,7 @@ var canonicalCLISurface = []string{
 	"init",
 	"lens",
 	"map",
+	"project",
 	"recall",
 	"record",
 	"serve",

--- a/cli/internal/cmd/central_cli_test.go
+++ b/cli/internal/cmd/central_cli_test.go
@@ -489,3 +489,58 @@ func TestRecallCmd_StrictProjectExcludesNull(t *testing.T) {
 		t.Errorf("strict should exclude NULL %s, got:\n%s", legacyID, out)
 	}
 }
+
+// Cycle 7: When cwd has no .mom-project.yaml ancestor, status surfaces
+// a one-line nudge pointing at /mom-project (per ADR 0016 Q5).
+func TestStatusCmd_NudgesWhenCwdUnbound(t *testing.T) {
+	openCentralTestLib(t)
+
+	// Chdir to an unbound dir.
+	unbound := t.TempDir()
+	orig, _ := os.Getwd()
+	if err := os.Chdir(unbound); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	buf := new(bytes.Buffer)
+	statusCmd.SetOut(buf)
+	statusCmd.SetErr(buf)
+	if err := runStatus(statusCmd, nil); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "/mom-project") {
+		t.Errorf("expected nudge mentioning /mom-project for unbound cwd, got:\n%s", out)
+	}
+}
+
+// Cycle 8: When cwd is bound, status reports the project id and stays quiet.
+func TestStatusCmd_ShowsProjectWhenBound(t *testing.T) {
+	openCentralTestLib(t)
+
+	bound := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bound, ".mom-project.yaml"),
+		[]byte("version: \"1\"\nid: alpha\n"), 0o644); err != nil {
+		t.Fatalf("write bind file: %v", err)
+	}
+	orig, _ := os.Getwd()
+	if err := os.Chdir(bound); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	buf := new(bytes.Buffer)
+	statusCmd.SetOut(buf)
+	statusCmd.SetErr(buf)
+	if err := runStatus(statusCmd, nil); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "alpha") {
+		t.Errorf("expected bound project id in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "/mom-project") {
+		t.Errorf("bound cwd should NOT trigger the nudge, got:\n%s", out)
+	}
+}

--- a/cli/internal/cmd/ops.go
+++ b/cli/internal/cmd/ops.go
@@ -11,6 +11,7 @@ import (
 	"github.com/momhq/mom/cli/internal/daemon"
 	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/memory"
+	"github.com/momhq/mom/cli/internal/project"
 	"github.com/momhq/mom/cli/internal/ux"
 	"github.com/spf13/cobra"
 )
@@ -71,6 +72,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	p := ux.NewPrinter(cmd.OutOrStdout())
 	p.Bold("MOM")
 	p.KeyValue("cwd", cwd, 12)
+	if id, found := project.IdForCwd(); found {
+		p.KeyValue("project", id, 12)
+	} else {
+		p.KeyValue("project", "(unbound — run /mom-project to bind this directory)", 12)
+	}
 	p.KeyValue("vault", path, 12)
 	p.KeyValue("memories", fmt.Sprintf("total %d, curated %d, draft %d", len(memories), curated, draft), 12)
 	p.KeyValue("types", fmt.Sprintf("episodic %d, semantic %d, procedural %d, untyped %d", types["episodic"], types["semantic"], types["procedural"], types["untyped"]), 12)

--- a/cli/internal/cmd/project.go
+++ b/cli/internal/cmd/project.go
@@ -1,0 +1,63 @@
+// Package cmd — project binding (ADR 0016).
+//
+// `mom project bind --id <slug>` writes a .mom-project.yaml at the current
+// working directory, declaring the project identity that gets stamped on
+// every memory captured from this directory or any subdirectory.
+//
+// Per ADR 0016 this CLI is the scriptable primitive; the interactive
+// front door is the /mom-project skill which shells to this command.
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/momhq/mom/cli/internal/project"
+	"github.com/spf13/cobra"
+)
+
+var (
+	projectBindId    string
+	projectBindForce bool
+)
+
+var projectCmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage MOM project bindings",
+	Long: `Manage the .mom-project.yaml binding that declares this directory's
+project identity (per ADR 0016). Memories captured from a bound directory
+carry the declared id; recall scopes to that id by default.`,
+}
+
+var projectBindCmd = &cobra.Command{
+	Use:   "bind",
+	Short: "Bind the current directory to a project id",
+	Long: `Write a .mom-project.yaml file at the current working directory.
+
+The file should be checked into version control so the binding travels with
+the repository across machines, clones, and forks.
+
+Examples:
+  mom project bind --id pi-agents-cli
+  mom project bind --id my-service --force   # overwrite an existing binding`,
+	RunE: runProjectBind,
+}
+
+func init() {
+	projectBindCmd.Flags().StringVar(&projectBindId, "id", "", "Project id to declare (required)")
+	projectBindCmd.Flags().BoolVar(&projectBindForce, "force", false, "Overwrite an existing binding with a different id")
+	_ = projectBindCmd.MarkFlagRequired("id")
+	projectCmd.AddCommand(projectBindCmd)
+}
+
+func runProjectBind(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting cwd: %w", err)
+	}
+	if err := project.WriteBinding(cwd, projectBindId, projectBindForce); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "bound %s to project %q\n", cwd, projectBindId)
+	return nil
+}

--- a/cli/internal/cmd/project_test.go
+++ b/cli/internal/cmd/project_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// execProjectBind chdirs to dir, invokes `mom project bind --id <id>` via
+// rootCmd, and returns combined output. Restores cwd via t.Cleanup.
+func execProjectBind(t *testing.T, dir, id string, force bool) (string, error) {
+	t.Helper()
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	args := []string{"project", "bind", "--id", id}
+	if force {
+		args = append(args, "--force")
+	}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// Tracer: writing a binding creates .mom-project.yaml at cwd.
+func TestProjectBind_WritesYamlAtCwd(t *testing.T) {
+	dir := t.TempDir()
+	out, err := execProjectBind(t, dir, "alpha", false)
+	if err != nil {
+		t.Fatalf("project bind: %v\noutput:\n%s", err, out)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".mom-project.yaml"))
+	if err != nil {
+		t.Fatalf("expected bind file to exist: %v", err)
+	}
+	if !strings.Contains(string(data), "id: alpha") {
+		t.Errorf("expected `id: alpha` in file body, got:\n%s", data)
+	}
+}
+
+// Cycle 2: bind file carries the watermark header so the user-owned
+// distinction is obvious in-place (per ADR 0016 Q6).
+func TestProjectBind_FileCarriesWatermark(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := execProjectBind(t, dir, "alpha", false); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, ".mom-project.yaml"))
+	if !strings.HasPrefix(string(data), "# MOM project binding") {
+		t.Errorf("expected watermark header at top, got:\n%s", data)
+	}
+	if !strings.Contains(string(data), "version: \"1\"") {
+		t.Errorf("expected version field, got:\n%s", data)
+	}
+}
+
+// Cycle 3: pathological id is rejected (newline / null byte / empty).
+func TestProjectBind_RejectsPathologicalId(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"empty", ""},
+		{"null-byte", "foo\x00bar"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_, err := execProjectBind(t, dir, c.id, false)
+			if err == nil {
+				t.Errorf("expected error for id %q", c.id)
+			}
+			if _, err := os.Stat(filepath.Join(dir, ".mom-project.yaml")); err == nil {
+				t.Errorf("bind file must not be written when id is rejected")
+			}
+		})
+	}
+}
+
+// Cycle 4: refuses overwrite when an existing file declares a different
+// id, unless --force is passed.
+func TestProjectBind_RefusesOverwriteWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := execProjectBind(t, dir, "alpha", false); err != nil {
+		t.Fatalf("first bind: %v", err)
+	}
+	out, err := execProjectBind(t, dir, "beta", false)
+	if err == nil {
+		t.Fatalf("expected error overwriting alpha → beta without --force; output:\n%s", out)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, ".mom-project.yaml"))
+	if !strings.Contains(string(data), "id: alpha") {
+		t.Errorf("original alpha binding must survive failed overwrite, got:\n%s", data)
+	}
+}
+
+// Cycle 5: --force overwrites.
+func TestProjectBind_ForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := execProjectBind(t, dir, "alpha", false); err != nil {
+		t.Fatalf("first bind: %v", err)
+	}
+	if _, err := execProjectBind(t, dir, "beta", true); err != nil {
+		t.Fatalf("force bind: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, ".mom-project.yaml"))
+	if !strings.Contains(string(data), "id: beta") {
+		t.Errorf("expected force overwrite to set id: beta, got:\n%s", data)
+	}
+}
+
+// Sanity: re-binding with the SAME id is a no-op success (idempotent).
+func TestProjectBind_SameIdIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := execProjectBind(t, dir, "alpha", false); err != nil {
+		t.Fatalf("first bind: %v", err)
+	}
+	if _, err := execProjectBind(t, dir, "alpha", false); err != nil {
+		t.Errorf("re-binding to same id should succeed without --force, got: %v", err)
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -44,4 +44,5 @@ func init() {
 	rootCmd.AddCommand(watchCmd)
 	rootCmd.AddCommand(demoCmd)
 	rootCmd.AddCommand(lensCmd)
+	rootCmd.AddCommand(projectCmd)
 }

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -109,6 +109,49 @@ func IdForCwd() (id string, found bool) {
 	return id, found
 }
 
+// WriteBinding writes (or rewrites) the .mom-project.yaml at dir with
+// the given id. Implements the ADR 0016 binding-write policy:
+//
+//   - The id is validated via the same lax rule the reader uses.
+//   - If no binding file exists, it is created with a watermark comment
+//     header so the user-owned distinction is visible in-place.
+//   - If a binding file exists with the SAME id, the call is a no-op
+//     success (idempotent re-bind).
+//   - If a binding file exists with a DIFFERENT id, the call fails
+//     unless force is true. Per ADR 0016 the user owns the file; we do
+//     not silently rewrite their declared identity.
+//
+// Per ADR 0016 changing the id starts a fresh project from MOM's
+// perspective — old memories keep the old id; the two cohorts do not
+// merge.
+func WriteBinding(dir, id string, force bool) error {
+	if err := validateId(id); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, BindFilename)
+	if existing, err := os.ReadFile(path); err == nil {
+		// File exists; compare declared id.
+		var bf bindFile
+		if uerr := yaml.Unmarshal(existing, &bf); uerr == nil && bf.ID == id {
+			return nil // idempotent re-bind
+		}
+		if !force {
+			return fmt.Errorf("%s already declares a different project id; pass --force to overwrite", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	body := BindFileWatermark + "version: \"1\"\nid: " + id + "\n"
+	return os.WriteFile(path, []byte(body), 0o644)
+}
+
+// BindFileWatermark is the comment header stamped at the top of every
+// freshly-written .mom-project.yaml so users can see at a glance that
+// they own the file.
+const BindFileWatermark = `# MOM project binding — owned by you, not regenerated.
+# Edit freely; check this file into version control.
+`
+
 // validateId is the lax sanity check on a project id. Per ADR 0016 the
 // data layer does not enforce a strict slug regex — users may choose
 // whatever string identifies their project (mixed case, spaces, emoji

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -26,6 +26,15 @@ const BindFilename = ".mom-project.yaml"
 // id is a user-chosen string, but unbounded length would be abuse.
 const MaxIdLength = 256
 
+// BindFileWatermark is the comment header stamped at the top of every
+// freshly-written .mom-project.yaml so users can see at a glance that
+// they own the file. Per ADR 0016 the file is user-owned; MOM only
+// reads it after the first write (the skill or the bind CLI writes it
+// once with the user's chosen id, then never touches it again).
+const BindFileWatermark = `# MOM project binding — owned by you, not regenerated.
+# Edit freely; check this file into version control.
+`
+
 // bindFile is the on-disk shape of .mom-project.yaml.
 type bindFile struct {
 	Version string `yaml:"version"`
@@ -144,13 +153,6 @@ func WriteBinding(dir, id string, force bool) error {
 	body := BindFileWatermark + "version: \"1\"\nid: " + id + "\n"
 	return os.WriteFile(path, []byte(body), 0o644)
 }
-
-// BindFileWatermark is the comment header stamped at the top of every
-// freshly-written .mom-project.yaml so users can see at a glance that
-// they own the file.
-const BindFileWatermark = `# MOM project binding — owned by you, not regenerated.
-# Edit freely; check this file into version control.
-`
 
 // validateId is the lax sanity check on a project id. Per ADR 0016 the
 // data layer does not enforce a strict slug regex — users may choose

--- a/skills/mom-project/SKILL.md
+++ b/skills/mom-project/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: mom-project
+description: Bind the current directory to a MOM project so captured memories are scoped to it. Use when the user wants to set up project scoping, bind a repo, declare a project id, rebind a directory, or asks about .mom-project.yaml.
+user-invocable: true
+allowed-tools: Bash(mom project*), Bash(cat .mom-project.yaml*), Bash(test -f .mom-project.yaml*)
+---
+
+Run only after explicit user request (or when the user accepts a nudge from `mom status` about an unbound directory).
+
+Per ADR 0016 the file `.mom-project.yaml` at a project root declares its identity. Memories captured from a bound directory carry the declared id; recall scopes to that id by default.
+
+## Flow
+
+1. Check whether the current directory is already bound:
+
+```bash
+test -f .mom-project.yaml && cat .mom-project.yaml
+```
+
+If the file exists, show the current id and ask the user one of:
+- keep the binding (do nothing)
+- rebind to a different id (note that this does NOT merge old memories — changing the id starts a fresh project from MOM's perspective)
+
+If the file does not exist, continue.
+
+2. Propose an `id`. Default = the directory's basename, normalised (lowercase, trim, replace spaces with dashes). Show the proposal and ask the user to confirm or override.
+
+The id is an opaque string MOM stores verbatim. Help the user pick one that is specific enough for their sharing context — git remotes are not consulted, so two unrelated projects on different machines can pick the same id and collide if they ever sync. Suggest something like `vendor/project` or `team-service` if that matters for them.
+
+3. Write the binding:
+
+```bash
+mom project bind --id <chosen-id>
+```
+
+If the directory already declares a different id and the user agreed to rebind, append `--force`.
+
+4. Suggest committing the file:
+
+```
+Check `.mom-project.yaml` into version control so the binding travels with the repo.
+```
+
+5. Do not silently rebind. The id is a shared artifact; the user should pick it deliberately.
+
+## Behavior rules
+
+- Never invoke `mom project bind` without confirming the id with the user.
+- Never run `mom init` from this skill — `mom init` is the global install flow and does not write project bindings (ADR 0016).
+- If `mom project bind` returns an error, surface the error to the user and stop.
+- After a successful bind, capture a one-line confirmation that the directory is now bound to `<id>`.


### PR DESCRIPTION
## Summary

Ships the user-facing binding surface for [ADR 0016](../blob/main/adr/0016-project-as-declared-first-class-identity.md). The foundation (schema + capture + recall) landed in #335; this PR ships what users actually touch.

Closes #332.

## What lands

- **CLI primitive** — \`mom project bind --id <slug> [--force]\` writes \`.mom-project.yaml\` with a watermark comment header so users see ownership at a glance. Idempotent on same-id, refuses overwrite without \`--force\`, surface validation via the shared lax rule.
- **\`project.WriteBinding\` helper** — all policy in the project package; the CLI is a thin wrapper. Small interface, deep module.
- **\`/mom-project\` skill** — interactive flow under \`skills/mom-project/SKILL.md\`. Detects existing binding, proposes a slugified id, confirms with the user, shells to \`mom project bind\`, suggests committing.
- **\`mom-status\` nudge** — adds a \`project\` line. Bound dirs show the id; unbound dirs show \`(unbound — run /mom-project to bind this directory)\`.
- **Architecture guardrails** — \`project\` added to the canonical CLI surface list.

## Test plan

- [x] 7 new tests (CLI: tracer + watermark + validation + refuse/force overwrite + idempotency; status: nudge appears when unbound, project id shown when bound).
- [x] Architecture guardrails GREEN with \`project\` in the canonical list.
- [x] Full \`go test ./...\` — only pre-existing session-id failures remain. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)