### PR TITLE
docs(v0.50.0): refresh README + CONTRIBUTING for new layout (#357)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,30 +9,55 @@
 
 ```bash
 git clone https://github.com/momhq/mom.git
-cd mom/cli
+cd mom
 make build
 make test
 ```
 
 ## Project structure
 
+The codebase uses a role-based top-level layout (see [ADR 0017](adr/0017-role-based-repo-layout.md)). Each bucket maps 1:1 to the role a package plays in the dataflow — not to whether it reads or writes.
+
 ```
-cli/
-├── cmd/mom/main.go              # entrypoint
-├── internal/
-│   ├── cmd/                     # cobra commands (init, upgrade, CRUD, ops, export)
-│   ├── adapters/runtime/        # RuntimeAdapter interface + impls (claude, codex, windsurf)
-│   ├── adapters/storage/        # StorageAdapter interface + impls (JSON)
-│   ├── config/                  # .mom/config.yaml handling
-│   ├── memory/                  # memory document types and validation
-│   ├── mcp/                     # MCP server (tools + resources)
-│   ├── cartographer/            # multi-repo scope detection
-│   ├── gardener/                # memory lifecycle, dedup, landmarks
-│   ├── transponder/             # local telemetry emitter (deprecated, see Herald)
-│   └── scope/                   # scope resolution
-├── Makefile
-├── go.mod
-└── go.sum
+cmd/mom/main.go                  # entrypoint
+ingress/                         # external input → in-process events
+├── cli/                         # cobra subcommands (init, recall, record, ops, …)
+├── mcp/                         # MCP stdio server (deprecated in v0.50 per ADR 0023)
+├── watcher/                     # harness transcript watchers (Claude, Codex, Pi)
+├── harness/                     # harness capability registry (detection, tiers)
+└── record/                      # shared explicit-write code path
+events/                          # canonical event pipeline (v0.50 work)
+├── editor/                      # canonicalization gateway (post-Ingress, pre-bus)
+├── registry/                    # schema registry (governance level B, ADR 0019)
+└── crier/                       # projector/replayer (Ledger → Vault via Librarian)
+bus/herald/                      # in-process event bus
+workers/                         # bus subscribers with side effects
+├── drafter/                     # event-stream → draft memories
+├── logbook/                     # operational telemetry
+├── cartographer/                # bootstrap seeding (parked, #240)
+└── gardener/                    # landmark computation; retention planned for v0.60
+services/                        # read-side application code
+├── finder/                      # recall query planner (FTS5 + escalation)
+└── lens/                        # local dashboard HTTP server
+storage/                         # durable state
+├── vault/                       # SQLite primitive
+├── librarian/                   # sole gate to vault writes/reads (ADR 0009)
+├── canonical/                   # canonical-path resolution + migration aggregation
+├── memory/                      # memory document types
+└── legacy/                      # pre-v0.30 JSON storage (migration path only)
+ops/                             # background lifecycle
+├── daemon/                      # platform service management
+└── diagnose/                    # introspection
+shared/                          # cross-cutting utilities
+├── config/                      # config.yaml (harness + watcher settings)
+├── pathutil/                    # path canonicalization
+├── scope/                       # multi-level discovery
+├── project/                     # .mom-project.yaml resolution (ADR 0016)
+├── ux/                          # TUI/output helpers
+└── archtest/                    # architectural invariant tests
+Makefile
+go.mod
+go.sum
 
 .mom/                            # MOM's own memory (dogfooding)
 ├── config.yaml                  # preferences
@@ -92,11 +117,11 @@ and core-flow architecture. They run as part of the normal Go test suite
 and in CI. To run them in isolation:
 
 ```bash
-cd cli && go test ./internal/cmd/ -run 'TestGuardrail_'
+go test ./ingress/cli/ -run 'TestGuardrail_'
 ```
 
 Adding a new exception requires updating the corresponding allowlist in
-`internal/cmd/architecture_guardrails_test.go` with explicit rationale.
+`ingress/cli/architecture_guardrails_test.go` with explicit rationale.
 
 ## PR process
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ brew update && brew upgrade mom && mom version
 
 ```bash
 git clone https://github.com/momhq/mom.git
-cd mom/cli
+cd mom
 make install
 ```
 
@@ -214,13 +214,24 @@ Skills install is a soft-fail step, so _mom_ can be usable even if the external 
 
 ## Project layout
 
+The codebase is organised into role-based top-level buckets (see [ADR 0017](adr/0017-role-based-repo-layout.md)).
+
 ```text
 .
-├── assets/                 # logo and brand assets
-├── cli/                    # Go CLI, MCP server, watcher, Lens server
-├── skills/                 # _mom_ slash skills
+├── cmd/mom/                # entrypoint
+├── ingress/                # external input: CLI, MCP, watcher adapters, harness detection, explicit record
+├── events/                 # canonical event Editor, schema Registry, Crier projector (v0.50 work)
+├── bus/herald/             # in-process event bus
+├── workers/                # bus subscribers — drafter, logbook, cartographer, gardener
+├── services/               # read-side application code — finder (recall), lens (dashboard)
+├── storage/                # durable state — vault, librarian (gate), canonical, memory, legacy
+├── ops/                    # background lifecycle — daemon, diagnose
+├── shared/                 # cross-cutting utilities — config, pathutil, scope, project, ux, archtest
+├── docs/                   # in-repo documentation
 ├── adr/                    # architecture decisions
 ├── prd/                    # product requirements
+├── skills/                 # _mom_ slash skills
+├── assets/                 # logo and brand assets
 ├── Formula/mom.rb          # Homebrew formula
 └── .github/workflows/      # CI and release automation
 ```


### PR DESCRIPTION
Closes #357. Updates the two live developer-facing docs after the v0.50 reorg.

## Changes

- **README.md**: \`cd mom/cli\` → \`cd mom\`. Project-layout block rewritten to show the eight role-based buckets from [ADR 0017](https://github.com/momhq/mom/blob/main/adr/0017-role-based-repo-layout.md).
- **CONTRIBUTING.md**: setup, project structure, and architecture-guardrail invocation updated for the new module root (no \`/cli\` prefix). Project-structure tree now enumerates every package by bucket with one-line descriptions and cross-links to ADRs 0009, 0016, 0017, 0019, 0023.

ADRs and PRDs are intentionally left referencing \`cli/internal/\` because they describe historical state at decision time.

## Test plan

- [x] No remaining \`cli/internal\` / \`cd cli\` / \`mom/cli\` references in README or CONTRIBUTING.
- [x] \`go test ./shared/archtest/...\` green.

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)