### PR TITLE
feat(events): Editor → Ledger write path (#366)

### DIFF
--- a/events/editor/editor.go
+++ b/events/editor/editor.go
@@ -16,6 +16,7 @@
 package editor
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/momhq/mom/bus/herald"
@@ -28,6 +29,14 @@ import (
 // Editor doesn't transitively pull herald-test dependencies.
 type Bus interface {
 	Publish(herald.Event)
+}
+
+// LedgerAppender is the Ledger's Append surface, narrowed to what
+// the Editor needs. Implementations: storage/ledger.Ledger (production),
+// test recorders. Defined here so the Editor can stay decoupled from
+// the concrete Ledger driver shape.
+type LedgerAppender interface {
+	Append(herald.Event) (uint64, error)
 }
 
 // Source carries the contextual metadata about *where* an input came
@@ -60,18 +69,29 @@ type Canonicalizer interface {
 // Editor is the canonicalization gateway. Construct via New.
 type Editor struct {
 	bus      Bus
+	ledger   LedgerAppender    // nil → Ledger append skipped (transitional)
 	registry *registry.Registry // nil → validation skipped (transitional)
 	logger   *log.Logger
 }
 
 // New constructs an Editor bound to bus and reg. If reg is nil, the
 // Editor skips schema validation (useful during the v0.50 transition
-// before #363 registers schemas).
+// before #363 registers schemas). Ledger append is opt-in via
+// WithLedger; absent that, the Editor publishes only onto the bus.
 func New(bus Bus, reg *registry.Registry, logger *log.Logger) *Editor {
 	if logger == nil {
 		logger = log.Default()
 	}
 	return &Editor{bus: bus, registry: reg, logger: logger}
+}
+
+// WithLedger returns a new Editor wired to ledger. Production callers
+// use this to enable the ADR 0021 durable-append path: every published
+// event is appended to the Ledger before reaching the bus. Returns the
+// receiver for fluent chaining.
+func (e *Editor) WithLedger(ledger LedgerAppender) *Editor {
+	e.ledger = ledger
+	return e
 }
 
 // Canonicalize composes a canonical herald.Event from in + src without
@@ -124,15 +144,32 @@ func (e *Editor) Canonicalize(in Canonicalizer, src Source) herald.Event {
 	}
 }
 
-// Publish is the production entry point: canonicalize the input and
-// publish it. Returns no error today — herald.Bus.Publish is fire-
-// and-forget — but the signature reserves room for #366 to surface
-// Ledger-append failures.
-func (e *Editor) Publish(in Canonicalizer, src Source) {
+// Publish is the production entry point. The order is fixed per
+// ADR 0021 §crash-safety:
+//
+//  1. Canonicalize the input.
+//  2. Append the canonical event to the Ledger (when wired). If
+//     append fails, the event is NOT published onto the bus — the
+//     caller observes the error and the bus stays consistent.
+//  3. Publish onto the bus.
+//
+// Editors without a Ledger (transitional builds, tests) skip step 2.
+// Editors without a Bus skip step 3.
+//
+// The promise: when Publish returns nil, the event is durably in the
+// Ledger (if wired). A crash between Ledger append and bus publish
+// leaves the event on Layer 1; Crier reprojects on restart (#367/#368).
+func (e *Editor) Publish(in Canonicalizer, src Source) error {
 	ev := e.Canonicalize(in, src)
+	if e.ledger != nil {
+		if _, err := e.ledger.Append(ev); err != nil {
+			return fmt.Errorf("editor: ledger append %s: %w", ev.Type, err)
+		}
+	}
 	if e.bus != nil {
 		e.bus.Publish(ev)
 	}
+	return nil
 }
 
 // encodeViolation builds the _schema_violation marker payload. The

--- a/events/editor/editor_test.go
+++ b/events/editor/editor_test.go
@@ -233,3 +233,75 @@ func writeSchemaDir(t *testing.T, family, filename, body string) string {
 	}
 	return dir
 }
+
+// recordingLedger captures Append calls for Editor → Ledger ordering tests.
+type recordingLedger struct {
+	events []herald.Event
+	failOn int // 1-indexed call number on which to return an error; 0 = never fail
+}
+
+func (r *recordingLedger) Append(e herald.Event) (uint64, error) {
+	if r.failOn > 0 && len(r.events)+1 == r.failOn {
+		return 0, errLedgerFull
+	}
+	r.events = append(r.events, e)
+	return uint64(len(r.events) - 1), nil
+}
+
+var errLedgerFull = ledgerErr("simulated ledger failure")
+
+type ledgerErr string
+
+func (e ledgerErr) Error() string { return string(e) }
+
+func TestPublish_AppendsToLedgerBeforeBus(t *testing.T) {
+	bus := &recordingBus{}
+	led := &recordingLedger{}
+	e := editor.New(bus, nil, nil).WithLedger(led)
+	if err := e.Publish(staticInput{
+		eventType: "capture.turn.observed",
+		payload:   map[string]any{"session_id": "s1", "text": "hi"},
+	}, editor.Source{Adapter: "claude-code"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(led.events) != 1 {
+		t.Fatalf("ledger.events len = %d, want 1", len(led.events))
+	}
+	if len(bus.events) != 1 {
+		t.Fatalf("bus.events len = %d, want 1", len(bus.events))
+	}
+	// Same payload reaches both layers.
+	if led.events[0].SessionID != bus.events[0].SessionID {
+		t.Errorf("session diverged: ledger=%q bus=%q", led.events[0].SessionID, bus.events[0].SessionID)
+	}
+}
+
+func TestPublish_LedgerFailure_AbortsBus(t *testing.T) {
+	bus := &recordingBus{}
+	led := &recordingLedger{failOn: 1}
+	e := editor.New(bus, nil, nil).WithLedger(led)
+	err := e.Publish(staticInput{
+		eventType: "capture.turn.observed",
+		payload:   map[string]any{"session_id": "s1"},
+	}, editor.Source{Adapter: "claude-code"})
+	if err == nil {
+		t.Fatal("expected error from ledger failure, got nil")
+	}
+	if len(bus.events) != 0 {
+		t.Fatalf("bus.events len = %d, want 0 (publish must abort on ledger failure)", len(bus.events))
+	}
+}
+
+func TestPublish_NoLedger_StillPublishesToBus(t *testing.T) {
+	bus := &recordingBus{}
+	e := editor.New(bus, nil, nil) // no WithLedger
+	if err := e.Publish(staticInput{
+		eventType: "capture.turn.observed",
+		payload:   map[string]any{"session_id": "s1"},
+	}, editor.Source{Adapter: "claude-code"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(bus.events) != 1 {
+		t.Fatalf("bus.events len = %d, want 1 (no-ledger build still publishes)", len(bus.events))
+	}
+}

--- a/events/editor/integration_test.go
+++ b/events/editor/integration_test.go
@@ -1,0 +1,105 @@
+package editor_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/momhq/mom/bus/herald"
+	"github.com/momhq/mom/events/editor"
+	"github.com/momhq/mom/storage/ledger"
+)
+
+// TestPublish_E2E_RealLedger appends through a real Ledger driver and
+// confirms the on-disk record matches what reached the bus. This is
+// the v0.50 baseline for "synthetic turn produces (a) ledger row +
+// (b) same downstream Vault state as before" from #366's acceptance.
+func TestPublish_E2E_RealLedger(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "ledger")
+	led, err := ledger.Open(dir)
+	if err != nil {
+		t.Fatalf("ledger.Open: %v", err)
+	}
+	defer led.Close()
+
+	bus := &recordingBus{}
+	e := editor.New(bus, nil, nil).WithLedger(led)
+
+	in := staticInput{
+		eventType: "capture.turn.observed",
+		payload:   map[string]any{"session_id": "e2e", "text": "hello world", "role": "user"},
+	}
+	if err := e.Publish(in, editor.Source{Adapter: "claude-code"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Bus saw it.
+	if len(bus.events) != 1 {
+		t.Fatalf("bus.events len = %d, want 1", len(bus.events))
+	}
+	if bus.events[0].Type != herald.TurnObserved {
+		t.Errorf("bus Type = %q, want %q", bus.events[0].Type, herald.TurnObserved)
+	}
+
+	// Ledger has it durably.
+	rec, err := led.Read(0)
+	if err != nil {
+		t.Fatalf("ledger.Read(0): %v", err)
+	}
+	if rec.Event.Type != herald.TurnObserved {
+		t.Errorf("ledger Type = %q, want %q", rec.Event.Type, herald.TurnObserved)
+	}
+	if got := rec.Event.Payload["text"]; got != "hello world" {
+		t.Errorf("ledger payload text = %v, want hello world", got)
+	}
+	if got := rec.Event.Payload["provenance_actor"]; got != "claude-code" {
+		t.Errorf("ledger payload provenance_actor = %v, want claude-code", got)
+	}
+}
+
+// TestPublish_E2E_CrashRecovery simulates a crash between Ledger
+// append and bus publish: append succeeds, bus.Publish is never
+// reached (we abort). On the next process restart, Crier (when
+// wired in #367) re-projects from the Ledger offset and produces
+// the same downstream Vault state. This PR just verifies the
+// Ledger retains the event when the bus path failed.
+func TestPublish_E2E_CrashRecovery(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "ledger")
+	led, err := ledger.Open(dir)
+	if err != nil {
+		t.Fatalf("ledger.Open: %v", err)
+	}
+
+	// Use a bus that panics — simulates the "crash after ledger,
+	// before bus" window. We catch the panic via defer/recover.
+	panicBus := &panickingBus{}
+	e := editor.New(panicBus, nil, nil).WithLedger(led)
+
+	func() {
+		defer func() { _ = recover() }() // swallow simulated crash
+		_ = e.Publish(staticInput{
+			eventType: "capture.turn.observed",
+			payload:   map[string]any{"session_id": "crash-test"},
+		}, editor.Source{Adapter: "claude-code"})
+	}()
+	_ = led.Close()
+
+	// Reopen the Ledger — event must still be there.
+	led2, err := ledger.Open(dir)
+	if err != nil {
+		t.Fatalf("ledger.Open after crash: %v", err)
+	}
+	defer led2.Close()
+	rec, err := led2.Read(0)
+	if err != nil {
+		t.Fatalf("ledger.Read(0) after crash: %v", err)
+	}
+	if rec.Event.SessionID != "crash-test" {
+		t.Errorf("session = %q, want crash-test (event must survive crash)", rec.Event.SessionID)
+	}
+}
+
+type panickingBus struct{}
+
+func (p *panickingBus) Publish(_ herald.Event) {
+	panic("simulated crash between ledger append and bus publish")
+}

--- a/ingress/cli/watch.go
+++ b/ingress/cli/watch.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/momhq/mom/events/editor"
 	"github.com/momhq/mom/storage/canonical"
+	"github.com/momhq/mom/storage/ledger"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/momhq/mom/bus/herald"
@@ -109,7 +110,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 			Sources:    sources,
 			SweepOnly:  true,
 			Bus:        bus,
-			Editor:     editor.New(bus, nil, nil),
+			Editor:     editor.New(bus, nil, nil).WithLedger(openCentralLedger()),
 		})
 		if err != nil {
 			return fmt.Errorf("creating watcher: %w", err)
@@ -136,7 +137,7 @@ func runWatch(cmd *cobra.Command, _ []string) error {
 		Sources:    sources,
 		DebounceMs: 300,
 		Bus:        bus,
-		Editor:     editor.New(bus, nil, nil),
+		Editor:     editor.New(bus, nil, nil).WithLedger(openCentralLedger()),
 	})
 	if err != nil {
 		return fmt.Errorf("creating watcher: %w", err)
@@ -259,7 +260,7 @@ func runWatchGlobal(sweepOnly bool) error {
 				Sources:    sources,
 				SweepOnly:  true,
 				Bus:        bus,
-				Editor:     editor.New(bus, nil, nil),
+				Editor:     editor.New(bus, nil, nil).WithLedger(openCentralLedger()),
 			})
 			if err != nil {
 				p.Warn(fmt.Sprintf("sweep %s: %v", projDir, err))
@@ -319,7 +320,7 @@ func runWatchGlobal(sweepOnly bool) error {
 			Sources:    sources,
 			DebounceMs: 300,
 			Bus:        bus,
-			Editor:     editor.New(bus, nil, nil),
+			Editor:     editor.New(bus, nil, nil).WithLedger(openCentralLedger()),
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[mom] watch %s: %v\n", projDir, err)
@@ -531,4 +532,22 @@ func openCentralWorkers() centralWorkers {
 		drafter: drafter.New(lib),
 		logbook: logbook.New(lib),
 	}
+}
+
+// openCentralLedger opens the Ledger at $HOME/.mom/ledger/ (per
+// ADR 0021). The Editor uses it for durable-append before bus
+// publish. Returns nil on failure so callers fall back to bus-only
+// publish without erroring out the watcher.
+func openCentralLedger() editor.LedgerAppender {
+	dir, err := canonical.Dir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "watch: canonical.Dir: %v — ledger not wired\n", err)
+		return nil
+	}
+	led, err := ledger.Open(filepath.Join(dir, "ledger"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "watch: ledger.Open: %v — ledger not wired\n", err)
+		return nil
+	}
+	return led
 }

--- a/ingress/cli/watch_helpers.go
+++ b/ingress/cli/watch_helpers.go
@@ -134,7 +134,7 @@ func sweepTranscripts(projectDir, momDir string) {
 		Sources:    sources,
 		SweepOnly:  true,
 		Bus:        bus,
-		Editor:     editor.New(bus, nil, nil),
+		Editor:     editor.New(bus, nil, nil).WithLedger(openCentralLedger()),
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[mom] sweep: %v\n", err)

--- a/ingress/watcher/watcher.go
+++ b/ingress/watcher/watcher.go
@@ -459,10 +459,12 @@ func (w *Watcher) ingestFile(path string) int {
 	// that haven't migrated yet.
 	if w.cfg.Editor != nil {
 		for _, t := range turns {
-			w.cfg.Editor.Publish(t, editor.Source{
+			if err := w.cfg.Editor.Publish(t, editor.Source{
 				Adapter: t.Harness,
 				Cwd:     resolveCwdForTurn(t, w.cfg.ProjectDir),
-			})
+			}); err != nil {
+				w.logf("editor publish (%s, session=%s): %v", herald.TurnObserved, t.SessionID, err)
+			}
 		}
 	} else if w.cfg.Bus != nil {
 		defaultProjectId := w.resolveProjectId()


### PR DESCRIPTION
Implements [ADR 0021](https://github.com/momhq/mom/blob/main/adr/0021-ledger-layer-1-canonical-log.md) crash-safety ordering. Editor.Publish now appends to the Ledger before publishing to the bus.

## Order
1. Canonicalize (provenance + project_id + schema validate)
2. Ledger.Append + fsync — durability promise
3. Bus.Publish — subscribers run

Ledger-append failure aborts the bus publish: subscribers never see an event whose canonical record wasn't durably persisted.

## Changes
- `events/editor/editor.go`: `LedgerAppender` interface + `WithLedger` fluent setter. `Publish` returns error.
- `ingress/watcher/watcher.go`: capture + log Editor error.
- `ingress/cli/watch.go`: `openCentralLedger()` opens `$HOME/.mom/ledger/`. All 5 production sites wire it.

## Tests
- Ordering: append-before-bus.
- Failure: ledger error aborts bus.
- No-ledger fallback.
- E2E with real ledger driver: round-trip + crash recovery (bus panics; event still in Ledger after reopen).

Closes #366