### PR TITLE
feat(events): family v1 schemas (#363)

### DIFF
--- a/bus/herald/herald.go
+++ b/bus/herald/herald.go
@@ -26,29 +26,36 @@ const (
 	ConfigChanged    EventType = "config-changed"
 	Error            EventType = "error"
 
-	// TurnObserved is the v0.30 source-of-truth event published by the
+	// TurnObserved is the source-of-truth event published by the
 	// watcher for every parsed turn. Carries the full structured turn
 	// (role, text, tool_calls with input, usage, model, provider) on
 	// the bus only — never persisted in raw form. Drafter consumes it
 	// for filter decisions; Logbook consumes it and persists a
 	// metadata-only projection (no text, no tool inputs) per ADR
 	// 0014's privacy contract.
-	TurnObserved EventType = "turn.observed"
+	//
+	// Renamed in v0.50 to capture.turn.observed per ADR 0018
+	// (family.subject.verb taxonomy). The constant name TurnObserved
+	// is the stable identifier; producers and subscribers use it.
+	TurnObserved EventType = "capture.turn.observed"
 
 	// MemoryRecord is the explicit-write event published by the MCP
 	// `mom_record` tool. Drafter consumes it, bypasses both filter
 	// layers (the user's explicitness wins per ADR 0014), and persists
-	// through Librarian. Logbook also subscribes to op.memory.created
-	// (below) for the audit stream.
-	MemoryRecord EventType = "memory.record"
+	// through Librarian.
+	//
+	// Renamed in v0.50 to capture.memory.recorded per ADR 0018.
+	MemoryRecord EventType = "capture.memory.recorded"
 
 	// OpMemoryCreated / OpMemoryRedacted / OpMemoryDropped are
 	// Drafter's outcome events for each turn it processed. Logbook
 	// subscribes to all three so Lens can show "memory was created /
 	// redacted / dropped" rows in the activity timeline.
-	OpMemoryCreated  EventType = "op.memory.created"
-	OpMemoryRedacted EventType = "op.memory.redacted"
-	OpMemoryDropped  EventType = "op.memory.dropped"
+	//
+	// Renamed in v0.50 to lifecycle.memory.* per ADR 0018.
+	OpMemoryCreated  EventType = "lifecycle.memory.created"
+	OpMemoryRedacted EventType = "lifecycle.memory.redacted"
+	OpMemoryDropped  EventType = "lifecycle.memory.dropped"
 )
 
 // Event is a single message on the bus.

--- a/events/registry/coverage_test.go
+++ b/events/registry/coverage_test.go
@@ -1,0 +1,80 @@
+package registry_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/momhq/mom/bus/herald"
+	"github.com/momhq/mom/events/registry"
+)
+
+// activeEventTypes is the set of EventType constants production code
+// actually publishes onto the bus. Adding a producer requires adding
+// its constant here AND registering its schema.
+//
+// Unused stubs in herald/herald.go (SessionStart, SessionEnd, etc.)
+// are intentionally NOT in this list — they pre-date v0.50 and no
+// publisher emits them today. When a producer ships, the producer's
+// PR adds the constant here + registers the schema in the same change.
+var activeEventTypes = []herald.EventType{
+	herald.TurnObserved,
+	herald.MemoryRecord,
+	herald.OpMemoryCreated,
+	herald.OpMemoryRedacted,
+	herald.OpMemoryDropped,
+}
+
+// TestRegistry_CoversAllActiveEventTypes asserts every active
+// EventType has a registered schema, and vice versa — no schema is
+// orphaned without a producer constant. Surfacing drift between code
+// and schemas at PR time is the whole point of ADR 0019's level B.
+func TestRegistry_CoversAllActiveEventTypes(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	schemasDir := filepath.Join(filepath.Dir(thisFile), "schemas")
+	r, err := registry.Load(schemasDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	registered := make(map[string]bool)
+	for _, n := range r.Names() {
+		registered[n] = true
+	}
+	active := make(map[string]bool)
+	for _, et := range activeEventTypes {
+		active[string(et)] = true
+	}
+
+	var missing, orphan []string
+	for name := range active {
+		if !registered[name] {
+			missing = append(missing, name)
+		}
+	}
+	for name := range registered {
+		if !active[name] {
+			orphan = append(orphan, name)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(orphan)
+
+	if len(missing) > 0 {
+		t.Errorf("EventType constants without registered schemas:\n  %v", missing)
+	}
+	if len(orphan) > 0 {
+		t.Errorf("registered schemas without producer constants (add to activeEventTypes or remove the schema):\n  %v", orphan)
+	}
+}
+
+// TestRegistry_ActiveEventTypesMatchTaxonomy asserts every active
+// EventType is a family.subject.verb name (ADR 0018). Producers that
+// publish legacy kebab-case names are caught here.
+func TestRegistry_ActiveEventTypesMatchTaxonomy(t *testing.T) {
+	for _, et := range activeEventTypes {
+		if !registry.EventNameRegex.MatchString(string(et)) {
+			t.Errorf("herald.EventType %q does not match family.subject.verb (ADR 0018)", et)
+		}
+	}
+}

--- a/events/registry/schemas/capture/memory.recorded.json
+++ b/events/registry/schemas/capture/memory.recorded.json
@@ -1,0 +1,13 @@
+{
+  "name": "capture.memory.recorded",
+  "description": "An explicit-write memory was recorded via mom_record (MCP) or `mom record` (CLI). Bypasses Drafter's filter layers per ADR 0014; the user's explicitness wins.",
+  "fields": {
+    "session_id":           {"type": "string", "required": true},
+    "project_id":           {"type": "string", "required": false},
+    "provenance_actor":     {"type": "string", "required": false},
+    "provenance_source_type": {"type": "string", "required": false},
+    "summary":              {"type": "string", "required": false},
+    "content":              {"type": "object", "required": true},
+    "tags":                 {"type": "array",  "required": false}
+  }
+}

--- a/events/registry/schemas/capture/turn.observed.json
+++ b/events/registry/schemas/capture/turn.observed.json
@@ -1,0 +1,16 @@
+{
+  "name": "capture.turn.observed",
+  "description": "A turn was observed on a harness transcript. Published by the watcher (ingress/watcher) for every parsed Turn. Carries the structured turn (role, text, tool_calls, usage, model, provider) on the bus; never persisted in raw form per ADR 0014.",
+  "fields": {
+    "session_id":       {"type": "string", "required": true},
+    "project_id":       {"type": "string", "required": false},
+    "provenance_actor": {"type": "string", "required": false},
+    "role":             {"type": "string", "required": true, "values": ["user", "assistant"]},
+    "text":             {"type": "string", "required": false},
+    "tool_calls":       {"type": "array",  "required": false},
+    "usage":            {"type": "object", "required": false},
+    "model":            {"type": "string", "required": false},
+    "provider":         {"type": "string", "required": false},
+    "harness":          {"type": "string", "required": false}
+  }
+}

--- a/events/registry/schemas/lifecycle/memory.created.json
+++ b/events/registry/schemas/lifecycle/memory.created.json
@@ -1,0 +1,12 @@
+{
+  "name": "lifecycle.memory.created",
+  "description": "Drafter persisted a new memory (cluster flush success). Logbook subscribes for the audit stream and Lens renders the activity timeline row.",
+  "fields": {
+    "session_id":       {"type": "string", "required": true},
+    "memory_id":        {"type": "string", "required": true},
+    "project_id":       {"type": "string", "required": false},
+    "summary":          {"type": "string", "required": false},
+    "tags":             {"type": "array",  "required": false},
+    "provenance_actor": {"type": "string", "required": false}
+  }
+}

--- a/events/registry/schemas/lifecycle/memory.dropped.json
+++ b/events/registry/schemas/lifecycle/memory.dropped.json
@@ -1,0 +1,9 @@
+{
+  "name": "lifecycle.memory.dropped",
+  "description": "Drafter's soft filter dropped a cluster (noise heuristic, short/ack-only content, etc.). No memory is persisted; this event exists so Lens can show 'dropped' rows in the activity timeline.",
+  "fields": {
+    "session_id":   {"type": "string", "required": true},
+    "project_id":   {"type": "string", "required": false},
+    "drop_reason":  {"type": "string", "required": false}
+  }
+}

--- a/events/registry/schemas/lifecycle/memory.redacted.json
+++ b/events/registry/schemas/lifecycle/memory.redacted.json
@@ -1,0 +1,11 @@
+{
+  "name": "lifecycle.memory.redacted",
+  "description": "Drafter's hard filter caught a secret in a cluster and redacted matching substrings before persisting. The matched substance is NEVER carried in this event (ADR 0014 §filter-audit).",
+  "fields": {
+    "session_id":         {"type": "string", "required": true},
+    "memory_id":          {"type": "string", "required": true},
+    "project_id":         {"type": "string", "required": false},
+    "filter_category":    {"type": "string", "required": false},
+    "redaction_count":    {"type": "number", "required": false}
+  }
+}

--- a/services/lens/server.go
+++ b/services/lens/server.go
@@ -146,7 +146,7 @@ func (s *Server) loadSessionData() (map[string]sessionData, int, error) {
 		b := get(e.SessionID)
 		b.includeTime(e.CreatedAt)
 		switch e.EventType {
-		case "turn.observed":
+		case "capture.turn.observed":
 			applyTurnObserved(b, e.Payload)
 		case "legacy.session.summary":
 			applyLegacySummary(b, e.Payload)

--- a/services/lens/server_test.go
+++ b/services/lens/server_test.go
@@ -40,7 +40,7 @@ func insertTurn(t *testing.T, lib *librarian.Librarian, sessionID, role string, 
 		payload = map[string]any{}
 	}
 	payload["role"] = role
-	_, err := lib.InsertOpEvent(librarian.OpEvent{EventType: "turn.observed", SessionID: sessionID, CreatedAt: at, Payload: payload})
+	_, err := lib.InsertOpEvent(librarian.OpEvent{EventType: "capture.turn.observed", SessionID: sessionID, CreatedAt: at, Payload: payload})
 	if err != nil {
 		t.Fatalf("InsertOpEvent: %v", err)
 	}

--- a/workers/logbook/turn_observed_test.go
+++ b/workers/logbook/turn_observed_test.go
@@ -77,7 +77,7 @@ func TestSubscribeTurnObserved_PersistsMetadataProjection(t *testing.T) {
 		},
 	})
 
-	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "turn.observed"})
+	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "capture.turn.observed"})
 	if err != nil {
 		t.Fatalf("QueryOpEvents: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestSubscribeTurnObserved_PreservesHarnessFromTurnPayload(t *testing.T) {
 		Payload:   turn.ToPayload(),
 	})
 
-	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "turn.observed"})
+	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{EventType: "capture.turn.observed"})
 	if err != nil {
 		t.Fatalf("QueryOpEvents: %v", err)
 	}


### PR DESCRIPTION
Implements [ADR 0018](https://github.com/momhq/mom/blob/main/adr/0018-canonical-event-schema.md). Registers a schema for every \`herald.EventType\` that production code actually publishes onto the bus.

## What changes

- Schemas land at \`events/registry/schemas/<family>/<subject>.<verb>.json\` for the five active producers:
  - \`capture.turn.observed\`
  - \`capture.memory.recorded\`
  - \`lifecycle.memory.created\`
  - \`lifecycle.memory.redacted\`
  - \`lifecycle.memory.dropped\`
- \`herald.EventType\` constant values rename to the new \`family.subject.verb\` strings. Constant symbols (\`TurnObserved\`, \`MemoryRecord\`, \`OpMemoryCreated\`, etc.) are unchanged — producers and subscribers continue to reference them by name.
- Three literal-string callsites updated to the new values: \`services/lens/server.go\`, \`services/lens/server_test.go\`, \`workers/logbook/turn_observed_test.go\`.

## Tests

- \`TestRegistry_CoversAllActiveEventTypes\` — bidirectional diff between \`activeEventTypes\` and registry contents. A new producer or a new schema must be added in lockstep.
- \`TestRegistry_ActiveEventTypesMatchTaxonomy\` — regex check on every active EventType per ADR 0018.
- All existing unit + integration tests green with the new constant values.

## Not changed

- Unused EventType stubs (\`SessionStart\`, \`SessionEnd\`, \`TurnComplete\`, \`ToolUse\`, \`CompactTriggered\`, \`MemoryCreated\`, \`MemoryPromoted\`, \`MemorySearched\`, \`MemoryDeleted\`, \`RecordAppended\`, \`ConfigChanged\`, \`Error\`) are kept in place but excluded from \`activeEventTypes\`. Their producers will land in future milestones and register schemas at that point.
- Old DB rows (\`op_events\` table) with legacy \`"turn.observed"\` / \`"op.memory.created"\` type strings remain on disk. Crier replay (#367/#368) is the right place to migrate historical rows if/when needed.

## Test plan

- [x] \`make verify-registry\` green (schema files load).
- [x] \`go test ./events/registry/...\` green (18 tests now).
- [x] Full \`go test ./...\` green (all 25 packages).

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)