### PR TITLE
test(events): archtest invariants for Editor placement (#364)

### DIFF
--- a/bus/herald/herald_arch_test.go
+++ b/bus/herald/herald_arch_test.go
@@ -1,0 +1,65 @@
+package herald_test
+
+import (
+	"testing"
+
+	"github.com/momhq/mom/shared/archtest"
+)
+
+// TestHerald_DoesNotImportIngress asserts the bus stays agnostic of
+// every ingress surface. ADR 0020's invariant: no raw adapter type
+// crosses the bus boundary. The bus knows only herald.Event; the
+// Editor (events/editor) is the single producer of canonical events.
+//
+// If a future PR adds, say, an "expose-the-watcher-Turn-on-the-bus"
+// shortcut, this test fails — and the right fix is to canonicalize
+// through the Editor, not loosen the rule.
+func TestHerald_DoesNotImportIngress(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/ingress/watcher",
+		"github.com/momhq/mom/ingress/harness",
+		"github.com/momhq/mom/ingress/cli",
+		"github.com/momhq/mom/ingress/mcp",
+		"github.com/momhq/mom/ingress/record",
+	)
+}
+
+// TestHerald_DoesNotImportEvents asserts the bus does not depend on
+// the events pipeline. Direction is bus ← editor (editor publishes
+// onto the bus); reversing the arrow would create a cycle and break
+// the "bus is a primitive" property.
+func TestHerald_DoesNotImportEvents(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/events/editor",
+		"github.com/momhq/mom/events/registry",
+		"github.com/momhq/mom/events/crier",
+	)
+}
+
+// TestHerald_DoesNotImportStorage asserts the bus is not a durable
+// storage. Persistence is Layer 1 (Ledger) and Layer 2 (Vault);
+// neither belongs in the bus.
+func TestHerald_DoesNotImportStorage(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/storage/vault",
+		"github.com/momhq/mom/storage/librarian",
+		"github.com/momhq/mom/storage/canonical",
+		"github.com/momhq/mom/storage/legacy",
+		"github.com/momhq/mom/storage/memory",
+	)
+}
+
+// TestHerald_DoesNotImportWorkersOrServices asserts the bus is below
+// every consumer. Workers (drafter, logbook) subscribe to the bus;
+// services (finder, lens) read from storage. Either importing this
+// way would invert the dependency.
+func TestHerald_DoesNotImportWorkersOrServices(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/workers/drafter",
+		"github.com/momhq/mom/workers/logbook",
+		"github.com/momhq/mom/workers/cartographer",
+		"github.com/momhq/mom/workers/gardener",
+		"github.com/momhq/mom/services/finder",
+		"github.com/momhq/mom/services/lens",
+	)
+}

--- a/events/editor/editor_arch_test.go
+++ b/events/editor/editor_arch_test.go
@@ -1,0 +1,61 @@
+package editor_test
+
+import (
+	"testing"
+
+	"github.com/momhq/mom/shared/archtest"
+)
+
+// TestEditor_DoesNotImportVault asserts that the Editor stays on the
+// canonicalization-and-bus boundary. Storage is the Crier's concern
+// (ADR 0022); the Editor must not reach into the Vault directly. The
+// Editor *will* gain a Ledger-append step in #366, which is allowed
+// (storage/ledger is Layer 1, not Vault). Vault import is forbidden.
+func TestEditor_DoesNotImportVault(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/storage/vault",
+	)
+}
+
+// TestEditor_DoesNotImportWatcherAdapters asserts the Editor stays
+// agnostic of any specific ingress adapter type. ADR 0020's invariant
+// is "no raw adapter type crosses the bus boundary" — the Editor sits
+// on the bus side of that boundary, so it must not depend on adapter
+// internals. Producers hand the Editor a Canonicalizer interface;
+// the concrete type stays on the ingress side.
+//
+// The watcher package itself contains the Turn type that implements
+// Canonicalizer. Editor importing the watcher package would couple
+// the gateway to a single producer.
+func TestEditor_DoesNotImportIngressAdapters(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/ingress/watcher",
+		"github.com/momhq/mom/ingress/harness",
+		"github.com/momhq/mom/ingress/cli",
+		"github.com/momhq/mom/ingress/mcp",
+		"github.com/momhq/mom/ingress/record",
+	)
+}
+
+// TestEditor_DoesNotImportWorkers asserts no worker is in scope. The
+// Editor publishes onto the bus; subscribers (Drafter, Logbook,
+// Cartographer, Gardener) react. The dependency direction is one-way.
+func TestEditor_DoesNotImportWorkers(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/workers/drafter",
+		"github.com/momhq/mom/workers/logbook",
+		"github.com/momhq/mom/workers/cartographer",
+		"github.com/momhq/mom/workers/gardener",
+	)
+}
+
+// TestEditor_DoesNotImportServices asserts the read path is invisible
+// to the Editor. Finder and Lens read from the Vault via Librarian;
+// the Editor writes (via Crier eventually) and emits onto the bus.
+// Coupling here would compromise the read/write separation.
+func TestEditor_DoesNotImportServices(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/services/finder",
+		"github.com/momhq/mom/services/lens",
+	)
+}


### PR DESCRIPTION
Implements [ADR 0020](https://github.com/momhq/mom/blob/main/adr/0020-editor-canonicalization-gateway.md) architectural invariants.

## Tests

**events/editor/editor_arch_test.go**
- Editor must not import \`storage/vault\` (Crier writes via Librarian).
- Editor must not import any ingress adapter package — the \`Canonicalizer\` interface keeps it producer-agnostic.
- Editor must not import any workers package (direction is one-way).
- Editor must not import services packages (read path is separate).

**bus/herald/herald_arch_test.go**
- Herald must not import any ingress package (no raw adapter type crosses the bus).
- Herald must not import \`events/{editor,registry,crier}\` (one-way dependency; reversing creates a cycle).
- Herald must not import storage packages.
- Herald must not import workers or services.

Together these pin the data flow Editor → bus → consumers and forbid every shortcut that would compromise the invariant.

## Test plan

- [x] \`go test ./events/editor/... ./bus/herald/...\` green.
- [x] Full \`go test ./...\` green.

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)