### PR TITLE
fix(codex): register hooks globally during mom init

### DIFF
--- a/cli/internal/adapters/harness/codex.go
+++ b/cli/internal/adapters/harness/codex.go
@@ -61,15 +61,33 @@ func (a *CodexAdapter) GenerateContextFile(config Config, constraints []Constrai
 }
 
 func (a *CodexAdapter) RegisterHooks() error {
+	return writeCodexHooks(filepath.Join(a.projectRoot, ".codex", "hooks.json"))
+}
+
+// RegisterGlobalHooks writes the same hook contract to the user-level
+// Codex config dir (~/.codex/hooks.json, or $CODEX_HOME/hooks.json when
+// set) so Codex Desktop sessions fire `mom watch --sweep` after each
+// Cascade response — same defensive sweep wired for project-local
+// installs, scoped to the user.
+func (a *CodexAdapter) RegisterGlobalHooks() error {
+	path, err := codexHomePath("hooks.json")
+	if err != nil {
+		return err
+	}
+	return writeCodexHooks(path)
+}
+
+// writeCodexHooks renders Codex's hooks.json format at the given path,
+// creating parent dirs as needed. The hook set is intentionally small:
+// one Stop hook running `mom watch --sweep`. Auxiliary signal — the
+// daemon's fsnotify watcher catches new transcripts even when this
+// hook never fires.
+func writeCodexHooks(hooksPath string) error {
 	hooks := []HookDef{
 		{Event: "Stop", Command: "mom watch --sweep"},
 	}
-	codexDir := filepath.Join(a.projectRoot, ".codex")
-	hooksPath := filepath.Join(codexDir, "hooks.json")
-
-	// Ensure .codex/ exists.
-	if err := os.MkdirAll(codexDir, 0755); err != nil {
-		return fmt.Errorf("creating .codex dir: %w", err)
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(hooksPath), err)
 	}
 
 	// Codex hooks.json format: { "hooks": { "Event": [ { "hooks": [ {...} ] } ] } }
@@ -89,20 +107,15 @@ func (a *CodexAdapter) RegisterHooks() error {
 		byEvent[h.Event] = append(byEvent[h.Event], group)
 	}
 
-	root := map[string]any{
-		"hooks": byEvent,
-	}
-
+	root := map[string]any{"hooks": byEvent}
 	data, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling hooks: %w", err)
 	}
-
 	data = append(data, '\n')
 	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
-		return fmt.Errorf("writing hooks.json: %w", err)
+		return fmt.Errorf("writing %s: %w", hooksPath, err)
 	}
-
 	return nil
 }
 
@@ -249,6 +262,7 @@ func codexHomePath(parts ...string) (string, error) {
 
 var (
 	_ GlobalAdapter    = (*CodexAdapter)(nil)
-	_ HookInstaller    = (*CodexAdapter)(nil)
+	_ HookInstaller       = (*CodexAdapter)(nil)
+	_ GlobalHookInstaller = (*CodexAdapter)(nil)
 	_ TranscriptSource = (*CodexAdapter)(nil)
 )

--- a/cli/internal/adapters/harness/codex.go
+++ b/cli/internal/adapters/harness/codex.go
@@ -261,8 +261,8 @@ func codexHomePath(parts ...string) (string, error) {
 }
 
 var (
-	_ GlobalAdapter    = (*CodexAdapter)(nil)
+	_ GlobalAdapter       = (*CodexAdapter)(nil)
 	_ HookInstaller       = (*CodexAdapter)(nil)
 	_ GlobalHookInstaller = (*CodexAdapter)(nil)
-	_ TranscriptSource = (*CodexAdapter)(nil)
+	_ TranscriptSource    = (*CodexAdapter)(nil)
 )

--- a/cli/internal/adapters/harness/codex_test.go
+++ b/cli/internal/adapters/harness/codex_test.go
@@ -274,3 +274,58 @@ func TestCodexAdapter_NoIdentity(t *testing.T) {
 		t.Error("should have fallback identity")
 	}
 }
+
+// TestCodexAdapter_RegisterGlobalHooks_WritesToHomeCodexDir locks the
+// global-install contract: mom init --harnesses codex must drop
+// hooks.json at ~/.codex/ so Codex Desktop fires `mom watch --sweep`
+// after each Cascade response. Without this, only project-local
+// inits get the hook wired.
+func TestCodexAdapter_RegisterGlobalHooks_WritesToHomeCodexDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	a := NewCodexAdapter("/tmp/unused-project-root")
+
+	if err := a.RegisterGlobalHooks(); err != nil {
+		t.Fatalf("RegisterGlobalHooks: %v", err)
+	}
+
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("reading global hooks.json: %v", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parse hooks.json: %v", err)
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		t.Fatal("missing top-level 'hooks' key")
+	}
+	stop, ok := hooks["Stop"].([]any)
+	if !ok || len(stop) == 0 {
+		t.Fatal("missing Stop event")
+	}
+	group := stop[0].(map[string]any)
+	inner := group["hooks"].([]any)
+	entry := inner[0].(map[string]any)
+	if entry["command"] != "mom watch --sweep" {
+		t.Errorf("Stop hook command = %v, want 'mom watch --sweep'", entry["command"])
+	}
+}
+
+// CODEX_HOME override puts the hooks.json under the override path.
+func TestCodexAdapter_RegisterGlobalHooks_HonorsCodexHome(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", codexHome)
+	a := NewCodexAdapter("/tmp/unused")
+
+	if err := a.RegisterGlobalHooks(); err != nil {
+		t.Fatalf("RegisterGlobalHooks: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(codexHome, "hooks.json")); err != nil {
+		t.Errorf("expected hooks.json under CODEX_HOME, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

\`CodexAdapter\` implemented \`HookInstaller\` (project-local \`hooks.json\`) but not \`GlobalHookInstaller\`, so \`mom init --harnesses codex\` wrote \`~/.codex/AGENTS.md\` + \`config.toml\` but **skipped \`~/.codex/hooks.json\`**.

The hook fires \`mom watch --sweep\` after each Cascade response as a defensive sweep trigger. The watcher's fsnotify ingestion catches new transcripts without it (confirmed in the codex audit smoke test), but the hook closes a small reliability gap for sessions where the daemon misses a write event.

Surfaced during the v0.40.0 readiness audit you asked for after Windsurf burned us.

## Changes

- Added \`RegisterGlobalHooks\` to \`CodexAdapter\`, writing to \`codexHomePath(\"hooks.json\")\` (honors \`CODEX_HOME\`).
- Extracted \`writeCodexHooks(path)\` so project-local and global registrations share the JSON renderer — no duplication.
- Added \`_ GlobalHookInstaller = (*CodexAdapter)(nil)\` interface guard.

## Test plan

- [x] \`TestCodexAdapter_RegisterGlobalHooks_WritesToHomeCodexDir\` — global hook lands at \`~/.codex/hooks.json\` with HOME isolated
- [x] \`TestCodexAdapter_RegisterGlobalHooks_HonorsCodexHome\` — \`CODEX_HOME\` override is honored
- [x] Full \`go test ./...\` — only pre-existing session-id failures remain
- [x] Live smoke test: \`mom init --harnesses codex\` against an isolated HOME now writes all three files (AGENTS.md, config.toml, hooks.json)

Net diff: +83 / −14 across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)