### PR TITLE
docs(v0.50.0): Phase 0 — ADRs 0017-0023 + PRD 0004

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ mom-export/
 # Autoresearch artifacts
 autoresearch.jsonl
 mom-autoresearch/
+
+# Working directories — local-only, not shipped
+/goals/
+/scripts/

--- a/adr/0017-role-based-repo-layout.md
+++ b/adr/0017-role-based-repo-layout.md
@@ -1,0 +1,68 @@
+# 0017 — Role-based repo layout
+
+MOM's `cli/internal/` directory has grown organically since v0.13: 32 sibling packages with no visible architecture. `watcher/`, `herald/`, `drafter/`, `librarian/`, `vault/`, `mcp/`, `daemon/` and twenty-five others sit side by side at the same depth. Readers cannot tell at a glance which packages are ingress, which are storage, which are workers, and which are shared infrastructure. New contributors discover the architecture only by reading code paths end-to-end. Architectural rules (e.g. "the read path must not depend on the Ledger", "Vault writes must route through Librarian") have no structural representation — they live in archtests and reviewer memory.
+
+This ADR adopts a role-based top-level layout that names the architecture in the filesystem. The eight buckets correspond 1:1 to the roles a package plays in the MOM dataflow, not to whether it reads or writes:
+
+```
+mom/
+├── cmd/mom/                              entrypoint
+├── ingress/
+│   ├── cli/                              CLI subcommands (user-driven ingress)
+│   ├── mcp/                              MCP server (harness ingress, deprecated)
+│   └── watcher/adapters/{claude,codex,pi}/   harness transcript ingress
+├── events/
+│   ├── editor/                           canonicalization gateway (post-Ingress, pre-bus)
+│   ├── registry/schemas/                 schema registry — source of truth
+│   └── crier/                            projector/replayer (Ledger → Vault)
+├── bus/herald/                           in-process event bus
+├── workers/
+│   ├── drafter/                          memory drafting from events
+│   ├── logbook/                          operational telemetry
+│   └── cartographer/                     bootstrap seeding (parked)
+├── services/
+│   ├── finder/                           recall query plan
+│   └── lens/                             session dashboard
+├── storage/
+│   ├── librarian/                        sole gate to Vault writes/reads
+│   ├── vault/                            SQLite-backed memory store
+│   └── ledger/                           append-only canonical event log
+├── ops/
+│   ├── daemon/                           background process lifecycle
+│   └── diagnose/                         doctor + introspection commands
+├── shared/
+│   ├── config/                           configuration loading
+│   ├── pathutil/                         path canonicalization
+│   ├── scope/                            project resolution
+│   ├── ux/                               TUI/output helpers
+│   └── archtest/                         architectural invariants
+└── docs/
+```
+
+Role beats read/write axis. Splitting `readers/` from `writers/` would put Finder (read) and Crier (write) in different buckets even though both project events into the Vault contract — and would put Librarian (both) somewhere awkward. Role naming keeps each package next to its dataflow neighbours: events live with events, storage lives with storage, and reviewers know where a new package belongs without litigating its read/write profile.
+
+`ingress/` includes both user-driven surfaces (CLI subcommands, MCP server) and machine-driven surfaces (watcher adapters). They share a role — translating external input into in-process events — and benefit from sitting together. `services/` covers the read-side application code (Finder, Lens) that composes storage primitives into user-facing answers. `workers/` covers consumers that subscribe to the bus and produce side effects other than Vault projection (Drafter, Logbook, Cartographer). `events/` is the new bucket created by this milestone: Editor canonicalizes raw input, the registry stores schemas, and Crier replays canonical events into the Vault. The `bus/` bucket holds the existing `herald` event bus and any future transports.
+
+`shared/` is reserved for genuinely cross-cutting utilities (path handling, configuration, scope resolution, UX helpers, archtest). It is not a dumping ground; anything that names a role belongs in that role's bucket.
+
+The Go module path remains `github.com/momhq/mom`. Internal import paths change from `github.com/momhq/mom/cli/internal/<pkg>` to `github.com/momhq/mom/<bucket>/<pkg>`. The reorganization is mechanical: ~94 Go files import ~32 distinct `cli/internal/*` packages, and a single PR rewrites every import in lockstep with the directory moves. `cli/internal/` ceases to exist; an archtest enforces that no future package re-introduces it.
+
+The decision is made now, in v0.50.0, because Items 1 (canonical events) and 2 (Ledger + Crier) introduce three new packages (`events/editor`, `events/crier`, `storage/ledger`). Landing the layout first means those packages drop into their final homes from day one and no second migration is required.
+
+## Consequences
+
+- Every architectural invariant in the roadmap maps to a concrete import-path rule: `archtest` rules (e.g. "`services/*` must not import `storage/ledger`", "`bus/herald` must not import raw adapter types") become readable in a glance because both sides of the rule are named by their role.
+- The reorganization is a single big-bang PR. Long-lived rename branches generate constant conflicts; one merge window with an empty queue is cheaper than a multi-week migration.
+- New contributors orient by reading the top-level directory listing. Onboarding documentation can point at the layout and stop.
+- The MCP server moves under `ingress/mcp` rather than disappearing immediately — ADR 0023 retires the transport in v0.60+, not in v0.50.
+- `mom-engineer/` and other internal-only documentation directories stay outside this repository. The layout describes what ships, not what supports the team.
+
+## Considered alternatives
+
+- **Keep `cli/internal/*` as a flat directory.** Rejected: the architecture exists; refusing to name it in the filesystem just makes every new contributor rediscover it. The layout is the cheapest possible documentation of the system.
+- **Split readers and writers (`readers/` vs `writers/`).** Rejected: collapses meaningfully different roles. Finder (reads Vault to answer queries) and Crier (writes Vault from Ledger events) play very different parts in the system; lumping both into `writers/` because Crier writes, or both into `readers/` because Finder reads, hides the distinction the architecture is built on.
+- **Layered architecture (`presentation/`, `application/`, `domain/`, `infrastructure/`).** Rejected: classical layering implies a strict dependency direction that MOM's pipeline doesn't follow. The bus is not above or below storage; it's adjacent. Forcing a layer name on each bucket would invite incorrect dependency assumptions.
+- **Feature folders (`recall/`, `record/`, `lifecycle/`).** Rejected: a single feature (recall) touches CLI, services, storage, and shared utilities. Co-locating by feature scatters the same role across many buckets and defeats the architectural-invariant story.
+- **Module split (multiple Go modules).** Rejected for v1: the codebase is small enough that a single module keeps tooling simple and refactors cheap. A future split (e.g. `cli/`, `events/`, `storage/` as separate modules) remains open if the team grows or external consumers want to depend on subsets.
+- **Keep `mcp/` at the top level rather than under `ingress/`.** Rejected: MCP is one of several ingress surfaces; it is not architecturally distinct from CLI ingress or watcher ingress. Promoting it to a top-level bucket would imply special status it doesn't have, especially given the v0.60+ retirement plan in ADR 0023.
+- **Defer the reorganization to v0.60.** Rejected: Items 1 and 2 add three new packages this milestone. Adding them under `cli/internal/` and moving them in v0.60 means doing the import rewrite twice. Cheaper to land the layout once, now.

--- a/adr/0018-canonical-event-schema.md
+++ b/adr/0018-canonical-event-schema.md
@@ -1,0 +1,44 @@
+# 0018 — Canonical event schema
+
+MOM ingests events from heterogeneous sources: Claude Code, Codex, and Pi watchers emit per-harness turn structures; the CLI emits explicit-record and lifecycle events; the daemon emits operational events. Today, every producer hand-rolls its payload shape and publishes directly onto Herald (`bus/herald`). `Turn.ToPayload()` (the current canonicalization-by-method) maps adapter-specific fields into a `map[string]any` that consumers parse defensively. Adding a producer means inventing keys; adding a consumer means guessing which keys are present. The `EventType` constants in Herald are strings with no naming discipline — `TurnObserved`, `MemoryRecord`, `OpMemoryCreated` — and no schema is attached to any of them.
+
+This ADR establishes a canonical event schema: every event published past the Ingress boundary conforms to a registered schema, identified by a name that follows the convention `family.subject.verb`.
+
+**Families v1.** Four families are introduced; a fifth is parked.
+
+- `capture` — the data MOM exists to remember. Turns observed from harnesses, memories recorded explicitly, drafts created by the Drafter.
+- `lifecycle` — state transitions on memories MOM already holds. Drafts promoted, drafts expired, memories curated, landmarks set.
+- `interaction` — agent ↔ tool exchanges that may carry meaningful context. Tool calls and tool returns, distinct from the turn that envelopes them.
+- `operational` — events about MOM itself. Daemon started/stopped, project bound, vault upgraded, filter audit incremented.
+- `bootstrap` — parked. Cartographer-driven seeding is on hold (see #240); when it returns the family is reserved.
+
+Family choice is a domain decision: "what kind of thing is this event about?" Reviewers can answer that for any new event without consulting a flowchart. The hybrid families + nested naming gives us coarse grouping for routing and fine grouping for evolution.
+
+**Subject + verb.** Inside a family, an event names its subject and the action that happened to it. `capture.turn.observed`, `capture.memory.recorded`, `lifecycle.draft.promoted`, `interaction.tool.called`, `operational.daemon.started`. The full name is `^(capture|lifecycle|interaction|operational)\.[a-z0-9_]+\.[a-z0-9_]+$` — a regex small enough to live in CI and in the registry loader.
+
+**Self-sufficient events.** A canonical event row in the Ledger must contain every field needed to project it. The Crier (ADR 0022) must be able to take any single event in isolation and produce the corresponding Vault state without consulting other events, the harness, or external context. This forecloses the "look up the turn this tool call belonged to" pattern that would couple events into chains and make replay order-dependent. If two events need to share data, both carry it; the registry validates the duplication.
+
+**The `herald.Event` envelope is reused.** Today's `herald.Event` (`bus/herald/herald.go`) already carries `Type EventType`, `SessionID string`, `Timestamp time.Time`, and `Payload map[string]any`. This ADR formalizes what `Type` is (a registered schema name) and what `Payload` contains (fields the schema declares). The envelope shape does not change; this ADR is a contract layered on top of an existing primitive, not a new type system.
+
+**Where canonicalization happens.** The Editor (ADR 0020) is the single gate between Ingress and the bus. Watcher adapters, CLI subcommands, and the MCP server hand raw input to the Editor; the Editor produces a canonical `herald.Event` and the Editor alone calls `bus.Publish`. No raw adapter type crosses the bus boundary.
+
+**Migration from `herald.EventType` constants.** Each existing constant in `herald.go` (`TurnObserved`, `MemoryRecord`, `OpMemoryCreated`, etc.) maps to exactly one `family.subject.verb` name. The Item 1 implementation introduces the new names, registers their schemas, and keeps the old constants as deprecated aliases for one release so external consumers (e.g. third-party bus subscribers, if any) have a window to migrate.
+
+## Consequences
+
+- Every event that crosses the bus is now a known shape. Consumers stop parsing defensively; they parse against a schema.
+- Adding a producer is a registry change plus an Editor mapping. The schema is reviewable on its own; the producer change is the implementation of an already-agreed contract.
+- Replay is well-defined. Crier loads events from the Ledger and projects them in isolation; no event depends on another event's existence in the projection step.
+- Family routing becomes cheap. Subscribers can filter by family prefix (e.g. "all `capture.*` events") without enumerating every event type.
+- The `bootstrap` family is reserved but unused; documenting it now prevents the cartographer revival from inventing a parallel taxonomy.
+
+## Considered alternatives
+
+- **Flat event-name vocabulary (no families).** Rejected: works for ten events, fails at fifty. The `family.subject.verb` convention costs nothing today and prevents reviewers from arguing over whether `tool_called` is closer to `turn_observed` or to `daemon_started`.
+- **Hierarchical event types as Go types (one struct per event).** Rejected for v1: would either fragment the bus into N typed channels or push consumers into type-switches. Keeping `herald.Event` with a `Payload map[string]any` plus schema validation lets the bus stay generic while still being safe at the validation boundary.
+- **Strict-runtime validation (reject unknown fields).** Rejected. This ADR formalises the schema; ADR 0019 chooses governance level B (CI-reviewed, permissive runtime). The permissiveness is intentional and discussed there.
+- **Producer-side event versioning (`capture.turn.observed.v2`).** Rejected for v1: version-as-suffix is one option among several (registry-internal schema versions, additive evolution, etc.). The registry (ADR 0019) is the right place to choose; this ADR leaves the name space clean.
+- **Chained events (`tool.called` carries a reference back to the parent `turn.observed`).** Rejected: violates self-sufficiency. If the projector needs to combine information from two events, both events carry it; the registry catches the duplication at review time. Replay must work on a single event in isolation.
+- **Reuse adapter-specific types as canonical (e.g. promote `watcher.Turn` to be the canonical capture event).** Rejected: locks the canonical schema to whichever harness drove its evolution. Editor canonicalization (ADR 0020) is the explicit decoupling step.
+- **Open string vocabularies modelled on provenance (ADR 0014).** Rejected here: provenance is a tagging axis where new values appear over time and are intentionally not enforced. Event types are protocol shapes; consumers need them stable enough to parse. The two are different concerns and the registry treats them differently.
+- **Skip the `interaction` family and roll tool events into `capture`.** Rejected: tool calls and returns are not turns. A single turn can spawn many tool calls; merging them collapses cardinality and makes recall queries ambiguous. Separate family, separate schemas.

--- a/adr/0019-schema-registry-governance-b.md
+++ b/adr/0019-schema-registry-governance-b.md
@@ -1,0 +1,71 @@
+# 0019 — Schema Registry + governance level B
+
+ADR 0018 establishes a canonical event schema with `family.subject.verb` names. That contract needs a home: a place where schemas live as data, a process for adding or changing them, and a runtime that knows what to do when an event arrives that doesn't match. This ADR defines that home (the Schema Registry under `events/registry/`) and chooses a governance level for it.
+
+**Registry shape.** Each registered schema is a JSON file under `events/registry/schemas/<family>/<subject>.<verb>.json`. Filenames are the source of truth for event names — the loader rejects any file whose name does not match the `family.subject.verb` regex from ADR 0018. The directory tree is the registry. There is no separate index file; adding a schema means committing a JSON file in the right place.
+
+Each schema declares required and optional fields, their types, and short descriptions. A minimal example for `capture.turn.observed`:
+
+```json
+{
+  "name": "capture.turn.observed",
+  "description": "A turn was observed on a harness transcript.",
+  "fields": {
+    "session_id":    {"type": "string", "required": true},
+    "project_id":    {"type": "string", "required": false},
+    "actor":         {"type": "string", "required": true, "values": ["user", "assistant", "tool"]},
+    "text":          {"type": "string", "required": true},
+    "tool_calls":    {"type": "array",  "required": false}
+  }
+}
+```
+
+The schema format is intentionally small. Anything richer (cross-field constraints, conditional requirements) is a future extension; v1 covers field names, types, required/optional, and bounded enums.
+
+**Three levels of governance considered.**
+
+- *Level A — strict runtime.* Every event is validated against its schema at publish time; unknown fields are rejected; missing required fields fail the publish. Tightest contract, highest friction.
+- *Level B — reviewed schemas, permissive runtime.* Schemas are reviewed and validated in CI (filename regex, JSON well-formedness, taxonomy compliance). At runtime, events are validated against required fields, but unknown fields are kept and a warning is logged. Events with missing required fields are logged at error level but **never dropped silently** — they reach the bus with a synthetic `_schema_violation` marker.
+- *Level C — schemas as documentation only.* Files exist but neither CI nor runtime consults them.
+
+**MOM adopts level B.** The reasoning is that MOM is harness-agnostic and its capture path runs continuously across heterogeneous, sometimes-broken producers. Strict runtime rejection means a malformed turn — produced by a harness update we haven't caught up to — silently disappears from the memory layer. That is the failure mode MOM exists to prevent. Permissive runtime keeps the data; CI keeps the schemas honest; the combination gives reviewers leverage without making the runtime fragile.
+
+**CI enforcement (level B's review half).** A `make verify-registry` (or equivalent CI step) runs on every PR that touches `events/registry/schemas/`:
+
+1. Every file path matches the `family.subject.verb.json` regex.
+2. Every file is well-formed JSON and parses against the registry's own schema-of-schemas.
+3. No event name is removed without an accompanying deprecation marker (an additive-only history check, scoped to released names).
+
+**Runtime enforcement (level B's permissive half).** The registry exposes `Validate(event) Result`. The Editor (ADR 0020) calls `Validate` on every event before publish:
+
+- Missing required fields produce an error-level log and a marker field on the event; the event still publishes. Crier (ADR 0022) is free to skip projection of events carrying the marker, but never silently.
+- Unknown fields produce a debug-level log on first occurrence per process and are otherwise passed through unchanged.
+- Type mismatches on declared fields produce an error-level log and the offending field is dropped from the event before publish; the rest of the event still publishes with a marker.
+
+The principle is **never lose data we already received, but make every deviation visible.** Operators reading Logbook see schema violations as first-class events; CI catches them at PR time; the runtime captures them as evidence rather than silently masking them.
+
+**Schema evolution.** Adding a new optional field is a non-breaking change and ships in a single PR. Adding a new required field is breaking and requires a deprecation pass: the field becomes required only after one release in which the producer is updated and the registry warns on missing values. Removing a field is breaking and follows the same deprecation cadence. Renaming uses add-new + deprecate-old over two releases.
+
+**`bootstrap` family.** Reserved but unused. The registry will refuse to load schemas under `events/registry/schemas/bootstrap/` until the cartographer revival lands.
+
+## Consequences
+
+- Schemas are reviewable as standalone files. A PR that adds `capture.turn.observed` is mechanically separable from the producer that emits it.
+- The runtime never loses data because of a schema mismatch. Recall and Logbook keep working even when a producer drifts.
+- Operators have a single place — schema violation logs — to see whether producers and the registry have diverged.
+- Schema evolution is explicit. "Adding a required field" is a multi-PR exercise, on purpose.
+- The registry has no dependency on the Vault or the Ledger. It is a pure data + validation library, importable from Editor, Crier, and tests.
+- CI runs the registry loader on every PR that touches schemas. Bad files fail loud and fast.
+
+## Considered alternatives
+
+- **Level A — strict runtime.** Rejected as the headline failure mode is silent data loss when a harness update changes a payload shape we haven't yet registered. MOM's job is to keep the memory; a strict runtime fights that job.
+- **Level C — documentation only.** Rejected: schemas that nothing consults rot in days. CI enforcement is the cheap half of level B and pays for itself the first time a typo would have shipped.
+- **Single registry file (`registry.json` listing all schemas).** Rejected: turns every schema change into a merge-conflict surface. Per-file schemas let independent PRs land independently.
+- **YAML schemas instead of JSON.** Rejected: events themselves are JSON-shaped, validators are JSON-native, and YAML's flexibility (anchors, multi-document streams) buys nothing here. JSON keeps tooling boring.
+- **Generated Go types from schemas.** Rejected for v1: would couple the registry to a code-generation step and create two sources of truth (the JSON, the generated `.go`). Validation against `map[string]any` is fine for now; the codegen door stays open if consumers start asking for it.
+- **Strict runtime with a feature flag.** Rejected: introducing a flag means we have to support both modes forever. The decision is the decision.
+- **External registry service (HTTP server).** Rejected: MOM runs on the user's machine. Adding a network dependency to a local memory tool is the wrong shape.
+- **Schemas as protobuf / Avro.** Rejected for v1: heavier tooling, more learning surface, and the gain (binary-stable wire format) is moot inside one process. JSON Schema-like declarations are sufficient.
+- **Auto-register schemas at runtime from producer code.** Rejected: removes the review surface that's the whole point. Schemas are reviewed, then producers emit them — not the other way around.
+- **No `_schema_violation` marker — just log and proceed.** Rejected: downstream consumers (especially Crier) need a programmatic signal, not just a log line, to decide whether to project an event.

--- a/adr/0020-editor-canonicalization-gateway.md
+++ b/adr/0020-editor-canonicalization-gateway.md
@@ -1,0 +1,54 @@
+# 0020 — Editor as canonicalization gateway
+
+In the current architecture, ingress packages publish to the bus directly. The watcher's `ToPayload()` method rolls a `Turn` into a `map[string]any` and calls `bus.Publish(herald.Event{...})` in the same step (`cli/internal/watcher/watcher.go`). The CLI does the same for explicit records. The MCP server does the same for tool invocations that produce events. Each ingress surface owns its own translation step, and each consumer learns the union of all such translations by reading every producer.
+
+ADR 0018 establishes that every event past the Ingress boundary must conform to a registered schema. ADR 0019 establishes the Schema Registry and chooses level B governance. This ADR names the package that performs the translation, fixes its position in the pipeline, and turns the position into an enforceable invariant.
+
+**The Editor.** A new package `events/editor` exposes a single contract:
+
+```go
+func Canonicalize(raw any, src Source) (herald.Event, error)
+```
+
+`raw` is the adapter-shaped value the Ingress already has (a `Turn`, a CLI record payload, an MCP tool invocation). `src` declares which adapter is calling (informational; used for provenance stamping). The Editor returns a `herald.Event` whose `Type` matches a registered schema and whose `Payload` is the canonical shape that schema describes. The Editor calls `registry.Validate` internally; level-B violations attach the `_schema_violation` marker per ADR 0019 and still return a publishable event.
+
+**Editor sits post-Ingress, pre-bus.** This is the architectural invariant. Every ingress surface — `ingress/cli`, `ingress/mcp`, `ingress/watcher/adapters/*` — calls `editor.Canonicalize` and publishes the result. No ingress surface calls `bus.Publish` directly with adapter-shaped data. No raw `Turn` (or future per-adapter struct) crosses the bus boundary.
+
+**Why a single gateway.** Three forces converge:
+
+1. *Consumers stop knowing about producers.* Drafter, Crier, Logbook, and future bus subscribers read canonical events. They don't import the watcher; they don't import the MCP server. Adding a fourth harness (e.g. OpenCode, per #155) adds a new adapter that calls the Editor, and the existing bus consumers learn nothing new.
+2. *Schema validation has a single call site.* Level B governance (ADR 0019) only works if every event is validated. A single gateway is one call site to audit; N gateways is N call sites and an inevitable miss.
+3. *Provenance stamping is centralized.* The Editor stamps `provenance_actor`, `provenance_source_type`, and `provenance_trigger_event` (ADR 0014) from a single rule set rather than letting each ingress surface invent its own values.
+
+**Enforced via archtest.** A test in `events/editor/editor_arch_test.go` asserts:
+
+- `bus/herald` does not import any `ingress/watcher/adapters/*` package, any `ingress/cli/internal-payload` type, or any other adapter-shaped type. The bus knows only `herald.Event`.
+- Every package that imports `bus/herald` either *is* `events/editor` or does not import any `ingress/*` package. (i.e. you can subscribe to the bus or you can be the Editor; you can't be a non-Editor publisher that also touches Ingress types.)
+
+The rules are slightly verbose to state but trivial to enforce — `shared/archtest.AssertNoDirectImport` (current package `cli/internal/archtest`) already supports the idiom (`archtest.go:76-88`). The archtest catches a future drift where someone adds a "quick" bypass and silently re-creates the multi-gateway problem.
+
+**Stateless and synchronous.** The Editor holds no state beyond the registry it loaded at startup. `Canonicalize` is a pure function from `(raw, src)` to `herald.Event` (plus log side-effects). It does not buffer, batch, or schedule. The order of events on the bus is the order producers call the Editor.
+
+**Editor and Ledger.** The Editor writes the canonical event to the Ledger (ADR 0021) **before** publishing to the bus. The order is fixed: canonicalize → validate → append to Ledger → publish to bus. If the Ledger append fails, the publish does not happen and the caller sees the error. The Ledger is the source of truth; the bus is a projection that can be rebuilt from the Ledger by Crier (ADR 0022).
+
+**Provenance and project scoping.** The Editor is also the resolver site for `project_id` (per ADR 0016). The Source declares the cwd that was active when the event was produced (carried by each adapter from the relevant turn / CLI invocation), and the Editor walks up looking for `.mom-project.yaml`. Centralising this means there is one place that stamps `project_id`, one cache to invalidate when the file changes, and one resolution rule to test.
+
+## Consequences
+
+- Every consumer in `workers/`, `services/`, and `events/crier` is decoupled from every producer in `ingress/`.
+- Adding an adapter is a self-contained change: write the adapter, hand its output to the Editor, done. No bus code is touched.
+- Schema violations all flow through one chokepoint and become observable as a single metric.
+- The Ledger-before-bus ordering means a crash between Ingress and bus loses *the bus event*, not *the canonical record*. On restart, the Ledger contains the event and Crier reprojects it.
+- The Editor becomes a critical path: every event in the system passes through it. Its tests carry weight; an archtest enforces nobody silently goes around it.
+- The current `Turn.ToPayload()` method is removed (or kept as a private helper inside `ingress/watcher`) once the Editor consumes the `Turn` directly. The transitional shim lasts one release; ADR 0023 retires it on the same cadence as MCP retirement.
+
+## Considered alternatives
+
+- **Per-adapter canonicalization (status quo).** Rejected: each adapter reinvents schema, provenance, and project resolution. The drift between adapters is the bug ADR 0018 exists to fix.
+- **Canonicalization as a bus-side filter (publish raw, transform on read).** Rejected: bus subscribers would each implement the transform, and the raw shape would leak into Logbook, Drafter, and Crier. The single-gateway argument applies in the other direction: one place to translate beats N places.
+- **Canonicalization in the registry (`registry.Canonicalize(raw)`).** Rejected: blurs the registry's role (data + validation) with a runtime adapter mapping. The registry says what a schema *is*; the Editor says how an adapter's input *maps to* a schema.
+- **Async Editor (buffers + worker pool).** Rejected for v1: hides ordering bugs behind a queue, complicates Ledger ordering, and the current load profile does not warrant the complexity.
+- **Multiple Editors (one per adapter, sharing the registry).** Rejected: just gives the same problem a different filename. The point of a gateway is that there is one.
+- **Editor as a method on each adapter type (`adapter.Editor`).** Rejected: ties the Editor to adapter packages and prevents the archtest invariants. Free function with explicit `Source` argument is cleaner.
+- **Validate-only Editor (publish whatever the producer hands in, validate after).** Rejected: produces events on the bus that the registry just declared invalid. Validation is part of the gate, not a side-effect downstream of it.
+- **Skip the Editor; have Crier validate at projection time.** Rejected: pushes the schema contract from "everything on the bus is canonical" to "Crier hopes the bus is canonical." Drafter, Logbook, and any future bus consumer would each need their own validation step. Editor centralises it.

--- a/adr/0021-ledger-layer-1-canonical-log.md
+++ b/adr/0021-ledger-layer-1-canonical-log.md
@@ -1,0 +1,57 @@
+# 0021 — Ledger as Layer 1 immutable canonical log
+
+Until v0.50, the Vault is MOM's only durable store. Memories, drafts, operational events, and filter audits all land in the same SQLite file (`$HOME/.mom/mom.db`, per ADR 0009). The Vault is excellent at what it does — graph-fluent recall, FTS, joins (ADR 0010) — but it is also a *projection*. Tag normalisation, draft promotion, type assignment, and other lifecycle operations rewrite Vault state. The system has no record of what arrived, only of what survived all the post-processing.
+
+This ADR introduces a second storage layer beneath the Vault: the **Ledger**. The Ledger holds canonical events (ADR 0018), validated by the registry (ADR 0019), canonicalized by the Editor (ADR 0020). It is append-only, immutable, and independent of the Vault. The Vault becomes Layer 2 — a projection of the Ledger maintained by Crier (ADR 0022).
+
+**Storage location.** The Ledger lives at `$HOME/.mom/ledger/` — a directory under the same home dir as the Vault, but **not** inside `mom.db`. The Ledger is its own file/directory tree, not a Vault table. Two physical artefacts, two responsibilities, two backup units.
+
+The choice not to add a `ledger_events` table to `mom.db` is deliberate. Sharing a SQLite file would couple Ledger writes to Vault lock contention, would entangle backup semantics (you can't restore the Vault without restoring the Ledger and vice versa), and would invite operational shortcuts like "just SELECT from the Ledger table in this Finder query" that this ADR exists to forbid.
+
+**File format.** The Ledger is a directory of segment files. Each segment is an append-only file of length-prefixed JSON event records. A `current` symlink (or a `current.txt` marker file on platforms without symlinks) points at the active segment. Segments rotate on size (default 64 MiB) or on day boundary, whichever comes first. The first 8 bytes of every segment are a magic number + version so older readers fail loudly on a future format change.
+
+Each event in the Ledger carries:
+
+- `id` — UUID assigned at append time (independent from `memory.id`).
+- `offset` — monotonically-increasing 64-bit position, unique per Ledger.
+- `appended_at` — server-clock timestamp at append time.
+- `event` — the canonical `herald.Event` produced by the Editor (`Type`, `SessionID`, `Timestamp`, `Payload`).
+
+`offset` is the durable identifier consumers use to checkpoint. Crier persists its last-applied offset; on restart it resumes from `offset + 1`.
+
+**Append-only.** The Ledger driver opens segment files with `O_APPEND` and never with any other write flag. The driver exposes only `Append(event) (offset, error)`, `Read(offset) (event, error)`, and `Iterate(from offset) iter`. There is no `Update`, no `Delete`, no `Truncate` (except `Compact` — see below). An archtest scans the driver source for forbidden write modes; the same archtest forbids any caller from importing `os.O_TRUNC | O_APPEND` style flags in the Ledger package. Operational mutability (per ADR 0011) does not apply to the Ledger; the Ledger is *substance* in the literal sense.
+
+**No mutation, ever — including for retention.** Memory retention (Item 3, deferred to v0.60) operates on the Vault projection, not on the Ledger. When a memory is deleted from the Vault, the originating Ledger event remains. Retention is a *forgetting* policy on Layer 2; the Layer 1 record of what was captured does not change. This separation is the whole reason for two layers: the historical truth and the operational projection are different things and deserve different rules.
+
+**Compaction.** The single exception to append-only is *segment-level* compaction: closed segments older than a configurable horizon (default: never) may be discarded as whole files. Compaction is a coarse-grained operational tool, not a record-level edit. Even when compaction runs, Crier's checkpoint is preserved and the Ledger reports the new oldest-available offset. Within any unsealed segment no record is ever rewritten.
+
+**Crash safety.** Every append is followed by an `fsync` on the segment file before the offset is returned to the caller. The Editor (ADR 0020) waits for the offset before publishing to the bus. If the process crashes between append and publish, the next startup sees the event in the Ledger and Crier reprojects it; if the process crashes during append, the partial write is detected on next open (length-prefix vs file-tail mismatch) and truncated to the last good record.
+
+**No reads on the recall path.** The user-facing read path is and remains CLI → Finder/Librarian → Vault (ADR 0009). The Ledger is not a query target. Recall, landmarks, drafts, lens dashboards — all read from the Vault. The Ledger is read by exactly one consumer: Crier. Archtests in `services/finder` and `services/lens` forbid importing `storage/ledger`.
+
+**Backup story.** Users back up `$HOME/.mom/` and get both layers in one tree. Sync (when it lands) ships Ledger segments through whatever transport makes sense; segments are immutable so they're trivially shareable. The Vault is a projection — losing it and reprojecting from the Ledger is a recovery path, not a crisis.
+
+**What the Ledger is not.** It is not an audit log of API calls. It is not a debug trace of internal function calls. It is not a Kafka-like distributed log. It is one local append-only file tree that holds the canonical events MOM has ingested, sufficient to rebuild the Vault projection.
+
+## Consequences
+
+- MOM gains an independent historical record. Recovering from a corrupted Vault is "delete `mom.db`, re-run Crier from offset 0."
+- Append is on the hot path of every captured turn. The cost is one `O_APPEND` write + `fsync`; on local disk this is sub-millisecond and acceptable.
+- Two storage units live under `$HOME/.mom/`. Documentation, backup guides, and `mom doctor` all gain a second checklist item.
+- Retention work (v0.60+, Item 3 deferred) plans against the Vault, not against the Ledger. The Ledger keeps growing until the user runs compaction on closed segments.
+- The Ledger format is owned by MOM and not exposed as a public protocol. Format evolution (segment header, record framing) is internal and migrations ship in `mom upgrade`.
+- An archtest enforces driver-level append-only semantics. Tampering with that requires changing the test, which is visible in code review.
+- Crier (ADR 0022) is the only Ledger consumer in the codebase. The contract is narrow and testable.
+
+## Considered alternatives
+
+- **Add a `ledger_events` table to `mom.db`.** Rejected: couples Ledger writes to Vault lock contention, entangles backups, and invites direct SQL queries that defeat the Layer-1 / Layer-2 separation. Two layers in two files is the cheap way to keep the responsibilities clean.
+- **Use an existing embedded log library (Bolt, Badger, LMDB, embedded Kafka).** Rejected for v1: bigger dependency, more knobs, fewer guarantees about the file layout being readable from outside Go. A directory of length-prefixed JSON segments is debuggable with `cat` and `jq`.
+- **Use SQLite for the Ledger but in a separate file (`ledger.db`).** Considered seriously. Rejected because (a) SQLite invites mutability primitives that the archtest then has to forbid by convention rather than by file format; (b) the operational model (immutable segments, day rotation, compaction) maps poorly to a single-file database; (c) tooling (`cat`, `jq`, `tail -f`) on a segment directory is friendlier for debugging.
+- **Write events to the bus first, then asynchronously to the Ledger.** Rejected: produces a window where the bus has events the Ledger does not. Crash recovery becomes "reconstruct what the bus thought it knew," which is impossible. Ledger-first is the only ordering that makes recovery deterministic.
+- **Make Crier optional (Ledger writes, Vault writes happen directly elsewhere).** Rejected: defeats the projection model. The whole point of Layer 1 is that Layer 2 is derivable from it.
+- **Allow Ledger compaction at record granularity (e.g. drop events older than 90 days).** Rejected: turns Layer 1 into another projection. Coarse-grained segment compaction is sufficient and preserves the immutability property within any open record range.
+- **Store the Ledger in `$XDG_DATA_HOME` instead of `$HOME/.mom/`.** Rejected: ADR 0009 chose `$HOME/.mom/` for the Vault; the Ledger lives alongside it for consistency and one-tree backups.
+- **Multiple Ledgers (one per project).** Rejected: ADR 0009 made the Vault central; per-project Ledgers would re-introduce the scatter problem (ADR 0016 makes project scoping a column, not a directory). The Ledger is global; events carry `project_id` per the Editor's resolution rule.
+- **Write the Ledger record as the same shape as the bus event (no envelope).** Rejected: the Ledger needs `offset` and `appended_at`, which are Ledger-assigned, not Editor-assigned. The envelope (`{id, offset, appended_at, event}`) carries the durable identifiers; the inner `event` is byte-identical to what crossed the bus.
+- **Drop the `fsync` for performance.** Rejected: the durability promise is the whole point. If `fsync` becomes a measured bottleneck, batching (group commit) is the next step, not skipping the flush.

--- a/adr/0022-crier-projector-via-librarian.md
+++ b/adr/0022-crier-projector-via-librarian.md
@@ -1,0 +1,62 @@
+# 0022 — Crier as projector/replayer via Librarian
+
+ADR 0021 establishes the Ledger as Layer 1: the immutable canonical log of events MOM has ingested. The Vault remains Layer 2: the projection of those events into a queryable form. Something has to read the Ledger and produce the Vault — and only that something is allowed to write to the Vault.
+
+This ADR names that component the **Crier** and pins down its contract.
+
+**Crier subscribes to the Ledger, not the bus.** This is the key architectural choice. The bus (`bus/herald`) is alive and useful for consumers that want at-most-once, in-process, ephemeral delivery — Drafter, Logbook, Lens hooks. But the Vault is durable state, and durable state must be derivable from durable input. Crier reads from `storage/ledger` by polling the next unapplied offset, applies the event, persists its new checkpoint, and loops. If the process restarts, Crier resumes from the checkpoint; if the Vault is deleted, Crier resumes from offset 0 and rebuilds it.
+
+This means the bus is no longer on the durability path. A bus subscriber that misses an event misses an event; a Crier that misses an event eventually catches up because its input is the Ledger, not a transient publish.
+
+**Crier writes the Vault only through Librarian.** Per ADR 0009 and the existing architecture, Librarian is the sole gate to Vault writes. Crier respects that. The package `events/crier` imports `storage/librarian` and never imports `storage/vault` directly. An archtest in `events/crier/crier_arch_test.go` enforces:
+
+```go
+archtest.AssertNoDirectImport(t, ".", "github.com/momhq/mom/storage/vault")
+```
+
+Crier calls Librarian's write APIs (`InsertMemory`, `PromoteDraft`, `UpdateTags`, etc., as they evolve through the milestone). Librarian remains responsible for substance-immutability enforcement (ADR 0011), graph-fluent tag normalisation (ADR 0010), and any future write-side invariants. Crier is a translator from canonical events into Librarian calls; Librarian is the gatekeeper of what the Vault looks like.
+
+**Crier is the only projector.** Drafter, Logbook, and any other bus subscriber may continue to write through Librarian (Logbook already does, for operational telemetry; Drafter writes drafts under explicit-record). But for the *projection of canonical events into Vault state*, Crier is alone. Two consumers projecting the same event into the Vault would produce double-writes and racing state; one consumer is the invariant.
+
+A subtlety: Drafter writes happen on the bus path today (a turn lands on the bus, Drafter decides to materialise it as a draft, Librarian persists). After v0.50, Drafter still subscribes to the bus and still writes drafts through Librarian — but the *canonical record* of the turn is in the Ledger and is projected by Crier independently. Drafter's draft is metadata about a turn, not the turn itself. The two flows do not collide because they write different rows (or, for shared rows, the schema gives Crier the substance and Drafter the operational fields per ADR 0011).
+
+**Projection is deterministic and self-sufficient.** ADR 0018 requires every canonical event to be self-sufficient. Crier exploits this: each event is projected in isolation. There is no batching, no transactional grouping across events, no "look up the previous event to compute this one." A single canonical event arrives, Crier maps its `Type` to a projection function, calls Librarian with the resulting arguments, and advances its checkpoint. The replay test (Phase 3.4 in the v0.50 plan) takes any single Ledger event in isolation, runs it through Crier, and asserts the Vault delta matches a fixture.
+
+This determinism is the foundation of recovery. "Rebuild the Vault" is "delete `mom.db`, run Crier from offset 0 to head." The operation is not magic; it is a finite sequence of projections each of which is testable in isolation.
+
+**At-least-once semantics with idempotency.** Crier persists its checkpoint *after* the Librarian write succeeds. If the process crashes between the write and the checkpoint persist, the event is re-applied on next startup. Projections must therefore be idempotent: re-projecting `capture.turn.observed` for the same `(session_id, timestamp)` does not insert a duplicate row. Librarian's `InsertMemory` already uses UUIDs (ADR 0013); idempotency for events with no natural key (e.g. `operational.daemon.started`) is achieved by including the Ledger `offset` as a deduplication key on the projection side.
+
+The alternative (checkpoint before write, exactly-once via two-phase commit) is not worth the complexity for a local SQLite-backed projection. At-least-once + idempotent projections is the standard pattern and the right one here.
+
+**Crier and bus subscribers coexist.** When a canonical event is published, two things happen in sequence:
+
+1. Editor (ADR 0020) appends the event to the Ledger and publishes to the bus.
+2. Bus subscribers (Drafter, Logbook, Lens hooks) react immediately for low-latency UX.
+3. Crier reads from the Ledger asynchronously and projects into the Vault.
+
+Latency for Crier's projection is bounded by its polling interval (default: a tight loop with a short backoff when idle). For typical interactive use the lag between event-on-bus and event-in-Vault is sub-second. For correctness, however, the design treats Crier as the source of Vault state and the bus subscribers as effects.
+
+**No bus reads for Crier.** A tempting shortcut is to have Crier double-subscribe (Ledger for replay, bus for live) so that it doesn't have to poll. Rejected: makes Crier care about two delivery semantics, complicates the "bus is not on the durability path" story, and the simpler design (Ledger only) is fast enough. If polling latency becomes a measured problem, we add a notification primitive between Editor's Ledger-append and Crier's loop — not a second subscription.
+
+**Ordering.** Crier projects events in Ledger order. Out-of-order projection is not supported in v1 and not needed: the Ledger assigns monotonic offsets in append order, and the Editor appends in publish order. If a future event family needs partition-level parallelism, the partition key is added to the Ledger envelope and Crier learns to parallelise within partitions while serialising offset-advancement; this is a v0.60+ concern.
+
+## Consequences
+
+- The Vault is fully derivable from the Ledger. "Re-project the world" is a routine operation, not a recovery panic.
+- The bus is no longer on the durability path. Bus crashes lose bus events but not Vault state.
+- Drafter, Logbook, and Lens keep using the bus and Librarian as before. Their write paths are unchanged.
+- Crier is the sole projector, enforced by archtest. Future drift ("just write to the Vault from this new package") is blocked at PR time.
+- Projections must be idempotent. New canonical events ship with a projection function and an idempotency proof in the form of a replay test.
+- A reset path exists: delete `mom.db`, restart, Crier rebuilds. This is documented in `mom doctor` as the recovery flow.
+- Crier's checkpoint is operational state (per ADR 0011) — it lives somewhere mutable (likely in the Vault as a one-row `crier_state` table managed by Librarian). Resetting the checkpoint to 0 + dropping the Vault triggers a full reprojection.
+
+## Considered alternatives
+
+- **Crier reads from the bus.** Rejected: ties Vault durability to bus liveness. A bus crash mid-publish would lose the projection of the missed event; recovery would require replaying from the Ledger anyway. The shorter and more correct design is to read from the Ledger directly.
+- **Multiple projectors (one per family, one per consumer).** Rejected: race conditions when two projectors touch the same Vault row, and the "Crier is sole projector" invariant becomes a coordination problem. Single projector + family-aware projection function is simpler and the Ledger is fast enough that one projector keeps up.
+- **Crier writes the Vault directly (bypass Librarian).** Rejected: defeats the gatekeeping property Librarian provides (substance immutability, tag normalisation, future write invariants). Crier is a *user* of Librarian, not a peer.
+- **Exactly-once semantics via two-phase commit.** Rejected for v1: complexity outweighs benefit for a local SQLite projection where re-applying an idempotent event is fast. At-least-once + idempotent is the right point on the curve.
+- **Crier subscribes to the Ledger via a watch/notify primitive (no polling).** Considered. Deferred: polling with a backoff is sufficient and avoids introducing a notification API surface in the Ledger driver. If we measure latency that matters, we add notification then.
+- **Reuse `workers/` for Crier (e.g. `workers/crier`).** Rejected: workers in the layout (Drafter, Logbook, Cartographer) are bus subscribers that produce side effects. Crier reads from the Ledger and writes to the Vault — a different role. Putting it under `events/crier` next to Editor and the registry keeps the projection pipeline visible as a unit.
+- **Crier and Drafter merged into one package.** Rejected: they have different inputs (Ledger vs bus), different write semantics (durable projection vs operational metadata), and merging them couples two release cadences. Keeping them separate keeps each one's contract small.
+- **Crier handles retention (delete-from-Vault).** Rejected: retention is the Gardener's job (Item 3, deferred to v0.60). Crier projects what happened; Gardener forgets what no longer needs to be remembered. Two policies, two components.

--- a/adr/0023-mcp-server-retirement.md
+++ b/adr/0023-mcp-server-retirement.md
@@ -1,0 +1,76 @@
+# 0023 — MCP Server retirement (deprecated in v0.50, retired in v0.60+)
+
+When MOM first shipped, the MCP server was the canonical way for an LLM harness to invoke MOM operations: a long-lived process speaking the Model Context Protocol, exposing `mom_status`, `mom_recall`, `mom_get`, `mom_landmarks`, and `mom_record` as tools the harness could call. Two forces have since shifted the equation:
+
+1. **The CLI grew up.** `mom status`, `mom recall`, `mom record` and friends are no longer thin wrappers around MCP handlers — they are independent code paths that read and write the central vault directly. Where the MCP server existed because there was no other way to reach MOM from a harness, the CLI now offers the same surface as ordinary subprocesses.
+2. **Harness ergonomics improved.** Claude Code, Codex, and Pi all support invoking subprocesses (Bash tool, shell hook) cleanly. The MCP transport solved a problem (long-lived state, structured tools) that the harnesses now solve themselves; one less long-lived server is one less thing to start, monitor, and authenticate.
+
+This ADR retires the MCP server. The retirement is staged: **v0.50 deprecates with a runtime warning; v0.60+ removes the transport.** This ADR documents both the end state and the bridge.
+
+**End state (v0.60+).**
+
+- The MCP server binary (`mom serve mcp`) is removed.
+- Harnesses invoke `mom <subcommand>` as subprocesses for every operation they previously called via MCP tools.
+- The harness adapter packages (`ingress/watcher/adapters/*`) continue to ingest transcripts; this is a separate concern and is unaffected. Watcher-driven *capture* stays; MCP-driven *invocation* leaves.
+- The `mom_status` semantics are preserved through `/mom-status` (skill) + `mom status` (CLI). The instructions block currently returned by the MCP `instructions` field is delivered through MOM's existing global-agent-file bootstrap (ADR 0015), which all supported harnesses already concatenate into the agent's context.
+
+**v0.50 deprecation behaviour.**
+
+- The MCP server is unchanged at the protocol level: it still exposes the same five tools and serves the same responses.
+- On startup, the server emits exactly one deprecation warning to stderr:
+  ```
+  WARN: MOM's MCP transport is deprecated and will be removed in v0.60+.
+        Configure your harness to invoke `mom <subcommand>` as a subprocess.
+        See adr/0023-mcp-server-retirement.md for details.
+  ```
+- A unit test asserts the warning is emitted exactly once per server boot. The check is on the boot path, not the request path; existing MCP sessions stay quiet after the initial line.
+- The `mom_status` MCP handler additionally returns the deprecation message inside its JSON payload (a `deprecation` field) so harnesses that log the structured response surface the warning to users.
+
+**CLI parity audit.** Before v0.50 tags, every MCP tool must have a functionally equivalent CLI subcommand. The current state (verified against `cli/internal/cmd/root.go` and `cli/internal/mcp/tools.go`):
+
+| MCP tool | CLI counterpart | Gap |
+|---|---|---|
+| `mom_status` | `mom status` (`cli/internal/cmd/ops.go`) | — |
+| `mom_recall` | `mom recall <query>` (`cli/internal/cmd/recall.go`) | — |
+| `mom_record` | `mom record` (stdin-piped, `cli/internal/cmd/record.go`) | — |
+| `mom_get` | **missing** | Add `mom get <id>` subcommand |
+| `mom_landmarks` | **missing** | Add `mom landmarks [--limit N]` subcommand |
+
+The two gaps ship as part of the v0.50 milestone (Phase 3 of the execution plan, sub-PR (a)). The new subcommands read through Finder/Librarian — the same code paths the MCP handlers use today — and produce JSON output compatible with what the MCP tools return, so a harness migrating from `mom_get` to `mom get --json <id>` sees the same shape.
+
+**"Functionally equivalent" means.** The CLI subcommand:
+
+1. Reads or writes the same data as its MCP counterpart, using the same underlying packages.
+2. Accepts the same logical inputs (with CLI-shaped argument forms — flags or positional args rather than JSON properties).
+3. Produces JSON output structurally equivalent to the MCP tool's response when invoked with `--json` (default for non-TTY stdout, opt-in for TTY).
+4. Exits 0 on success and non-zero with a structured error on failure.
+
+The parity is enforced by a test in `ingress/mcp/parity_test.go` that, for each MCP tool, calls both the MCP handler and the CLI subcommand against a fixture vault and asserts the responses match modulo well-known transport differences (e.g. JSON-RPC framing).
+
+**The `instructions` story.** The MCP `instructions` field today is correct per the protocol spec but not actually injected by any supported harness (per ADR 0015). MOM's operating protocol reaches agents through the global-agent-file bootstrap blocks (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, etc.), and that delivery path does not depend on the MCP server. Removing MCP does not remove agent-side instructions; the bootstrap blocks already handle it.
+
+**The `mom_status` discovery story.** Today the MCP server is what agents call to "find MOM" at session start. In the CLI-subprocess model, the agent runs `mom status` (or the `/mom-status` skill) instead. The global-agent-file bootstrap block already instructs the agent to do this; ADR 0015 wrote the bootstrap to be transport-agnostic for exactly this reason.
+
+**Migration window.** v0.50.x runs the MCP server with the deprecation warning. The CHANGELOG announces the v0.60 removal. Anyone running MOM through MCP gets the warning every session boot for the duration of the v0.50 cycle.
+
+**What is not retired in v0.50.** The MCP package itself stays compiled and shipped in v0.50. Removing it is a v0.60 follow-up issue (referenced from this ADR by GitHub URL in the relevant issue body). v0.50's job is to (a) confirm CLI parity, (b) install the warning, (c) close the parity gaps. v0.60's job is to delete the server.
+
+## Consequences
+
+- v0.50 is non-breaking for anyone using the MCP transport: it still works, with a noticeable warning. Users have a full release cycle to switch harness configurations.
+- The CLI gains two new subcommands (`mom get`, `mom landmarks`) which close the parity gaps and become the public interface for those operations.
+- A `parity_test` in `ingress/mcp/` prevents the CLI and MCP outputs from drifting during the deprecation window.
+- Once v0.60 removes MCP, MOM ships a smaller binary and one fewer long-lived process. No daemon supervision is needed for invocation paths; the watcher daemon (separate concern) remains for transcript capture.
+- Documentation referencing `mom serve mcp` is updated in v0.50 to call it "deprecated" and to point at the CLI-subprocess pattern. Removed entirely in v0.60.
+- The harness-side change is "swap the MCP tool definition for a shell-out to `mom <cmd>`." MOM's docs ship a small migration guide for each supported harness.
+
+## Considered alternatives
+
+- **Retire MCP in v0.50 (hard cut, no deprecation cycle).** Rejected: breaks anyone running through MCP without warning. A one-release deprecation is cheap and gives users a real window.
+- **Keep MCP indefinitely as a parallel surface.** Rejected: two surfaces means two test surfaces, two failure modes, and two answers when a user asks "how do I invoke MOM?" The CLI is winning; the second surface is overhead.
+- **Replace MCP with a different long-lived protocol (e.g. gRPC, JSON-RPC over a socket).** Rejected: solves a problem we don't have. The CLI is fast enough; subprocess startup is not a measured bottleneck; and "go back to a long-lived server" would re-introduce the daemonisation overhead that motivated this retirement in the first place.
+- **Move MCP tools onto the watcher daemon (one process, two transports).** Rejected: conflates capture (transcript ingestion) with invocation (agent-initiated tool calls). The daemon's reason to exist is the watcher; MCP doesn't need to be there.
+- **Retire MCP without a parity audit (assume the CLI is close enough).** Rejected: the audit caught two real gaps (`mom_get`, `mom_landmarks`). Closing them is part of the milestone, not a follow-up.
+- **Convert MCP into a thin shim that itself invokes CLI subprocesses.** Rejected for v0.50: would have to live somewhere, would still need maintenance, and the gain (smaller MCP code) is marginal compared to "just call the CLI from the harness." If a future user has an unusual transport need, the door is not closed — they can write the shim themselves.
+- **Keep the `instructions` field as the canonical bootstrap channel.** Rejected: ADR 0015 already chose the global-agent-file pattern because no supported harness injects MCP `instructions` into agent context. Doubling down on `instructions` would invest in a path no harness uses today.
+- **Defer the CLI parity work to v0.60.** Rejected: the deprecation warning is meaningless if users discover, after migrating their harness, that `mom_get` has no CLI counterpart. Parity ships with the warning.

--- a/prd/0004-v0-50.md
+++ b/prd/0004-v0-50.md
@@ -1,0 +1,111 @@
+# PRD 0004 — v0.50(alpha): role-based repo layout, canonical event schema, and dual storage
+
+## Problem Statement
+
+MOM's v0.30 storage consolidation (PRD 0003) gave the project a single Vault, a graph-fluent schema, and a clean Drafter pipeline. v0.40 hardened harness reliability and shipped per-turn project scoping (ADR 0016). With those foundations in place, three structural problems now block the next round of features:
+
+1. **The internal architecture is invisible.** `cli/internal/` holds 32 sibling packages with no role-based organisation. Reviewers and new contributors cannot tell which packages are ingress, which are storage, which are workers, and which are shared utilities. Architectural rules ("the read path must not depend on the future Ledger", "Vault writes must route through Librarian") live in archtests and reviewer memory rather than in the filesystem.
+2. **Event flow is informal.** Every ingress surface (watcher adapters, CLI subcommands, MCP server) hand-rolls its event payload and publishes directly onto Herald. Consumers parse `map[string]any` defensively. There is no schema, no taxonomy, and no contract between producers and consumers — adding a producer means inventing keys; adding a consumer means guessing which keys exist.
+3. **The Vault is MOM's only durable store.** Memories, drafts, operational events, and filter audits all live in `mom.db`. Lifecycle operations (tag normalisation, draft promotion, type assignment) rewrite Vault rows. The system has no record of what was originally captured — only of what survived all the post-processing. There is no recovery path other than "restore the Vault from backup."
+
+These three problems are interlocking. The architecture cannot be named in the filesystem (problem 1) without first agreeing on the new components (events Editor, Schema Registry, Ledger, Crier). The new components cannot be added (problems 2 and 3) without disturbing every place that imports from `cli/internal/*`. v0.50 addresses all three in dependency order.
+
+## Solution
+
+v0.50 ships three locked items, in the order **Item 6 → Item 1 → Item 2**, on a single `v0.50-dev` integration branch.
+
+### Item 6 — Role-based repo layout (ADR 0017)
+
+The codebase is reorganised from `cli/internal/<32 packages>` into eight role-based top-level buckets that match the architectural diagram:
+
+```
+mom/
+├── cmd/mom/                              entrypoint
+├── ingress/{cli,mcp,watcher/adapters/*}  user + harness ingress
+├── events/{editor,registry,crier}        canonicalization + projection
+├── bus/herald/                           in-process event bus
+├── workers/{drafter,logbook,cartographer}  bus subscribers with side-effects
+├── services/{finder,lens}                read-side application code
+├── storage/{librarian,vault,ledger}      durable state + gatekeeper
+├── ops/{daemon,diagnose}                 background lifecycle + introspection
+├── shared/{config,pathutil,scope,ux,archtest}  cross-cutting utilities
+└── docs/
+```
+
+The reorganisation ships as a single big-bang PR. Existing import paths are rewritten from `github.com/momhq/mom/cli/internal/<pkg>` to `github.com/momhq/mom/<bucket>/<pkg>` in lockstep with the directory moves. The Go module path remains `github.com/momhq/mom`. An archtest in `shared/archtest/layout_test.go` enforces that `cli/internal/` does not return.
+
+### Item 1 — Canonical event schema + Schema Registry + Editor (ADRs 0018, 0019, 0020)
+
+Three coordinated changes establish the event contract:
+
+- **Schema definition.** Every event past the Ingress boundary conforms to a registered schema, identified by a `family.subject.verb` name. Families v1 are `capture`, `lifecycle`, `interaction`, `operational`; `bootstrap` is reserved for the Cartographer revival. Events are *self-sufficient*: a single Ledger row contains all data needed to project it. (ADR 0018)
+- **Schema Registry under `events/registry/`.** Each schema is a JSON file at `events/registry/schemas/<family>/<subject>.<verb>.json`. CI validates filenames, JSON well-formedness, and additive-only history. Runtime is **governance level B**: required-field violations are logged as errors and the event is still published with a `_schema_violation` marker; unknown fields are logged once per process and passed through unchanged; type mismatches drop the offending field and mark the event. The principle is *never lose data we already received, but make every deviation visible*. (ADR 0019)
+- **Editor as canonicalization gateway.** A new package `events/editor` is the single gate between Ingress and the bus. Every ingress surface calls `editor.Canonicalize(raw, src)`; the Editor validates against the registry, stamps provenance and `project_id`, and publishes through `bus.Publish`. Archtests forbid the bus from importing adapter types directly. (ADR 0020)
+
+### Item 2 — Dual storage: Ledger + Crier + MCP deprecation (ADRs 0021, 0022, 0023)
+
+- **The Ledger.** A new append-only canonical log at `$HOME/.mom/ledger/`, stored as length-prefixed JSON segments. The Ledger is Layer 1: the immutable historical record of canonical events. The Vault becomes Layer 2: a projection. Append is `O_APPEND` + `fsync`; the driver exposes no Update/Delete operations and an archtest forbids them. (ADR 0021)
+- **The Crier.** A new package `events/crier` reads the Ledger by offset, projects each event into the Vault by calling Librarian, and persists its checkpoint. Projections are deterministic and idempotent; replay is "delete `mom.db`, run Crier from offset 0." Crier is the *sole projector* into the Vault; an archtest forbids any non-Librarian Vault writes and forbids Crier from importing `storage/vault` directly. (ADR 0022)
+- **MCP deprecation.** The MCP server stays alive in v0.50 but emits a deprecation warning at boot. Two CLI parity gaps surfaced during planning (`mom_get` and `mom_landmarks` have no CLI counterparts) are closed by new `mom get` and `mom landmarks` subcommands. A parity test asserts equivalence between MCP handlers and CLI subcommands. The MCP transport is removed in v0.60+. (ADR 0023)
+
+### Read path unchanged
+
+The user-facing read path remains CLI → Finder/Librarian → Vault. v0.50 introduces no Ledger reads on the read path. Archtests in `services/finder` and `services/lens` forbid importing `storage/ledger`. Recall, landmarks, drafts, lens dashboards — all read from the Vault as they did before.
+
+### Branching and process
+
+- Phase 0 (this PRD + ADRs 0017–0023) merges to `main` first.
+- `v0.50-dev` is branched from `main` after Phase 0 merges.
+- Items 6, 1, 2 land on `v0.50-dev` in dependency order, broken into 15 issues carrying the `v0.50.0` milestone.
+- Every issue body links to its referenced ADR(s) and this PRD by full GitHub URL.
+- Every PR includes `Closes #N` so issues auto-close at merge.
+- `v0.50-dev` merges into `main` only at release tag time, mirroring the v0.40 pattern.
+- A release-gate CI job asserts zero open issues remain in the `v0.50.0` milestone at tag.
+
+## User Stories
+
+1. As a contributor opening the repo for the first time, I want the top-level directory listing to name the architecture, so that I can orient without reading every package end-to-end.
+2. As a reviewer, I want architectural rules ("the read path must not import the Ledger") to be enforced by archtests against named buckets, so that drift is caught at PR time rather than during a future regression.
+3. As a developer adding a new harness adapter, I want to drop the adapter under `ingress/watcher/adapters/<name>/`, hand its output to the Editor, and be done, so that I do not touch the bus, the Vault, or any consumer code.
+4. As a developer adding a new event family, I want to register a JSON schema under `events/registry/schemas/<family>/`, and have CI validate it, so that the schema is reviewable as a standalone change before any producer or consumer is written.
+5. As a developer running MOM with a harness whose payload shape has drifted, I want the runtime to log the schema violation but still capture the event, so that my memory layer keeps working through harness upgrades.
+6. As a developer auditing event flow, I want every event past the Ingress boundary to go through one canonicalization point, so that schema validation and provenance stamping have a single audit surface.
+7. As a developer maintaining MOM, I want the Vault to be derivable from the Ledger, so that a corrupted `mom.db` is recovered by re-running Crier rather than by restoring a backup.
+8. As a developer adding a new canonical event, I want every event to be self-sufficient (no chains, no parent references), so that projection works on a single event in isolation and the replay test for that event is a one-event fixture.
+9. As a developer running MOM, I want the Ledger to live in a separate file/directory from the Vault, so that backups, file locks, and operational tooling can treat each layer independently.
+10. As a developer auditing storage writes, I want Crier to be the only package that projects canonical events into the Vault, so that double-writes and racing projections are structurally impossible.
+11. As a developer running MOM through the MCP transport in v0.50, I want a clear deprecation warning at server boot, so that I know to migrate my harness configuration before v0.60+ retires the transport.
+12. As a developer migrating off MCP, I want every MCP tool to have a functionally equivalent CLI subcommand, so that I can switch my harness to invoke `mom <cmd>` as a subprocess without losing functionality.
+13. As a developer using the v0.30 CLI surface (`mom_get`, `mom_landmarks`) through MCP, I want corresponding `mom get` and `mom landmarks` CLI subcommands shipped in v0.50, so that the deprecation path is complete on day one.
+14. As a release manager, I want a CI release-gate job that asserts zero open issues in the `v0.50.0` milestone at tag time, so that the milestone never silently spills into the next release.
+15. As a contributor opening an issue against v0.50, I want the PR template to require a `Closes #N` line, so that merging the PR automatically closes the issue and the milestone stays clean.
+16. As an operator running `mom doctor`, I want the diagnostic output to include both the Vault path and the Ledger path, so that I can verify both layers are present and writable.
+17. As a developer reading the v0.50 ADRs, I want each ADR to restate its decision inline (no references to internal-only documentation), so that I have a complete picture from the public repo alone.
+18. As a developer extending MOM in v0.60, I want the `bootstrap` event family to be reserved but unused in v0.50, so that the Cartographer revival inherits a clean naming space without retroactive collisions.
+
+## Out of scope
+
+- **Item 3 (Memory retention via Gardener).** Deferred to v0.60.0. v0.50 introduces the Ledger and pins the rule that retention operates on the Vault projection, not on the Ledger; the actual policy and Gardener implementation ship later.
+- **Item 4 (LLM query-plan boundary).** Dropped from the roadmap.
+- **Item 5 (Provenance + attestations).** Deferred to a later milestone.
+- **MCP server removal.** v0.50 deprecates the MCP transport with a runtime warning; the actual removal of `ingress/mcp` happens in v0.60+.
+- **Hybrid recall query + UX overhaul.** Deferred to v0.60.0 (separately from Item 3) as the recall overhaul.
+- **Bootstrap (Cartographer) revival.** The `bootstrap` event family is reserved in v0.50 but no producer ships.
+- **Sync, multi-machine federation.** Out of scope for v0.50; the Ledger's append-only segment format is amenable to future sync work but no transport is built.
+
+## References
+
+- [adr/0009-storage-consolidation-home-canonical.md](https://github.com/momhq/mom/blob/main/adr/0009-storage-consolidation-home-canonical.md)
+- [adr/0010-graph-fluent-schema-normalization.md](https://github.com/momhq/mom/blob/main/adr/0010-graph-fluent-schema-normalization.md)
+- [adr/0011-substance-immutability-operational-mutability.md](https://github.com/momhq/mom/blob/main/adr/0011-substance-immutability-operational-mutability.md)
+- [adr/0013-uuid-only-memory-ids.md](https://github.com/momhq/mom/blob/main/adr/0013-uuid-only-memory-ids.md)
+- [adr/0014-capture-filtering-privacy-quality.md](https://github.com/momhq/mom/blob/main/adr/0014-capture-filtering-privacy-quality.md)
+- [adr/0015-bootstrap-mcp-instructions-and-global-agent-marker.md](https://github.com/momhq/mom/blob/main/adr/0015-bootstrap-mcp-instructions-and-global-agent-marker.md)
+- [adr/0016-project-as-declared-first-class-identity.md](https://github.com/momhq/mom/blob/main/adr/0016-project-as-declared-first-class-identity.md)
+- [adr/0017-role-based-repo-layout.md](https://github.com/momhq/mom/blob/main/adr/0017-role-based-repo-layout.md)
+- [adr/0018-canonical-event-schema.md](https://github.com/momhq/mom/blob/main/adr/0018-canonical-event-schema.md)
+- [adr/0019-schema-registry-governance-b.md](https://github.com/momhq/mom/blob/main/adr/0019-schema-registry-governance-b.md)
+- [adr/0020-editor-canonicalization-gateway.md](https://github.com/momhq/mom/blob/main/adr/0020-editor-canonicalization-gateway.md)
+- [adr/0021-ledger-layer-1-canonical-log.md](https://github.com/momhq/mom/blob/main/adr/0021-ledger-layer-1-canonical-log.md)
+- [adr/0022-crier-projector-via-librarian.md](https://github.com/momhq/mom/blob/main/adr/0022-crier-projector-via-librarian.md)
+- [adr/0023-mcp-server-retirement.md](https://github.com/momhq/mom/blob/main/adr/0023-mcp-server-retirement.md)


### PR DESCRIPTION
## Summary

Phase 0 of the v0.50.0 milestone. Lands the seven architectural ADRs and the umbrella PRD on \`main\` before \`v0.50-dev\` is branched and any Item 6 / Item 1 / Item 2 code work begins.

### Documents

- \`adr/0017-role-based-repo-layout.md\` — Role-based top-level buckets (events/, storage/, ingress/, bus/, workers/, services/, ops/, shared/).
- \`adr/0018-canonical-event-schema.md\` — \`family.subject.verb\` taxonomy; v1 families capture, lifecycle, interaction, operational; bootstrap parked.
- \`adr/0019-schema-registry-governance-b.md\` — Schema Registry under \`events/registry/\`; governance level B (CI-reviewed, permissive runtime).
- \`adr/0020-editor-canonicalization-gateway.md\` — Editor as the sole gate between Ingress and the bus; archtest invariants.
- \`adr/0021-ledger-layer-1-canonical-log.md\` — Ledger as Layer 1 immutable canonical log under \`~/.mom/ledger/\`; append-only segments.
- \`adr/0022-crier-projector-via-librarian.md\` — Crier as sole projector into Vault via Librarian; at-least-once + idempotent.
- \`adr/0023-mcp-server-retirement.md\` — v0.50 deprecation warning; v0.60+ retirement; CLI-subprocess harness model.
- \`prd/0004-v0-50.md\` — Umbrella PRD covering Items 6, 1, 2; cross-references all seven ADRs.

Plus \`/goals\` and \`/scripts\` added to \`.gitignore\` for local working directories.

### Authoring rule

ADRs and the PRD are self-contained — no references to internal-only directories or any path outside this open-source repo. Decisions are restated inline so external contributors have a complete picture.

### Gate to next phase

\`v0.50-dev\` is branched from \`main\` **only after** this PR merges. CI on \`v0.50-dev\` will confirm \`adr/0017-*\` through \`adr/0023-*\` and \`prd/0004-v0-50.md\` all exist before any Item 6 PR opens.

## Test plan

- [ ] All 7 ADR files present in \`adr/\`
- [ ] \`prd/0004-v0-50.md\` present
- [ ] Every ADR link in PRD 0004's References section resolves
- [ ] No references to \`mom-engineer/\` or other internal-only paths
- [ ] \`.gitignore\` excludes \`/goals\` and \`/scripts\`

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)