### PR TITLE
fix(watcher): emit harness on Turn.ToPayload

### DIFF
--- a/cli/internal/logbook/turn_observed_test.go
+++ b/cli/internal/logbook/turn_observed_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/momhq/mom/cli/internal/librarian"
 	"github.com/momhq/mom/cli/internal/logbook"
 	"github.com/momhq/mom/cli/internal/vault"
+	"github.com/momhq/mom/cli/internal/watcher"
 )
 
 // TestSubscribeTurnObserved_PersistsMetadataProjection locks the
@@ -219,5 +220,53 @@ func TestSubscribeTurnObserved_DropsEventsWithoutSessionID(t *testing.T) {
 	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{})
 	if len(rows) != 0 {
 		t.Errorf("got %d rows, want 0 (empty session_id should drop)", len(rows))
+	}
+}
+
+// TestSubscribeTurnObserved_PreservesHarnessFromTurnPayload locks the
+// full chain that #340 fixed: when a watcher.Turn with Harness set
+// flows through Turn.ToPayload() → herald.Event → Logbook, the
+// persisted op_events.payload carries the harness.
+//
+// The existing PersistsMetadataProjection test builds the payload by
+// hand (it always had "harness" in the map), so it never noticed that
+// ToPayload was dropping the field. This test goes via ToPayload to
+// verify the integration.
+func TestSubscribeTurnObserved_PreservesHarnessFromTurnPayload(t *testing.T) {
+	dir := t.TempDir()
+	migs := append(librarian.Migrations(), logbook.Migrations()...)
+	sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
+	v, err := vault.Open(filepath.Join(dir, "mom.db"), migs)
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	lib := librarian.New(v)
+	w := logbook.New(lib)
+	bus := herald.NewBus()
+	defer w.SubscribeTurnObserved(bus)()
+
+	turn := watcher.Turn{
+		SessionID: "s-harness",
+		Role:      "user",
+		Text:      "hello",
+		Harness:   "pi",
+	}
+	bus.Publish(herald.Event{
+		Type:      herald.TurnObserved,
+		SessionID: turn.SessionID,
+		Payload:   turn.ToPayload(),
+	})
+
+	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "turn.observed"})
+	if err != nil {
+		t.Fatalf("QueryOpEvents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d op_events rows, want 1", len(rows))
+	}
+	got, _ := rows[0].Payload["harness"].(string)
+	if got != "pi" {
+		t.Errorf("op_events.payload.harness = %q, want pi", got)
 	}
 }

--- a/cli/internal/watcher/turn.go
+++ b/cli/internal/watcher/turn.go
@@ -62,7 +62,8 @@ type Usage struct {
 // reinvent extraction.
 //
 // Keys: "role", "text", "tool_calls" ([]map with name/input/category),
-// "usage" (map of token counts), "model", "provider".
+// "usage" (map of token counts), "model", "provider", "harness",
+// "project_id".
 func (t Turn) ToPayload() map[string]any {
 	out := map[string]any{
 		"role": t.Role,
@@ -103,6 +104,9 @@ func (t Turn) ToPayload() map[string]any {
 	}
 	if t.Provider != "" {
 		out["provider"] = t.Provider
+	}
+	if t.Harness != "" {
+		out["harness"] = t.Harness
 	}
 	if t.ProjectId != "" {
 		out["project_id"] = t.ProjectId

--- a/cli/internal/watcher/turn_emit_test.go
+++ b/cli/internal/watcher/turn_emit_test.go
@@ -291,3 +291,30 @@ func TestIngestFile_OmitsProjectIdWhenUnbound(t *testing.T) {
 		t.Errorf("payload should omit project_id when unbound, got %v", captured[0].Payload["project_id"])
 	}
 }
+
+// TestTurn_ToPayload_EmitsHarness locks the contract that watcher
+// adapters' harness identity (claude-code, codex, pi, …) rides on the
+// herald payload so Logbook and Drafter can attribute the turn to the
+// right harness. Pre-#340 ToPayload silently dropped this field.
+func TestTurn_ToPayload_EmitsHarness(t *testing.T) {
+	turn := Turn{
+		SessionID: "s",
+		Role:      "user",
+		Text:      "hi",
+		Harness:   "pi",
+	}
+	p := turn.ToPayload()
+	if p["harness"] != "pi" {
+		t.Errorf("payload[harness] = %v, want pi", p["harness"])
+	}
+}
+
+// When Harness is empty, payload omits the key — keeps the bus clean
+// for paths that don't carry harness information.
+func TestTurn_ToPayload_OmitsHarnessWhenEmpty(t *testing.T) {
+	turn := Turn{SessionID: "s", Role: "user", Text: "hi"}
+	p := turn.ToPayload()
+	if _, ok := p["harness"]; ok {
+		t.Errorf("payload should omit harness when empty, got %v", p["harness"])
+	}
+}


### PR DESCRIPTION
## Summary

\`Turn.ToPayload\` was silently dropping the \`harness\` field — every watcher adapter sets \`Turn.Harness\` (\"claude-code\", \"codex\", \"pi\", \"windsurf\"), but the herald payload omitted it. Downstream consumers (Logbook \`projectTurnObserved\`, Drafter \`observeTurn\`) all expect the key and got empty strings.

Live consequence: transcript-derived memories show \`provenance_actor=\"watcher\"\` instead of the actual harness. User-facing symptom in this session: \"pi transcripts don't appear to be flowing\" — pi turns ARE being ingested, they just look identical to claude turns in op_events.

Caught while investigating #338 (the daemon restart issue). Same vault inspection showed today's 20 memories: 17 \"watcher\", 3 \"codex\" (those 3 came via hooks, different path). Zero attributed to their actual adapter.

Closes #340.

## Fix

One line in \`Turn.ToPayload\` plus the matching docstring update.

## Test plan

- [x] Unit: \`TestTurn_ToPayload_EmitsHarness\` + \`TestTurn_ToPayload_OmitsHarnessWhenEmpty\`
- [x] End-to-end: \`TestSubscribeTurnObserved_PreservesHarnessFromTurnPayload\` — drives a real \`watcher.Turn\` through \`Turn.ToPayload\` → herald → Logbook → \`op_events.payload\` and verifies harness lands on the persisted row. The existing PersistsMetadataProjection test built the payload by hand with harness in the map, so it never noticed the bug.
- [x] Architecture guardrails + full \`go test ./...\` (only pre-existing session-id failures remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)