### PR TITLE
cleanup(v0.40): close #347 #348 #349 #350 #351 — session env, retired tool names, harness rename, content tolerance

### DIFF
--- a/.github/mrp/schemas/capture-payload.schema.json
+++ b/.github/mrp/schemas/capture-payload.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/momhq/mom/mrp/v0/capture-payload",
   "title": "MRP v0 — Capture dual-output payload",
-  "description": "Returned by the runtime adapter when a capture event fires (session.end, compact.triggered, clear.triggered). Both fields land: raw for future re-processing, drafts for immediate use.",
+  "description": "Returned by the harness adapter when a capture event fires (session.end, compact.triggered, clear.triggered). Both fields land: raw for future re-processing, drafts for immediate use.",
   "type": "object",
   "required": ["raw_exhaust", "classified_drafts"],
   "additionalProperties": false,
@@ -13,7 +13,7 @@
     },
     "classified_drafts": {
       "type": "array",
-      "description": "Runtime's inline attempt at structured memory drafts. May be empty if runtime does not support inline classification.",
+      "description": "Harness's inline attempt at structured memory drafts. May be empty if harness does not support inline classification.",
       "items": {
         "type": "object",
         "required": ["type", "summary", "confidence"],
@@ -40,7 +40,7 @@
           "confidence": {
             "type": "string",
             "enum": ["EXTRACTED", "INFERRED", "AMBIGUOUS"],
-            "description": "How confident the runtime is in this classification"
+            "description": "How confident the harness is in this classification"
           }
         }
       }

--- a/.github/mrp/schemas/clear-triggered.schema.json
+++ b/.github/mrp/schemas/clear-triggered.schema.json
@@ -2,9 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/momhq/mom/mrp/v0/clear-triggered",
   "title": "MRP v0 — clear.triggered event",
-  "description": "Emitted when the user or runtime triggers /clear. Fires capture in auto bypass mode (no interactive wrap-up).",
+  "description": "Emitted when the user or harness triggers /clear. Fires capture in auto bypass mode (no interactive wrap-up).",
   "type": "object",
-  "required": ["mrp_version", "event", "session_id", "runtime", "timestamp"],
+  "required": ["mrp_version", "event", "session_id", "harness", "timestamp"],
   "additionalProperties": false,
   "properties": {
     "mrp_version": {
@@ -22,7 +22,7 @@
       "minLength": 1,
       "description": "Unique session identifier"
     },
-    "runtime": {
+    "harness": {
       "type": "string",
       "minLength": 1,
       "description": "Adapter name"
@@ -34,8 +34,8 @@
     },
     "trigger_source": {
       "type": "string",
-      "enum": ["user", "runtime"],
-      "description": "Whether the user or the runtime initiated clear"
+      "enum": ["user", "harness"],
+      "description": "Whether the user or the harness initiated clear"
     }
   }
 }

--- a/.github/mrp/schemas/compact-triggered.schema.json
+++ b/.github/mrp/schemas/compact-triggered.schema.json
@@ -2,9 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/momhq/mom/mrp/v0/compact-triggered",
   "title": "MRP v0 — compact.triggered event",
-  "description": "Emitted when the user or runtime triggers /compact. Fires capture in auto bypass mode (no interactive wrap-up).",
+  "description": "Emitted when the user or harness triggers /compact. Fires capture in auto bypass mode (no interactive wrap-up).",
   "type": "object",
-  "required": ["mrp_version", "event", "session_id", "runtime", "timestamp"],
+  "required": ["mrp_version", "event", "session_id", "harness", "timestamp"],
   "additionalProperties": false,
   "properties": {
     "mrp_version": {
@@ -22,7 +22,7 @@
       "minLength": 1,
       "description": "Unique session identifier"
     },
-    "runtime": {
+    "harness": {
       "type": "string",
       "minLength": 1,
       "description": "Adapter name"
@@ -34,8 +34,8 @@
     },
     "trigger_source": {
       "type": "string",
-      "enum": ["user", "runtime"],
-      "description": "Whether the user or the runtime initiated compact"
+      "enum": ["user", "harness"],
+      "description": "Whether the user or the harness initiated compact"
     }
   }
 }

--- a/.github/mrp/schemas/session-end.schema.json
+++ b/.github/mrp/schemas/session-end.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/momhq/mom/mrp/v0/session-end",
   "title": "MRP v0 — session.end event",
   "type": "object",
-  "required": ["mrp_version", "event", "session_id", "runtime", "timestamp", "started_at", "ended_at"],
+  "required": ["mrp_version", "event", "session_id", "harness", "timestamp", "started_at", "ended_at"],
   "additionalProperties": false,
   "properties": {
     "mrp_version": {
@@ -21,7 +21,7 @@
       "minLength": 1,
       "description": "Unique session identifier"
     },
-    "runtime": {
+    "harness": {
       "type": "string",
       "minLength": 1,
       "description": "Adapter name"
@@ -48,7 +48,7 @@
     },
     "exit_reason": {
       "type": "string",
-      "enum": ["user_ended", "runtime_ended", "timeout", "error"],
+      "enum": ["user_ended", "harness_ended", "timeout", "error"],
       "description": "Why the session ended"
     }
   }

--- a/.github/mrp/schemas/session-start.schema.json
+++ b/.github/mrp/schemas/session-start.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/momhq/mom/mrp/v0/session-start",
   "title": "MRP v0 — session.start event",
   "type": "object",
-  "required": ["mrp_version", "event", "session_id", "runtime", "timestamp", "started_at"],
+  "required": ["mrp_version", "event", "session_id", "harness", "timestamp", "started_at"],
   "additionalProperties": false,
   "properties": {
     "mrp_version": {
@@ -21,7 +21,7 @@
       "minLength": 1,
       "description": "Unique session identifier (UUID recommended)"
     },
-    "runtime": {
+    "harness": {
       "type": "string",
       "minLength": 1,
       "description": "Adapter name (e.g. claude-code, codex, windsurf)"

--- a/.github/mrp/schemas/turn-complete.schema.json
+++ b/.github/mrp/schemas/turn-complete.schema.json
@@ -2,9 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/momhq/mom/mrp/v0/turn-complete",
   "title": "MRP v0 — turn.complete event",
-  "description": "Emitted when one full turn finishes (user prompt + runtime response). Opt-in — adapters that cannot track turn boundaries must not synthesize this event.",
+  "description": "Emitted when one full turn finishes (user prompt + harness response). Opt-in — adapters that cannot track turn boundaries must not synthesize this event.",
   "type": "object",
-  "required": ["mrp_version", "event", "session_id", "runtime", "timestamp", "turn_index"],
+  "required": ["mrp_version", "event", "session_id", "harness", "timestamp", "turn_index"],
   "additionalProperties": false,
   "properties": {
     "mrp_version": {
@@ -22,7 +22,7 @@
       "minLength": 1,
       "description": "Unique session identifier"
     },
-    "runtime": {
+    "harness": {
       "type": "string",
       "minLength": 1,
       "description": "Adapter name"
@@ -45,7 +45,7 @@
     "completion_tokens": {
       "type": "integer",
       "minimum": 0,
-      "description": "Token count for the runtime response (optional)"
+      "description": "Token count for the harness response (optional)"
     }
   }
 }

--- a/.github/mrp/v0.md
+++ b/.github/mrp/v0.md
@@ -1,14 +1,14 @@
-# MRP v0 — MOM Runtime Protocol (Pre-Stable)
+# MRP v0 — MOM Harness Protocol (Pre-Stable)
 
 > **Status:** Pre-stable. Breaking changes allowed until v1. v1 locks with MOM public rebrand.
 
 ## Overview
 
-MRP is the formal contract between L.E.O. and any agent runtime (Claude Code, Codex, Cline, Cursor, etc.).
-It defines the events a runtime must emit, the payload shapes L.E.O. expects, and the capability
+MRP is the formal contract between MOM and any agent harness (Claude Code, Codex, Cline, Cursor, etc.).
+It defines the events a harness must emit, the payload shapes MOM expects, and the capability
 declaration format each adapter publishes.
 
-MRP is **narrow by design**: it covers only runtime-to-L.E.O. events. Git events, filesystem
+MRP is **narrow by design**: it covers only harness-to-MOM events. Git events, filesystem
 watch, and external integrations are out of scope.
 
 ---
@@ -25,15 +25,15 @@ watch, and external integrations are out of scope.
 
 ## Core Events
 
-Runtimes emit these events to L.E.O.'s adapter layer.
+Harnesses emit these events to MOM's adapter layer.
 
 | Event               | When                                             | Required for                        |
 |---------------------|--------------------------------------------------|-------------------------------------|
-| `session.start`     | Runtime opens a session with a user              | Telemetry, scope resolution         |
-| `session.end`       | User or runtime ends the session cleanly         | Capture (interactive wrap-up)       |
+| `session.start`     | Harness opens a session with a user              | Telemetry, scope resolution         |
+| `session.end`       | User or harness ends the session cleanly         | Capture (interactive wrap-up)       |
 | `turn.complete`     | One full turn finished (prompt + response)       | Optional — richer telemetry only    |
-| `compact.triggered` | User or runtime runs `/compact`                  | Capture (auto bypass mode)          |
-| `clear.triggered`   | User or runtime runs `/clear`                    | Capture (auto bypass mode)          |
+| `compact.triggered` | User or harness runs `/compact`                  | Capture (auto bypass mode)          |
+| `clear.triggered`   | User or harness runs `/clear`                    | Capture (auto bypass mode)          |
 
 ### Notes
 
@@ -47,10 +47,10 @@ Runtimes emit these events to L.E.O.'s adapter layer.
 ## What MRP Is NOT Responsible For
 
 **Git events.** Commit detection lives in a separate git integration (git hook, MCP server, etc.)
-that writes to L.E.O. independently. The runtime consumes a KB that already includes
+that writes to MOM independently. The harness consumes a KB that already includes
 commit-linked memories — it does not emit them.
 
-**Filesystem events.** L.E.O.'s watch mode (if added) lives alongside MRP, not inside it.
+**Filesystem events.** MOM's watch mode (if added) lives alongside MRP, not inside it.
 
 Keeping MRP narrow prevents it from accumulating concerns that belong elsewhere.
 
@@ -65,7 +65,7 @@ All events share a common envelope:
   "mrp_version": "v0",
   "event": "<event-name>",
   "session_id": "<uuid>",
-  "runtime": "<adapter-name>",
+  "harness": "<adapter-name>",
   "timestamp": "<RFC3339>"
 }
 ```
@@ -77,7 +77,7 @@ All events share a common envelope:
   "mrp_version": "v0",
   "event": "session.start",
   "session_id": "abc123",
-  "runtime": "claude-code",
+  "harness": "claude-code",
   "timestamp": "2026-04-18T10:00:00Z",
   "started_at": "2026-04-18T10:00:00Z",
   "project_root": "/path/to/project",
@@ -92,12 +92,12 @@ All events share a common envelope:
   "mrp_version": "v0",
   "event": "session.end",
   "session_id": "abc123",
-  "runtime": "claude-code",
+  "harness": "claude-code",
   "timestamp": "2026-04-18T11:00:00Z",
   "started_at": "2026-04-18T10:00:00Z",
   "ended_at": "2026-04-18T11:00:00Z",
   "turn_count": 12,
-  "exit_reason": "user_ended|runtime_ended|timeout|error"
+  "exit_reason": "user_ended|harness_ended|timeout|error"
 }
 ```
 
@@ -108,7 +108,7 @@ All events share a common envelope:
   "mrp_version": "v0",
   "event": "turn.complete",
   "session_id": "abc123",
-  "runtime": "claude-code",
+  "harness": "claude-code",
   "timestamp": "2026-04-18T10:05:00Z",
   "turn_index": 1,
   "prompt_tokens": 1024,
@@ -123,9 +123,9 @@ All events share a common envelope:
   "mrp_version": "v0",
   "event": "compact.triggered",
   "session_id": "abc123",
-  "runtime": "claude-code",
+  "harness": "claude-code",
   "timestamp": "2026-04-18T10:30:00Z",
-  "trigger_source": "user|runtime"
+  "trigger_source": "user|harness"
 }
 ```
 
@@ -136,9 +136,9 @@ All events share a common envelope:
   "mrp_version": "v0",
   "event": "clear.triggered",
   "session_id": "abc123",
-  "runtime": "claude-code",
+  "harness": "claude-code",
   "timestamp": "2026-04-18T10:45:00Z",
-  "trigger_source": "user|runtime"
+  "trigger_source": "user|harness"
 }
 ```
 
@@ -146,7 +146,7 @@ All events share a common envelope:
 
 ## Capture Dual-Output Payload
 
-When a capture event fires (`session.end`, `compact.triggered`, `clear.triggered`), the runtime
+When a capture event fires (`session.end`, `compact.triggered`, `clear.triggered`), the harness
 adapter returns a dual-output payload. Both fields land: raw for future re-processing, drafts
 for immediate use.
 
@@ -167,17 +167,17 @@ for immediate use.
 | Field               | Required | Description                                           |
 |---------------------|----------|-------------------------------------------------------|
 | `raw_exhaust`       | Yes      | Unprocessed session context (transcript, summary, etc.) |
-| `classified_drafts` | Yes      | Runtime's inline attempt at structured memory drafts  |
+| `classified_drafts` | Yes      | Harness's inline attempt at structured memory drafts  |
 
-`classified_drafts` may be an empty array `[]` if the runtime does not support inline
-classification — L.E.O. processes `raw_exhaust` as a fallback.
+`classified_drafts` may be an empty array `[]` if the harness does not support inline
+classification — MOM processes `raw_exhaust` as a fallback.
 
 ---
 
 ## Adapter Capability Declaration
 
 Each adapter declares which MRP events it natively supports. This YAML file is embedded in the
-binary and read at runtime.
+binary and read at process startup.
 
 ```yaml
 adapter: claude-code
@@ -198,10 +198,10 @@ experimental: []
 | `supports`     | Yes      | Events natively supported                                |
 | `experimental` | Yes      | Events emitted best-effort; may fire unreliably          |
 
-An event listed under `experimental` is emitted on a best-effort basis. L.E.O. will not crash
+An event listed under `experimental` is emitted on a best-effort basis. MOM will not crash
 if it is missing, but capture reliability is reduced.
 
-Events not listed under either `supports` or `experimental` are **unsupported** — L.E.O. does
+Events not listed under either `supports` or `experimental` are **unsupported** — MOM does
 not expect them from this adapter.
 
 ---
@@ -227,13 +227,13 @@ are emitted heuristically.
 - **v1**: Stable. Locked with MOM public rebrand. Backward compatibility required for all
   changes; breaking changes require a new major version (`v2`).
 - Adapters declare the MRP version they implement via the `mrp_version` field in every event payload.
-- L.E.O. rejects events from unknown MRP versions with a clear error message.
+- MOM rejects events from unknown MRP versions with a clear error message.
 
 ---
 
 ## Extension Points (v1 roadmap)
 
-- `git.commit` event — emitted by git integration, not the runtime
-- `scope.changed` event — runtime signals active directory change
+- `git.commit` event — emitted by git integration, not the harness
+- `scope.changed` event — harness signals active directory change
 - Multi-user session support (shared session ID)
 - Cursor adapter (alpha, targeting v0.9)

--- a/cli/internal/adapters/harness/content.go
+++ b/cli/internal/adapters/harness/content.go
@@ -14,7 +14,7 @@ MOM remembers project decisions across sessions.
 
 At session start, call ` + "`mom_status`" + `.
 
-Prefer skills and CLI: /mom-status, /mom-recall, /mom-wrap-up. For explicit "remember/save this" requests, pipe text to ` + "`mom record`" + ` through CLI; never invent session IDs, and omit ` + "`--session`" + ` unless you have a real runtime session ID. MCP fallback is for startup, discovery, or when CLI is unavailable.
+Prefer skills and CLI: /mom-status, /mom-recall, /mom-wrap-up. For explicit "remember/save this" requests, pipe text to ` + "`mom record`" + ` through CLI; never invent session IDs, and omit ` + "`--session`" + ` unless you have a real harness session ID. MCP fallback is for startup, discovery, or when CLI is unavailable.
 `
 }
 

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -328,12 +328,12 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 	emitter.EmitSessionEvent(herald.SessionEvent{
 		SessionID: "s-init",
 		RepoID:    filepath.Base(cwd),
-		Runtime:   cfg.PrimaryRuntime(),
+		Harness:   cfg.PrimaryHarness(),
 		StartedAt: startedAt,
 		Trigger:   "normal",
 	})
-	emitter.EmitRuntimeHealth(herald.RuntimeHealth{
-		Runtime:       cfg.PrimaryRuntime(),
+	emitter.EmitHarnessHealth(herald.HarnessHealth{
+		Harness:       cfg.PrimaryHarness(),
 		TS:            time.Now().UTC().Format(time.RFC3339),
 		WrapUpSuccess: true,
 		LatencyMS:     0,

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -277,11 +277,11 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 	// ── Phase 3: Generate harness context files ────────────────────────────
 	var genErr error
 	doGenerate := func() {
-		runtimeCfg := buildRuntimeConfig(cfg)
+		harnessCfg := buildHarnessConfig(cfg)
 
-		runtimeConstraints := buildRuntimeConstraints()
-		runtimeSkills := buildRuntimeSkills()
-		runtimeIdentity := buildRuntimeIdentity()
+		harnessConstraints := buildHarnessConstraints()
+		harnessSkills := buildHarnessSkills()
+		harnessIdentity := buildHarnessIdentity()
 
 		// Install global context/tool integration for all selected harnesses.
 		for _, rt := range result.Harnesses {
@@ -289,7 +289,7 @@ func runInitWithConfig(cmd *cobra.Command, cwd string, force bool, result Onboar
 			if !ok {
 				continue
 			}
-			if err := installGlobalHarness(adapter, rt, runtimeCfg, runtimeConstraints, runtimeSkills, runtimeIdentity); err != nil {
+			if err := installGlobalHarness(adapter, rt, harnessCfg, harnessConstraints, harnessSkills, harnessIdentity); err != nil {
 				genErr = err
 				return
 			}
@@ -393,10 +393,10 @@ func runReinit(cmd *cobra.Command, cwd, momDir string, result OnboardingResult, 
 	// Refresh global context/tool integration for all enabled harnesses. This
 	// doubles as a repair path when a user deletes one global file and reruns init.
 	registry := harness.NewRegistry(cwd)
-	runtimeCfg := buildRuntimeConfig(cfg)
-	runtimeConstraints := buildRuntimeConstraints()
-	runtimeSkills := buildRuntimeSkills()
-	runtimeIdentity := buildRuntimeIdentity()
+	harnessCfg := buildHarnessConfig(cfg)
+	harnessConstraints := buildHarnessConstraints()
+	harnessSkills := buildHarnessSkills()
+	harnessIdentity := buildHarnessIdentity()
 	installed := make([]string, 0, len(cfg.EnabledHarnesses()))
 
 	for _, rt := range cfg.EnabledHarnesses() {
@@ -404,7 +404,7 @@ func runReinit(cmd *cobra.Command, cwd, momDir string, result OnboardingResult, 
 		if !ok {
 			continue
 		}
-		if err := installGlobalHarness(adapter, rt, runtimeCfg, runtimeConstraints, runtimeSkills, runtimeIdentity); err != nil {
+		if err := installGlobalHarness(adapter, rt, harnessCfg, harnessConstraints, harnessSkills, harnessIdentity); err != nil {
 			p.Warnf("%s global integration: %v", rt, err)
 			continue
 		}
@@ -432,10 +432,10 @@ func runReinit(cmd *cobra.Command, cwd, momDir string, result OnboardingResult, 
 	return nil
 }
 
-// buildRuntimeConfig converts a config.Config to a harness.Config.
+// buildHarnessConfig converts a config.Config to a harness.Config.
 // Autonomy was retired from the persisted config; generated context files still
 // include the balanced default so the harness retains the behavioral directive.
-func buildRuntimeConfig(cfg *config.Config) harness.Config {
+func buildHarnessConfig(cfg *config.Config) harness.Config {
 	commMode := cfg.Communication.Mode
 	if commMode == "" {
 		commMode = "concise"
@@ -455,20 +455,20 @@ func buildRuntimeConfig(cfg *config.Config) harness.Config {
 	}
 }
 
-// buildRuntimeConstraints returns no generated central constraints. Agent behavior
+// buildHarnessConstraints returns no generated central constraints. Agent behavior
 // is delivered through installed skills and compact context files.
-func buildRuntimeConstraints() []harness.Constraint {
+func buildHarnessConstraints() []harness.Constraint {
 	return nil
 }
 
-// buildRuntimeSkills returns no generated central skills. Slash skills are
+// buildHarnessSkills returns no generated central skills. Slash skills are
 // installed through the skills package manager instead.
-func buildRuntimeSkills() []harness.Skill {
+func buildHarnessSkills() []harness.Skill {
 	return nil
 }
 
-// buildRuntimeIdentity parses the identity JSON into a harness.Identity.
-func buildRuntimeIdentity() *harness.Identity {
+// buildHarnessIdentity parses the identity JSON into a harness.Identity.
+func buildHarnessIdentity() *harness.Identity {
 	var identityData struct {
 		What        string   `json:"what"`
 		Philosophy  string   `json:"philosophy"`
@@ -517,12 +517,12 @@ func skillsAgentForHarness(h string) (string, bool) {
 	}
 }
 
-func installGlobalHarness(adapter harness.Adapter, rt string, runtimeCfg harness.Config, constraints []harness.Constraint, skills []harness.Skill, identity *harness.Identity) error {
+func installGlobalHarness(adapter harness.Adapter, rt string, harnessCfg harness.Config, constraints []harness.Constraint, skills []harness.Skill, identity *harness.Identity) error {
 	global, ok := adapter.(harness.GlobalAdapter)
 	if !ok {
 		return fmt.Errorf("%s does not support global install", rt)
 	}
-	if err := global.GenerateGlobalContextFile(runtimeCfg, constraints, skills, identity); err != nil {
+	if err := global.GenerateGlobalContextFile(harnessCfg, constraints, skills, identity); err != nil {
 		return fmt.Errorf("generating context: %w", err)
 	}
 	if err := global.RegisterGlobalMCP(); err != nil {

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -429,6 +429,10 @@ func removeKnownGeneratedCentralDocs(momDir string, dryRun bool) ([]upgradeActio
 }
 
 func removeDeadHookCommands(projectRoot string, dryRun bool) ([]upgradeAction, error) {
+	// Windsurf paths remain here purely for legacy upgrade cleanup —
+	// users who installed MOM hooks before Windsurf retirement
+	// (#342/#343) still have stale hook entries that need pruning. The
+	// harness itself is no longer supported (see harness_retirement.go).
 	paths := []string{
 		filepath.Join(projectRoot, ".claude", "settings.json"),
 		filepath.Join(projectRoot, ".codex", "hooks.json"),

--- a/cli/internal/cmd/upgrade.go
+++ b/cli/internal/cmd/upgrade.go
@@ -846,17 +846,17 @@ func kebabOnly(s string) string {
 func regenerateHarnessFiles(projectRoot, momDir string, cfg *config.Config) error {
 	registry := harness.NewRegistry(projectRoot)
 
-	runtimeCfg := buildRuntimeConfig(cfg)
-	runtimeConstraints := buildRuntimeConstraints()
-	runtimeSkills := buildRuntimeSkills()
-	runtimeIdentity := buildRuntimeIdentity()
+	harnessCfg := buildHarnessConfig(cfg)
+	harnessConstraints := buildHarnessConstraints()
+	harnessSkills := buildHarnessSkills()
+	harnessIdentity := buildHarnessIdentity()
 
 	for _, rt := range cfg.EnabledHarnesses() {
 		adapter, ok := registry.Get(rt)
 		if !ok {
 			continue
 		}
-		if err := adapter.GenerateContextFile(runtimeCfg, runtimeConstraints, runtimeSkills, runtimeIdentity); err != nil {
+		if err := adapter.GenerateContextFile(harnessCfg, harnessConstraints, harnessSkills, harnessIdentity); err != nil {
 			return fmt.Errorf("generating %s context: %w", rt, err)
 		}
 

--- a/cli/internal/diagnose/diagnose.go
+++ b/cli/internal/diagnose/diagnose.go
@@ -61,10 +61,7 @@ func ComputeReport(sessions []SessionLog) *Report {
 			if recall, ok := mem.Detail["mom_recall"]; ok {
 				totalRecall += recall
 			}
-			if recall, ok := mem.Detail["search_memories"]; ok {
-				totalRecall += recall
-			}
-			if draft, ok := mem.Detail["create_memory_draft"]; ok {
+			if draft, ok := mem.Detail["mom_record"]; ok {
 				totalDraftCreated += draft
 			}
 		}
@@ -119,7 +116,7 @@ func ComputeReport(sessions []SessionLog) *Report {
 		r.ContextRediscovery = float64(totalGitGrep) / float64(totalToolCalls)
 	}
 
-	// Write-back rate: create_memory_draft / interactions.
+	// Write-back rate: mom_record / interactions.
 	if totalInteractions > 0 {
 		r.WriteBackRate = float64(totalDraftCreated) / float64(totalInteractions)
 	}

--- a/cli/internal/diagnose/diagnose_test.go
+++ b/cli/internal/diagnose/diagnose_test.go
@@ -40,8 +40,8 @@ func TestComputeReport_SingleSession(t *testing.T) {
 		"mom_memory": {
 			Total: 3,
 			Detail: map[string]int{
-				"mom_recall":          2,
-				"create_memory_draft": 1,
+				"mom_recall": 2,
+				"mom_record": 1,
 			},
 		},
 		"codebase_read": {
@@ -105,7 +105,7 @@ func TestComputeReport_MultipleSessions(t *testing.T) {
 	s2 := makeSession(6, map[string]diagnose.ToolGroup{
 		"mom_memory": {
 			Total:  6,
-			Detail: map[string]int{"search_memories": 6},
+			Detail: map[string]int{"mom_recall": 6},
 		},
 		"codebase_read": {
 			Total:  2,

--- a/cli/internal/explicitrecord/explicitrecord.go
+++ b/cli/internal/explicitrecord/explicitrecord.go
@@ -29,8 +29,9 @@ var sessionEnvKeys = []string{
 }
 
 // Request is the shared explicit-write contract for `mom record` and
-// `mom_record`. The caller may provide SessionID when it is a real runtime ID;
-// otherwise ResolveSessionID checks known harness environment variables.
+// `mom_record`. The caller may provide SessionID when it is a real harness
+// session id; otherwise ResolveSessionID checks known harness environment
+// variables.
 type Request struct {
 	SessionID string
 	Summary   string
@@ -91,7 +92,11 @@ func Publish(bus *herald.Bus, req Request) (Result, error) {
 	return Result{SessionID: sessionID, Summary: req.Summary, Tags: tags, Actor: actor}, nil
 }
 
-func LooksLikeRuntimeSessionID(sessionID string) bool {
+// LooksLikeHarnessSessionID reports whether the given string has the shape
+// of a real harness-issued session identifier (UUID, or a timestamped
+// UUID-suffixed cursor filename). Used to reject invented or human-friendly
+// strings before they reach the persistence layer.
+func LooksLikeHarnessSessionID(sessionID string) bool {
 	s := strings.TrimSpace(sessionID)
 	if s == "" {
 		return false
@@ -122,8 +127,8 @@ func LooksLikeRuntimeSessionID(sessionID string) bool {
 
 func ResolveSessionID(explicit string) (string, error) {
 	if s := strings.TrimSpace(explicit); s != "" {
-		if !LooksLikeRuntimeSessionID(s) {
-			return "", fmt.Errorf("session_id %q does not look like a runtime session ID; do not invent one", s)
+		if !LooksLikeHarnessSessionID(s) {
+			return "", fmt.Errorf("session_id %q does not look like a harness session ID; do not invent one", s)
 		}
 		return s, nil
 	}

--- a/cli/internal/explicitrecord/explicitrecord.go
+++ b/cli/internal/explicitrecord/explicitrecord.go
@@ -13,12 +13,19 @@ import (
 
 var ErrMissingSessionID = errors.New("session_id is required; do not invent one")
 
+// sessionEnvKeys is the ordered list of env vars consulted when no
+// explicit session id is supplied. MOM_SESSION_ID is the neutral name
+// every harness should export going forward; the harness-specific
+// names remain for backwards compatibility with harnesses that have
+// not yet adopted MOM_SESSION_ID. First non-empty value wins.
 var sessionEnvKeys = []string{
+	"MOM_SESSION_ID",
 	"CLAUDE_CODE_SESSION_ID",
 	"CLAUDE_SESSION_ID",
 	"CODEX_THREAD_ID",
 	"CODEX_SESSION_ID",
-	"WINDSURF_TRAJECTORY_ID",
+	// WINDSURF_TRAJECTORY_ID was retired alongside the Windsurf harness
+	// in #342/#343 and removed from this list in v0.40 cleanup.
 }
 
 // Request is the shared explicit-write contract for `mom record` and

--- a/cli/internal/explicitrecord/explicitrecord_test.go
+++ b/cli/internal/explicitrecord/explicitrecord_test.go
@@ -47,6 +47,51 @@ func TestResolveSessionIDUsesHarnessEnv(t *testing.T) {
 	}
 }
 
+// TestResolveSessionIDUsesMomSessionIDEnv asserts the neutral
+// MOM_SESSION_ID env var is recognised by the resolver. This lets any
+// harness (including Pi) satisfy the CLI by exporting a single
+// well-known name, without MOM needing a bespoke entry per harness.
+func TestResolveSessionIDUsesMomSessionIDEnv(t *testing.T) {
+	t.Setenv("MOM_SESSION_ID", "mom-neutral-session")
+	got, err := ResolveSessionID("")
+	if err != nil {
+		t.Fatalf("ResolveSessionID: %v", err)
+	}
+	if got != "mom-neutral-session" {
+		t.Fatalf("got %q, want mom-neutral-session", got)
+	}
+}
+
+// TestResolveSessionIDPrefersMomSessionIDOverHarnessEnv asserts the
+// neutral MOM_SESSION_ID takes precedence over harness-specific env
+// vars when both are set. The neutral name is the future contract;
+// harness-specific names are kept for backwards compatibility but lose
+// the race when explicitly overridden.
+func TestResolveSessionIDPrefersMomSessionIDOverHarnessEnv(t *testing.T) {
+	t.Setenv("MOM_SESSION_ID", "neutral")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "claude")
+	got, err := ResolveSessionID("")
+	if err != nil {
+		t.Fatalf("ResolveSessionID: %v", err)
+	}
+	if got != "neutral" {
+		t.Fatalf("got %q, want neutral (MOM_SESSION_ID should win)", got)
+	}
+}
+
+// TestResolveSessionIDIgnoresRetiredWindsurfEnv asserts that the
+// retired Windsurf harness env var is no longer consulted. Windsurf
+// support was retired in #342/#343; the env key was kept around as
+// dead code until v0.40 cleanup. Setting it must not resolve a
+// session.
+func TestResolveSessionIDIgnoresRetiredWindsurfEnv(t *testing.T) {
+	t.Setenv("WINDSURF_TRAJECTORY_ID", "windsurf-traj")
+	_, err := ResolveSessionID("")
+	if !errors.Is(err, ErrMissingSessionID) {
+		t.Fatalf("err = %v, want ErrMissingSessionID (Windsurf env must be ignored)", err)
+	}
+}
+
 func TestResolveSessionIDRejectsInventedExplicit(t *testing.T) {
 	_, err := ResolveSessionID("fresh-install-e2e")
 	if err == nil {

--- a/cli/internal/explicitrecord/explicitrecord_test.go
+++ b/cli/internal/explicitrecord/explicitrecord_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/momhq/mom/cli/internal/herald"
 )
 
-func TestLooksLikeRuntimeSessionID(t *testing.T) {
+func TestLooksLikeHarnessSessionID(t *testing.T) {
 	cases := []struct {
 		id   string
 		want bool
@@ -19,8 +19,8 @@ func TestLooksLikeRuntimeSessionID(t *testing.T) {
 		{"", false},
 	}
 	for _, tc := range cases {
-		if got := LooksLikeRuntimeSessionID(tc.id); got != tc.want {
-			t.Fatalf("LooksLikeRuntimeSessionID(%q) = %v, want %v", tc.id, got, tc.want)
+		if got := LooksLikeHarnessSessionID(tc.id); got != tc.want {
+			t.Fatalf("LooksLikeHarnessSessionID(%q) = %v, want %v", tc.id, got, tc.want)
 		}
 	}
 }
@@ -32,7 +32,7 @@ func TestResolveSessionIDPrefersExplicit(t *testing.T) {
 		t.Fatalf("ResolveSessionID: %v", err)
 	}
 	if got != "11111111-1111-4111-8111-111111111111" {
-		t.Fatalf("got %q, want explicit runtime session", got)
+		t.Fatalf("got %q, want explicit harness session", got)
 	}
 }
 

--- a/cli/internal/herald/emitter.go
+++ b/cli/internal/herald/emitter.go
@@ -97,10 +97,10 @@ func (e *Emitter) EmitConsumptionEvent(ev ConsumptionEvent) {
 	}
 }
 
-// EmitRuntimeHealth emits a RuntimeHealth event, stamping the Kind field.
-func (e *Emitter) EmitRuntimeHealth(ev RuntimeHealth) {
-	ev.Kind = "RuntimeHealth"
+// EmitHarnessHealth emits a HarnessHealth event, stamping the Kind field.
+func (e *Emitter) EmitHarnessHealth(ev HarnessHealth) {
+	ev.Kind = "HarnessHealth"
 	if err := e.Emit(ev); err != nil {
-		log.Printf("[herald] warn: EmitRuntimeHealth: %v", err)
+		log.Printf("[herald] warn: EmitHarnessHealth: %v", err)
 	}
 }

--- a/cli/internal/herald/emitter_test.go
+++ b/cli/internal/herald/emitter_test.go
@@ -57,7 +57,7 @@ func TestEmitSessionEvent(t *testing.T) {
 	e.EmitSessionEvent(SessionEvent{
 		SessionID:     "s-abc",
 		RepoID:        "mom",
-		Runtime:       "claude-code",
+		Harness:       "claude-code",
 		StartedAt:     "2026-04-18T12:00:00Z",
 		Trigger:       "normal",
 		TurnCount:     12,
@@ -152,13 +152,13 @@ func TestEmitConsumptionEvent(t *testing.T) {
 	assertEqual(t, "context", "prompt", got["context"])
 }
 
-func TestEmitRuntimeHealth(t *testing.T) {
+func TestEmitHarnessHealth(t *testing.T) {
 	e, telDir := newTmpEmitter(t)
 	day := time.Date(2026, 4, 18, 13, 0, 0, 0, time.UTC)
 	setNow(t, day)
 
-	e.EmitRuntimeHealth(RuntimeHealth{
-		Runtime:       "claude-code",
+	e.EmitHarnessHealth(HarnessHealth{
+		Harness:       "claude-code",
 		TS:            "2026-04-18T13:00:00Z",
 		WrapUpSuccess: true,
 		LatencyMS:     420,
@@ -169,7 +169,7 @@ func TestEmitRuntimeHealth(t *testing.T) {
 		t.Fatalf("expected 1 line, got %d", len(lines))
 	}
 	got := lines[0]
-	assertEqual(t, "kind", "RuntimeHealth", got["kind"])
+	assertEqual(t, "kind", "HarnessHealth", got["kind"])
 	assertEqual(t, "wrap_up_success", true, got["wrap_up_success"])
 	assertEqual(t, "latency_ms", float64(420), got["latency_ms"])
 }
@@ -181,11 +181,11 @@ func TestDayRotation(t *testing.T) {
 
 	day1 := time.Date(2026, 4, 18, 23, 59, 59, 0, time.UTC)
 	setNow(t, day1)
-	e.EmitRuntimeHealth(RuntimeHealth{Runtime: "claude-code", TS: "2026-04-18T23:59:59Z", WrapUpSuccess: true})
+	e.EmitHarnessHealth(HarnessHealth{Harness: "claude-code", TS: "2026-04-18T23:59:59Z", WrapUpSuccess: true})
 
 	day2 := time.Date(2026, 4, 19, 0, 0, 1, 0, time.UTC)
 	nowFn = func() time.Time { return day2 }
-	e.EmitRuntimeHealth(RuntimeHealth{Runtime: "claude-code", TS: "2026-04-19T00:00:01Z", WrapUpSuccess: true})
+	e.EmitHarnessHealth(HarnessHealth{Harness: "claude-code", TS: "2026-04-19T00:00:01Z", WrapUpSuccess: true})
 
 	file1 := filepath.Join(telDir, "2026-04-18.jsonl")
 	file2 := filepath.Join(telDir, "2026-04-19.jsonl")
@@ -215,7 +215,7 @@ func TestDisabledEmitter(t *testing.T) {
 	day := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 	setNow(t, day)
 
-	e.EmitRuntimeHealth(RuntimeHealth{Runtime: "claude-code", TS: "2026-04-18T12:00:00Z", WrapUpSuccess: true})
+	e.EmitHarnessHealth(HarnessHealth{Harness: "claude-code", TS: "2026-04-18T12:00:00Z", WrapUpSuccess: true})
 
 	telDir := filepath.Join(momDir, "logs")
 	entries, _ := os.ReadDir(telDir)
@@ -243,7 +243,7 @@ func TestReadOnlyDirNoPanic(t *testing.T) {
 	setNow(t, day)
 
 	// Must not panic.
-	e.EmitRuntimeHealth(RuntimeHealth{Runtime: "claude-code", TS: "2026-04-18T12:00:00Z", WrapUpSuccess: false})
+	e.EmitHarnessHealth(HarnessHealth{Harness: "claude-code", TS: "2026-04-18T12:00:00Z", WrapUpSuccess: false})
 }
 
 // ── Multiple events same day ─────────────────────────────────────────────────
@@ -253,9 +253,9 @@ func TestMultipleEventsAppend(t *testing.T) {
 	day := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 	setNow(t, day)
 
-	e.EmitRuntimeHealth(RuntimeHealth{Runtime: "r1", TS: "T", WrapUpSuccess: true})
-	e.EmitRuntimeHealth(RuntimeHealth{Runtime: "r2", TS: "T", WrapUpSuccess: false})
-	e.EmitSessionEvent(SessionEvent{SessionID: "s-1", Runtime: "claude-code", Trigger: "normal"})
+	e.EmitHarnessHealth(HarnessHealth{Harness: "r1", TS: "T", WrapUpSuccess: true})
+	e.EmitHarnessHealth(HarnessHealth{Harness: "r2", TS: "T", WrapUpSuccess: false})
+	e.EmitSessionEvent(SessionEvent{SessionID: "s-1", Harness: "claude-code", Trigger: "normal"})
 
 	lines := readLines(t, filepath.Join(telDir, "2026-04-18.jsonl"))
 	if len(lines) != 3 {

--- a/cli/internal/herald/events.go
+++ b/cli/internal/herald/events.go
@@ -6,7 +6,7 @@ type SessionEvent struct {
 	SessionID     string  `json:"session_id"`
 	OrgID         string  `json:"org_id,omitempty"`
 	RepoID        string  `json:"repo_id"`
-	Runtime       string  `json:"runtime"`
+	Harness       string  `json:"harness"`
 	StartedAt     string  `json:"started_at"`
 	EndedAt       *string `json:"ended_at"`
 	Trigger       string  `json:"trigger"`
@@ -50,10 +50,10 @@ type ConsumptionEvent struct {
 	Context   string  `json:"context"`
 }
 
-// RuntimeHealth records health metrics for a runtime at wrap-up time.
-type RuntimeHealth struct {
+// HarnessHealth records health metrics for a harness at wrap-up time.
+type HarnessHealth struct {
 	Kind          string  `json:"kind"`
-	Runtime       string  `json:"runtime"`
+	Harness       string  `json:"harness"`
 	TS            string  `json:"ts"`
 	WrapUpSuccess bool    `json:"wrap_up_success"`
 	ErrorType     *string `json:"error_type"`

--- a/cli/internal/herald/events_schema_test.go
+++ b/cli/internal/herald/events_schema_test.go
@@ -72,7 +72,7 @@ func TestMRPSessionStart_ValidMinimal(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "session.start",
 		SessionID:  "sess-001",
-		Runtime:    "claude-code",
+		Harness:    "claude-code",
 		Timestamp:  "2026-04-18T10:00:00Z",
 		StartedAt:  "2026-04-18T10:00:00Z",
 	})
@@ -83,7 +83,7 @@ func TestMRPSessionStart_ValidWithOptionals(t *testing.T) {
 		MRPVersion:  "v0",
 		Event:       "session.start",
 		SessionID:   "sess-002",
-		Runtime:     "codex",
+		Harness:     "codex",
 		Timestamp:   "2026-04-18T10:00:00Z",
 		StartedAt:   "2026-04-18T10:00:00Z",
 		ProjectRoot: "/home/user/project",
@@ -99,14 +99,14 @@ func TestMRPSessionStart_MissingRequired(t *testing.T) {
 		{
 			name: "missing mrp_version",
 			ev: MRPSessionStart{
-				Event: "session.start", SessionID: "s", Runtime: "r",
+				Event: "session.start", SessionID: "s", Harness: "r",
 				Timestamp: "2026-04-18T10:00:00Z", StartedAt: "2026-04-18T10:00:00Z",
 			},
 		},
 		{
 			name: "missing session_id",
 			ev: MRPSessionStart{
-				MRPVersion: "v0", Event: "session.start", Runtime: "r",
+				MRPVersion: "v0", Event: "session.start", Harness: "r",
 				Timestamp: "2026-04-18T10:00:00Z", StartedAt: "2026-04-18T10:00:00Z",
 			},
 		},
@@ -114,7 +114,7 @@ func TestMRPSessionStart_MissingRequired(t *testing.T) {
 			name: "missing started_at",
 			ev: MRPSessionStart{
 				MRPVersion: "v0", Event: "session.start", SessionID: "s",
-				Runtime: "r", Timestamp: "2026-04-18T10:00:00Z",
+				Harness: "r", Timestamp: "2026-04-18T10:00:00Z",
 			},
 		},
 	}
@@ -130,7 +130,7 @@ func TestMRPSessionStart_WrongEventConst(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "session.end", // wrong const
 		SessionID:  "s",
-		Runtime:    "r",
+		Harness:    "r",
 		Timestamp:  "2026-04-18T10:00:00Z",
 		StartedAt:  "2026-04-18T10:00:00Z",
 	})
@@ -143,7 +143,7 @@ func TestMRPSessionEnd_ValidMinimal(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "session.end",
 		SessionID:  "sess-001",
-		Runtime:    "claude-code",
+		Harness:    "claude-code",
 		Timestamp:  "2026-04-18T11:00:00Z",
 		StartedAt:  "2026-04-18T10:00:00Z",
 		EndedAt:    "2026-04-18T11:00:00Z",
@@ -157,7 +157,7 @@ func TestMRPSessionEnd_ValidWithOptionals(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "session.end",
 		SessionID:  "sess-002",
-		Runtime:    "claude-code",
+		Harness:    "claude-code",
 		Timestamp:  "2026-04-18T11:00:00Z",
 		StartedAt:  "2026-04-18T10:00:00Z",
 		EndedAt:    "2026-04-18T11:00:00Z",
@@ -171,7 +171,7 @@ func TestMRPSessionEnd_MissingEndedAt(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "session.end",
 		SessionID:  "s",
-		Runtime:    "r",
+		Harness:    "r",
 		Timestamp:  "2026-04-18T11:00:00Z",
 		StartedAt:  "2026-04-18T10:00:00Z",
 		// EndedAt missing
@@ -184,7 +184,7 @@ func TestMRPSessionEnd_InvalidExitReason(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "session.end",
 		SessionID:  "s",
-		Runtime:    "r",
+		Harness:    "r",
 		Timestamp:  "2026-04-18T11:00:00Z",
 		StartedAt:  "2026-04-18T10:00:00Z",
 		EndedAt:    "2026-04-18T11:00:00Z",
@@ -193,14 +193,14 @@ func TestMRPSessionEnd_InvalidExitReason(t *testing.T) {
 }
 
 func TestMRPSessionEnd_AllExitReasons(t *testing.T) {
-	for _, reason := range []string{"user_ended", "runtime_ended", "timeout", "error"} {
+	for _, reason := range []string{"user_ended", "harness_ended", "timeout", "error"} {
 		r := reason
 		t.Run(reason, func(t *testing.T) {
 			mustPass(t, "session-end.schema.json", MRPSessionEnd{
 				MRPVersion: "v0",
 				Event:      "session.end",
 				SessionID:  "s",
-				Runtime:    "r",
+				Harness:    "r",
 				Timestamp:  "2026-04-18T11:00:00Z",
 				StartedAt:  "2026-04-18T10:00:00Z",
 				EndedAt:    "2026-04-18T11:00:00Z",
@@ -217,7 +217,7 @@ func TestMRPTurnComplete_ValidMinimal(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "turn.complete",
 		SessionID:  "sess-001",
-		Runtime:    "claude-code",
+		Harness:    "claude-code",
 		Timestamp:  "2026-04-18T10:05:00Z",
 		TurnIndex:  0,
 	})
@@ -230,7 +230,7 @@ func TestMRPTurnComplete_ValidWithTokens(t *testing.T) {
 		MRPVersion:       "v0",
 		Event:            "turn.complete",
 		SessionID:        "sess-001",
-		Runtime:          "claude-code",
+		Harness:          "claude-code",
 		Timestamp:        "2026-04-18T10:05:00Z",
 		TurnIndex:        1,
 		PromptTokens:     &prompt,
@@ -244,7 +244,7 @@ func TestMRPTurnComplete_MissingTurnIndex(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "turn.complete",
 		// SessionID missing — required field
-		Runtime:   "claude-code",
+		Harness:   "claude-code",
 		Timestamp: "2026-04-18T10:05:00Z",
 		TurnIndex: 1,
 	})
@@ -257,20 +257,20 @@ func TestMRPCompactTriggered_ValidMinimal(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "compact.triggered",
 		SessionID:  "sess-001",
-		Runtime:    "claude-code",
+		Harness:    "claude-code",
 		Timestamp:  "2026-04-18T10:30:00Z",
 	})
 }
 
 func TestMRPCompactTriggered_ValidTriggerSources(t *testing.T) {
-	for _, src := range []string{"user", "runtime"} {
+	for _, src := range []string{"user", "harness"} {
 		s := src
 		t.Run(src, func(t *testing.T) {
 			mustPass(t, "compact-triggered.schema.json", MRPCompactTriggered{
 				MRPVersion:    "v0",
 				Event:         "compact.triggered",
 				SessionID:     "s",
-				Runtime:       "r",
+				Harness:       "r",
 				Timestamp:     "2026-04-18T10:30:00Z",
 				TriggerSource: &s,
 			})
@@ -284,7 +284,7 @@ func TestMRPCompactTriggered_InvalidTriggerSource(t *testing.T) {
 		MRPVersion:    "v0",
 		Event:         "compact.triggered",
 		SessionID:     "s",
-		Runtime:       "r",
+		Harness:       "r",
 		Timestamp:     "2026-04-18T10:30:00Z",
 		TriggerSource: &src,
 	})
@@ -297,20 +297,20 @@ func TestMRPClearTriggered_ValidMinimal(t *testing.T) {
 		MRPVersion: "v0",
 		Event:      "clear.triggered",
 		SessionID:  "sess-001",
-		Runtime:    "claude-code",
+		Harness:    "claude-code",
 		Timestamp:  "2026-04-18T10:45:00Z",
 	})
 }
 
 func TestMRPClearTriggered_ValidTriggerSources(t *testing.T) {
-	for _, src := range []string{"user", "runtime"} {
+	for _, src := range []string{"user", "harness"} {
 		s := src
 		t.Run(src, func(t *testing.T) {
 			mustPass(t, "clear-triggered.schema.json", MRPClearTriggered{
 				MRPVersion:    "v0",
 				Event:         "clear.triggered",
 				SessionID:     "s",
-				Runtime:       "r",
+				Harness:       "r",
 				Timestamp:     "2026-04-18T10:45:00Z",
 				TriggerSource: &s,
 			})
@@ -324,7 +324,7 @@ func TestMRPClearTriggered_InvalidTriggerSource(t *testing.T) {
 		MRPVersion:    "v0",
 		Event:         "clear.triggered",
 		SessionID:     "s",
-		Runtime:       "r",
+		Harness:       "r",
 		Timestamp:     "2026-04-18T10:45:00Z",
 		TriggerSource: &src,
 	})

--- a/cli/internal/herald/mrp_events.go
+++ b/cli/internal/herald/mrp_events.go
@@ -1,6 +1,6 @@
 package herald
 
-// MRP v0 event structs — wire protocol between a runtime adapter and MOM.
+// MRP v0 event structs — wire protocol between a harness adapter and MOM.
 // Field names match JSON schema definitions in .github/mrp/schemas/.
 
 // MRPSessionStart is the session.start MRP event.
@@ -8,7 +8,7 @@ type MRPSessionStart struct {
 	MRPVersion  string `json:"mrp_version"`
 	Event       string `json:"event"`
 	SessionID   string `json:"session_id"`
-	Runtime     string `json:"runtime"`
+	Harness     string `json:"harness"`
 	Timestamp   string `json:"timestamp"`
 	StartedAt   string `json:"started_at"`
 	ProjectRoot string `json:"project_root,omitempty"`
@@ -20,7 +20,7 @@ type MRPSessionEnd struct {
 	MRPVersion string  `json:"mrp_version"`
 	Event      string  `json:"event"`
 	SessionID  string  `json:"session_id"`
-	Runtime    string  `json:"runtime"`
+	Harness    string  `json:"harness"`
 	Timestamp  string  `json:"timestamp"`
 	StartedAt  string  `json:"started_at"`
 	EndedAt    string  `json:"ended_at"`
@@ -33,7 +33,7 @@ type MRPTurnComplete struct {
 	MRPVersion       string `json:"mrp_version"`
 	Event            string `json:"event"`
 	SessionID        string `json:"session_id"`
-	Runtime          string `json:"runtime"`
+	Harness          string `json:"harness"`
 	Timestamp        string `json:"timestamp"`
 	TurnIndex        int    `json:"turn_index"`
 	PromptTokens     *int   `json:"prompt_tokens,omitempty"`
@@ -45,7 +45,7 @@ type MRPCompactTriggered struct {
 	MRPVersion    string  `json:"mrp_version"`
 	Event         string  `json:"event"`
 	SessionID     string  `json:"session_id"`
-	Runtime       string  `json:"runtime"`
+	Harness       string  `json:"harness"`
 	Timestamp     string  `json:"timestamp"`
 	TriggerSource *string `json:"trigger_source,omitempty"`
 }
@@ -55,7 +55,7 @@ type MRPClearTriggered struct {
 	MRPVersion    string  `json:"mrp_version"`
 	Event         string  `json:"event"`
 	SessionID     string  `json:"session_id"`
-	Runtime       string  `json:"runtime"`
+	Harness       string  `json:"harness"`
 	Timestamp     string  `json:"timestamp"`
 	TriggerSource *string `json:"trigger_source,omitempty"`
 }

--- a/cli/internal/mcp/mom_record.go
+++ b/cli/internal/mcp/mom_record.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/momhq/mom/cli/internal/explicitrecord"
@@ -62,10 +63,29 @@ func (s *Server) toolMomRecord(args map[string]any) (toolCallResult, error) {
 // failure mode gets its own message so callers can tell "I forgot to
 // pass it" from "I passed something but the wrong shape" from "I
 // passed an object but it had no fields."
+//
+// Transport tolerance (#351): some harness tool gateways serialise
+// object-typed MCP parameters to JSON strings before forwarding. When
+// the value arrives as a string, it is parsed and accepted only if it
+// decodes to a non-empty JSON object. Strings that decode to anything
+// else (primitive, array, null) or are not valid JSON are rejected
+// with a clear error — the empty-object and shape invariants below
+// still apply post-decode.
 func requireMapArg(args map[string]any, key string) (map[string]any, error) {
 	v, ok := args[key]
 	if !ok || v == nil {
 		return nil, fmt.Errorf("%s is required", key)
+	}
+	if s, isString := v.(string); isString {
+		var parsed any
+		if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+			return nil, fmt.Errorf("%s must be an object (got string that is not valid JSON: %v)", key, err)
+		}
+		m, isMap := parsed.(map[string]any)
+		if !isMap {
+			return nil, fmt.Errorf("%s must be an object (got JSON %T)", key, parsed)
+		}
+		v = m
 	}
 	m, ok := v.(map[string]any)
 	if !ok {

--- a/cli/internal/mcp/mom_record_test.go
+++ b/cli/internal/mcp/mom_record_test.go
@@ -218,6 +218,81 @@ func TestMomRecord_RejectsNonObjectContent(t *testing.T) {
 	}
 }
 
+// TestMomRecord_AcceptsContentAsStringifiedJSON locks the v0.40
+// harness-transport tolerance behaviour (#351). Some harness tool
+// gateways (notably Pi) serialise object-typed MCP parameters to
+// JSON strings before forwarding. The handler must accept either a
+// native map or a JSON string that parses into one, so well-formed
+// records from those harnesses are not silently dropped.
+func TestMomRecord_AcceptsContentAsStringifiedJSON(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	res, err := srv.toolMomRecord(map[string]any{
+		"session_id": "33333333-3333-4333-8333-333333333333",
+		"summary":    "stringified payload",
+		"content":    `{"text":"deploy notes from pi"}`,
+	})
+	if err != nil {
+		t.Fatalf("toolMomRecord: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("got IsError=true: %+v", res)
+	}
+	got, ok := rs.get()
+	if !ok {
+		t.Fatal("no event published")
+	}
+	payloadContent, ok := got.Payload["content"].(map[string]any)
+	if !ok {
+		t.Fatalf("event content not parsed to map: %T %+v", got.Payload["content"], got.Payload["content"])
+	}
+	if payloadContent["text"] != "deploy notes from pi" {
+		t.Errorf("content.text = %v, want \"deploy notes from pi\"", payloadContent["text"])
+	}
+}
+
+// TestMomRecord_RejectsStringifiedJSONWithEmptyObject keeps the
+// empty-content invariant after we permit string coercion: a string
+// that parses to an empty object must still be rejected and must not
+// publish an event.
+func TestMomRecord_RejectsStringifiedJSONWithEmptyObject(t *testing.T) {
+	srv, rs := newSrvWithSubscriber(t)
+	_, err := srv.toolMomRecord(map[string]any{
+		"session_id": "44444444-4444-4444-8444-444444444444",
+		"content":    `{}`,
+	})
+	if err == nil {
+		t.Fatal("expected error for stringified empty object")
+	}
+	if rs.count.Load() != 0 {
+		t.Errorf("event count = %d, want 0", rs.count.Load())
+	}
+}
+
+// TestMomRecord_RejectsStringifiedNonObject locks the rule that
+// stringified primitives or arrays do NOT coerce into the object
+// shape mom_record requires. Only JSON objects pass.
+func TestMomRecord_RejectsStringifiedNonObject(t *testing.T) {
+	cases := []string{
+		`"just a string"`, // valid JSON, not an object
+		`123`,             // number
+		`["text"]`,        // array
+		`null`,            // null
+	}
+	for _, raw := range cases {
+		srv, rs := newSrvWithSubscriber(t)
+		_, err := srv.toolMomRecord(map[string]any{
+			"session_id": "55555555-5555-4555-8555-555555555555",
+			"content":    raw,
+		})
+		if err == nil {
+			t.Fatalf("raw=%q: expected error", raw)
+		}
+		if rs.count.Load() != 0 {
+			t.Fatalf("raw=%q: event count = %d, want 0", raw, rs.count.Load())
+		}
+	}
+}
+
 // TestMomRecord_RejectsTagsThatNormaliseToEmpty locks the lesson from
 // the previous attempt: a memory + entity edge was persisted and THEN
 // UpsertTag("") failed downstream, leaving an orphan memory. The fix

--- a/cli/internal/memory/memory_schema_test.go
+++ b/cli/internal/memory/memory_schema_test.go
@@ -31,7 +31,7 @@ const fullDocJSON = `{
 	"classification": "INTERNAL",
 	"compartments": {"project": ["alpha", "beta"], "department": ["engineering"]},
 	"provenance": {
-		"runtime": "claude-code",
+		"harness": "claude-code",
 		"trigger_event": "session.end",
 		"commit_sha": "deadbeef",
 		"raw_exhaust_ref": ".mom/raw/2026-04-13.jsonl"
@@ -135,7 +135,7 @@ func TestFullDoc_RoundTrip(t *testing.T) {
 	if len(doc2.Compartments["project"]) != 2 {
 		t.Errorf("compartments[project] mismatch: got %v", doc2.Compartments["project"])
 	}
-	if doc2.Provenance == nil || doc2.Provenance.Runtime != "claude-code" {
+	if doc2.Provenance == nil || doc2.Provenance.Harness != "claude-code" {
 		t.Errorf("provenance.runtime mismatch: got %v", doc2.Provenance)
 	}
 	if doc2.Provenance.RawExhaustRef != ".mom/raw/2026-04-13.jsonl" {
@@ -291,7 +291,7 @@ func TestNewDoc_WriteEmitsFields(t *testing.T) {
 		Classification: "INTERNAL",
 		Compartments:   map[string][]string{},
 		Provenance: &Provenance{
-			Runtime:      "claude-code",
+			Harness:      "claude-code",
 			TriggerEvent: "session.end",
 		},
 		Landmark:        false,
@@ -323,8 +323,8 @@ func TestNewDoc_WriteEmitsFields(t *testing.T) {
 	if !ok {
 		t.Fatal("provenance is not an object")
 	}
-	if prov["runtime"] != "claude-code" {
-		t.Errorf("provenance.runtime mismatch: got %v", prov["runtime"])
+	if prov["harness"] != "claude-code" {
+		t.Errorf("provenance.harness mismatch: got %v", prov["harness"])
 	}
 }
 

--- a/cli/internal/memory/schema.go
+++ b/cli/internal/memory/schema.go
@@ -38,7 +38,7 @@ var validClassification = map[string]bool{
 
 // Provenance captures the origin of a memory document.
 type Provenance struct {
-	Runtime       string `json:"runtime,omitempty"`
+	Harness       string `json:"harness,omitempty"`
 	TriggerEvent  string `json:"trigger_event,omitempty"`
 	CommitSHA     string `json:"commit_sha,omitempty"`
 	RawExhaustRef string `json:"raw_exhaust_ref,omitempty"`

--- a/cli/internal/watcher/categorize.go
+++ b/cli/internal/watcher/categorize.go
@@ -35,7 +35,7 @@ func CategorizeToolCall(toolName string) string {
 	}
 }
 
-// NormalizeToolName strips runtime-specific prefixes from tool names.
+// NormalizeToolName strips harness-specific prefixes from tool names.
 // Claude Code namespaces MCP tools as "mcp__<server>__<tool>"; this
 // returns the bare tool name so categorisation is harness-agnostic.
 func NormalizeToolName(toolName string) string {

--- a/cli/internal/watcher/categorize.go
+++ b/cli/internal/watcher/categorize.go
@@ -47,11 +47,17 @@ func NormalizeToolName(toolName string) string {
 	return toolName
 }
 
+// isMemoryTool recognises the v0.30 live MCP memory tool surface.
+// Retired names (create_memory_draft, mom_record_turn, list_landmarks,
+// get_memory, search_memories) are intentionally absent — they no
+// longer ship and are dropped from categorisation in v0.40 cleanup
+// (#349). The canonical live set lives in mcp/tools.go.
 func isMemoryTool(name string) bool {
-	return name == "mom_recall" || name == "search_memories" || name == "get_memory" ||
-		name == "create_memory_draft" || name == "list_landmarks" ||
-		name == "mom_record_turn" || name == "mom_record" ||
-		name == "mom_get" || name == "mom_landmarks" || name == "mom_status"
+	return name == "mom_recall" ||
+		name == "mom_record" ||
+		name == "mom_get" ||
+		name == "mom_landmarks" ||
+		name == "mom_status"
 }
 
 // CategorizeObservedToolCall returns the Lens category and privacy-safe name

--- a/cli/internal/watcher/categorize_test.go
+++ b/cli/internal/watcher/categorize_test.go
@@ -15,6 +15,13 @@ func TestCategorizeToolCall(t *testing.T) {
 		{"mom_status", "mom_memory"},
 		{"mcp__mom__mom_recall", "mom_memory"},
 		{"mcp__mom__mom_record", "mom_memory"},
+		// Retired MCP tool names (#349) — no longer recognised as memory
+		// tools; they fall through to the system catch-all.
+		{"create_memory_draft", "system"}, // renamed to mom_record
+		{"mom_record_turn", "system"},     // folded into mom_record
+		{"list_landmarks", "system"},      // renamed to mom_landmarks
+		{"get_memory", "system"},          // renamed to mom_get
+		{"search_memories", "system"},     // pre-v0.30 name; replaced by mom_recall
 		// Codebase reads.
 		{"Read", "codebase_read"},
 		{"Grep", "codebase_read"},

--- a/cli/internal/watcher/watcher.go
+++ b/cli/internal/watcher/watcher.go
@@ -261,7 +261,7 @@ func (w *Watcher) TranscriptDir() string {
 	return w.cfg.TranscriptDir
 }
 
-// TranscriptDirs returns all resolved transcript directories with their runtime names.
+// TranscriptDirs returns all resolved transcript directories with their harness names.
 func (w *Watcher) TranscriptDirs() map[string]string {
 	dirs := make(map[string]string, len(w.sources))
 	for _, src := range w.sources {


### PR DESCRIPTION
## Summary

v0.40 cleanup parity pass — closes five issues uncovered during the post-architecture-review scan. All small, all bundled here because the changes touch overlapping files and share intent (close the harness-terminology rename + drop legacy debris).

## What ships

| Commit | Closes | What |
|---|---|---|
| `eab0402` | #347, #348 | Add `MOM_SESSION_ID` neutral env, drop retired `WINDSURF_TRAJECTORY_ID` |
| `8f80cba` | #351 | `mom_record` MCP accepts `content` as stringified JSON (Pi transport tolerance) |
| `a180325` | #349 | Drop retired MCP tool names (`create_memory_draft`, `mom_record_turn`, `list_landmarks`, `get_memory`, `search_memories`) from watcher / diagnose |
| `7601418` | #350 | Rename `Runtime → Harness` across MRP, herald events, memory schema, wire schemas, and the MRP v0 spec doc |
| `84f0f19` | (follow-up review) | Trailing harness rename in `explicitrecord`, `watcher` doc comments, and the global agent content template |
| `3d46461` | (follow-up review) | Rename `runtime*` locals + private builders in `cmd` to `harness*` (values were already typed `harness.X`) |

## Highlights

### #347 — `MOM_SESSION_ID`
- Prepended to `sessionEnvKeys` so every harness can satisfy the CLI by exporting one neutral name.
- Backwards-compatible — existing harness-specific names still work.
- Pi extension needs a companion change to actually export it (filed separately on the Pi repo; not blocking this release).

### #348 — Windsurf cleanup
- `WINDSURF_TRAJECTORY_ID` removed from `sessionEnvKeys`.
- `upgrade.go` Windsurf hook-cleanup paths kept (legacy migration concern) with a clarifying comment.

### #349 — Retired MCP tool names
- `isMemoryTool` in `watcher/categorize.go` now lists only the live v0.30 surface: `mom_recall`, `mom_record`, `mom_get`, `mom_landmarks`, `mom_status`.
- `diagnose` write-back-rate metric switches from `create_memory_draft` to `mom_record` (the renamed live name).
- Tests assert retired names categorise as `system`, not `mom_memory`.

### #350 — Runtime → Harness rename
- Total rename across live wire structs, JSON tags, internal helpers, and the MRP v0 spec doc.
- Preserved by design: legacy YAML / JSON readers in `config.go` and `daemon/registry.go` (they exist to migrate old user state files).
- Wire schemas under `.github/mrp/schemas/*.json` updated end-to-end (property names, required arrays, enum values).
- Spec doc replaces residual `L.E.O.` references with `MOM` (closes spec-side cleanup of #311).

### #351 — `mom_record` content tolerance
- Pi's tool gateway forwards object-typed MCP params as JSON strings. The handler now coerces well-formed JSON-object strings back to objects.
- Existing invariants preserved post-decode (`required`, non-empty, object-shaped).
- Strings that aren't valid JSON objects (primitives, arrays, null, malformed) still rejected with clear errors.

## Checks

- `go vet ./...` clean.
- `go test ./...` green (full suite).
- Architecture guardrails (`TestGuardrail_*`) green.
- No live `runtime` references remain in `cli/internal/` outside Go stdlib usage and explicit legacy migration readers.

## Out of scope

- Pi extension side of #347 and #351 — separate repo, separate ticket, non-blocking for v0.40.
- `CONTRIBUTING.md` stale references to `adapters/runtime/` and `transponder/` — doc drift, not touched here.
- Deprecated `config.EnabledRuntimes()` / `PrimaryRuntime()` shims — kept; removal is a separate breaking-change decision.
