### PR TITLE
feat(events): Crier projector MVP (#367)

### DIFF
--- a/events/crier/crier.go
+++ b/events/crier/crier.go
@@ -1,0 +1,117 @@
+// Package crier projects canonical events from the Ledger (ADR 0021)
+// into the Vault via Librarian (ADR 0022). Crier is the sole projector:
+// archtests forbid it from importing storage/vault directly, and an
+// archtest in #369 forbids services from reading the Ledger.
+//
+// Semantics are at-least-once + idempotent. Crier reads the Ledger
+// from checkpoint+1, applies each event via librarian.ApplyLedgerEvent
+// (which writes the projection and advances the checkpoint in a
+// single transaction), and continues.
+//
+// The MVP exposes a one-shot Replay that drains the Ledger from
+// checkpoint to head. A daemon-loop variant (Run-with-poll) is a
+// follow-up — Replay is sufficient for #368 (replay tests) and for
+// the v0.50 wire-up.
+package crier
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/momhq/mom/storage/ledger"
+	"github.com/momhq/mom/storage/librarian"
+)
+
+// Projector is the Librarian-shaped surface Crier needs. Implemented
+// by storage/librarian.Librarian (production); a test double in
+// crier_test.go covers idempotency and error paths.
+type Projector interface {
+	GetCrierCheckpoint() (librarian.CrierCheckpoint, error)
+	ApplyLedgerEvent(offset int64, eventType, sessionID string, createdAt time.Time, payload map[string]any) (applied bool, err error)
+}
+
+// LedgerReader is the Ledger-shaped surface Crier needs. Implemented
+// by storage/ledger.Ledger.
+type LedgerReader interface {
+	Iterate(from uint64) *ledger.Iter
+}
+
+// Crier reads from a LedgerReader and projects into a Projector.
+// Construct via New; call Replay to drain the Ledger up to its head.
+type Crier struct {
+	led LedgerReader
+	pro Projector
+}
+
+// New constructs a Crier wired to led and pro.
+func New(led LedgerReader, pro Projector) *Crier {
+	return &Crier{led: led, pro: pro}
+}
+
+// Stats summarizes a Replay run.
+type Stats struct {
+	// Applied is the number of events that produced a NEW projection
+	// (the row did not already exist).
+	Applied int
+	// Skipped is the number of events that were re-applied no-op-ly:
+	// offset <= checkpoint, or the op_events UNIQUE index caught a
+	// duplicate.
+	Skipped int
+	// LastOffset is the offset of the most recently processed event,
+	// or the prior checkpoint when no events were available.
+	LastOffset int64
+}
+
+// Replay drains the Ledger from checkpoint+1 to the current head and
+// returns a Stats summary. Errors during a single projection abort
+// the Replay (returning a partial Stats); the next Replay call
+// resumes from the last successful checkpoint.
+//
+// Replay holds no exclusive lock on the Ledger or the Librarian —
+// concurrent producers may continue appending while Crier reads.
+// Iter.Next is safe against in-flight appends because each segment
+// read uses its own file handle and stops at the first incomplete
+// record.
+func (c *Crier) Replay() (Stats, error) {
+	if c.led == nil || c.pro == nil {
+		return Stats{}, errors.New("crier: not wired (led=nil or pro=nil)")
+	}
+	cp, err := c.pro.GetCrierCheckpoint()
+	if err != nil {
+		return Stats{}, fmt.Errorf("crier: get checkpoint: %w", err)
+	}
+	stats := Stats{LastOffset: cp.Offset}
+	startFrom := uint64(0)
+	if cp.Offset >= 0 {
+		startFrom = uint64(cp.Offset + 1)
+	}
+	it := c.led.Iterate(startFrom)
+	defer it.Close()
+	for {
+		rec, ok := it.Next()
+		if !ok {
+			break
+		}
+		applied, err := c.pro.ApplyLedgerEvent(
+			int64(rec.Offset),
+			string(rec.Event.Type),
+			rec.Event.SessionID,
+			rec.AppendedAt,
+			rec.Event.Payload,
+		)
+		if err != nil {
+			return stats, fmt.Errorf("crier: apply offset %d: %w", rec.Offset, err)
+		}
+		if applied {
+			stats.Applied++
+		} else {
+			stats.Skipped++
+		}
+		stats.LastOffset = int64(rec.Offset)
+	}
+	if err := it.Err(); err != nil {
+		return stats, fmt.Errorf("crier: iterate: %w", err)
+	}
+	return stats, nil
+}

--- a/events/crier/crier_arch_test.go
+++ b/events/crier/crier_arch_test.go
@@ -1,0 +1,48 @@
+package crier_test
+
+import (
+	"testing"
+
+	"github.com/momhq/mom/shared/archtest"
+)
+
+// TestCrier_DoesNotImportVaultDirectly is the architectural invariant
+// ADR 0022 names: Crier projects via Librarian and only via Librarian.
+// Importing storage/vault directly would bypass the substance-
+// immutability + tag-normalisation invariants Librarian enforces.
+func TestCrier_DoesNotImportVaultDirectly(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/storage/vault",
+	)
+}
+
+// TestCrier_DoesNotImportIngressOrBus asserts the direction of the
+// data flow: Ledger → Crier → Librarian → Vault. The bus is not in
+// Crier's path; ingress packages produce events that the Editor
+// canonicalizes — Crier reads from the Ledger, never from a
+// transient bus event.
+func TestCrier_DoesNotImportIngressOrBus(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/bus/herald",
+		"github.com/momhq/mom/ingress/watcher",
+		"github.com/momhq/mom/ingress/cli",
+		"github.com/momhq/mom/ingress/mcp",
+		"github.com/momhq/mom/ingress/record",
+		"github.com/momhq/mom/ingress/harness",
+	)
+}
+
+// TestCrier_DoesNotImportWorkersOrServices asserts Crier is its own
+// projector — not a worker, not a service. Workers subscribe to the
+// bus; services read from the Vault for query-time. Crier writes the
+// Vault from the Ledger; mixing roles would create a cycle.
+func TestCrier_DoesNotImportWorkersOrServices(t *testing.T) {
+	archtest.AssertNoDirectImport(t, ".",
+		"github.com/momhq/mom/workers/drafter",
+		"github.com/momhq/mom/workers/logbook",
+		"github.com/momhq/mom/workers/cartographer",
+		"github.com/momhq/mom/workers/gardener",
+		"github.com/momhq/mom/services/finder",
+		"github.com/momhq/mom/services/lens",
+	)
+}

--- a/events/crier/crier_test.go
+++ b/events/crier/crier_test.go
@@ -1,0 +1,219 @@
+package crier_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/momhq/mom/bus/herald"
+	"github.com/momhq/mom/events/crier"
+	"github.com/momhq/mom/storage/canonical"
+	"github.com/momhq/mom/storage/ledger"
+	"github.com/momhq/mom/storage/librarian"
+	"github.com/momhq/mom/storage/vault"
+)
+
+// openLibrarian opens a fresh vault under t.TempDir() with the full
+// canonical migration set (including migration 6 which crier needs).
+func openLibrarian(t *testing.T) (*librarian.Librarian, func()) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "mom.db")
+	v, err := vault.Open(dbPath, canonical.Migrations())
+	if err != nil {
+		t.Fatalf("vault.Open: %v", err)
+	}
+	lib := librarian.New(v)
+	return lib, func() { _ = v.Close() }
+}
+
+func openLedger(t *testing.T) *ledger.Ledger {
+	t.Helper()
+	l, err := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatalf("ledger.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	return l
+}
+
+func ev(typ herald.EventType, session string) herald.Event {
+	return herald.Event{
+		Type:      typ,
+		SessionID: session,
+		Timestamp: time.Now().UTC(),
+		Payload: map[string]any{
+			"session_id": session,
+			"role":       "user",
+		},
+	}
+}
+
+func TestReplay_AppliesNewEvents(t *testing.T) {
+	lib, closeFn := openLibrarian(t)
+	defer closeFn()
+	led := openLedger(t)
+
+	// Append 3 events to the Ledger.
+	for _, s := range []string{"s1", "s2", "s3"} {
+		if _, err := led.Append(ev(herald.TurnObserved, s)); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+
+	c := crier.New(led, lib)
+	stats, err := c.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if stats.Applied != 3 {
+		t.Errorf("Applied = %d, want 3", stats.Applied)
+	}
+	if stats.Skipped != 0 {
+		t.Errorf("Skipped = %d, want 0", stats.Skipped)
+	}
+	if stats.LastOffset != 2 {
+		t.Errorf("LastOffset = %d, want 2", stats.LastOffset)
+	}
+}
+
+func TestReplay_IsIdempotentOnRerun(t *testing.T) {
+	lib, closeFn := openLibrarian(t)
+	defer closeFn()
+	led := openLedger(t)
+	for i := 0; i < 5; i++ {
+		_, _ = led.Append(ev(herald.TurnObserved, "session"))
+	}
+
+	c := crier.New(led, lib)
+	first, err := c.Replay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Applied != 5 {
+		t.Fatalf("first Replay: Applied = %d, want 5", first.Applied)
+	}
+
+	// Rerun: nothing new should apply.
+	second, err := c.Replay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Applied != 0 {
+		t.Errorf("second Replay: Applied = %d, want 0 (idempotent)", second.Applied)
+	}
+}
+
+func TestReplay_ResumesAfterCheckpoint(t *testing.T) {
+	lib, closeFn := openLibrarian(t)
+	defer closeFn()
+	led := openLedger(t)
+
+	for i := 0; i < 3; i++ {
+		_, _ = led.Append(ev(herald.TurnObserved, "session"))
+	}
+	c := crier.New(led, lib)
+	if _, err := c.Replay(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append 2 more events after the first replay.
+	for i := 0; i < 2; i++ {
+		_, _ = led.Append(ev(herald.TurnObserved, "session"))
+	}
+	stats, err := c.Replay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Applied != 2 {
+		t.Errorf("Applied = %d, want 2 (only new events)", stats.Applied)
+	}
+	if stats.LastOffset != 4 {
+		t.Errorf("LastOffset = %d, want 4", stats.LastOffset)
+	}
+}
+
+func TestReplay_EmptyLedgerIsOk(t *testing.T) {
+	lib, closeFn := openLibrarian(t)
+	defer closeFn()
+	led := openLedger(t)
+
+	c := crier.New(led, lib)
+	stats, err := c.Replay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Applied != 0 || stats.Skipped != 0 {
+		t.Errorf("empty replay: stats = %+v, want zero", stats)
+	}
+}
+
+func TestReplay_ProjectsCorrectVaultState(t *testing.T) {
+	lib, closeFn := openLibrarian(t)
+	defer closeFn()
+	led := openLedger(t)
+
+	// Append one event.
+	_, _ = led.Append(ev(herald.OpMemoryCreated, "session-vault-state"))
+
+	c := crier.New(led, lib)
+	if _, err := c.Replay(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the op_event row landed via librarian.QueryOpEvents.
+	rows, err := lib.QueryOpEvents(librarian.OpEventFilter{
+		SessionID: "session-vault-state",
+	})
+	if err != nil {
+		t.Fatalf("QueryOpEvents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].EventType != string(herald.OpMemoryCreated) {
+		t.Errorf("EventType = %q, want %q", rows[0].EventType, herald.OpMemoryCreated)
+	}
+}
+
+func TestReplay_FullReprojectionFromOffsetZero(t *testing.T) {
+	dir := t.TempDir()
+	// Use a stable ledger dir so we can reopen.
+	ledDir := filepath.Join(dir, "ledger")
+	led, err := ledger.Open(ledDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4; i++ {
+		_, _ = led.Append(ev(herald.TurnObserved, "repro"))
+	}
+	_ = led.Close()
+
+	// Open fresh vault + reopen ledger; replay from scratch.
+	v, err := vault.Open(filepath.Join(dir, "mom.db"), canonical.Migrations())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer v.Close()
+	lib := librarian.New(v)
+
+	led2, err := ledger.Open(ledDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer led2.Close()
+
+	c := crier.New(led2, lib)
+	stats, err := c.Replay()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Applied != 4 {
+		t.Fatalf("full reprojection: Applied = %d, want 4", stats.Applied)
+	}
+
+	// Vault state is exactly what Crier projected.
+	rows, _ := lib.QueryOpEvents(librarian.OpEventFilter{SessionID: "repro"})
+	if len(rows) != 4 {
+		t.Errorf("rows = %d, want 4", len(rows))
+	}
+}

--- a/storage/canonical/canonical.go
+++ b/storage/canonical/canonical.go
@@ -96,6 +96,25 @@ func Migrations() []vault.Migration {
 			)`,
 		},
 	})
+	migs = append(migs, vault.Migration{
+		// Crier (ADR 0022) projects canonical events from the Ledger
+		// (ADR 0021) into the Vault. To stay idempotent at-least-once
+		// we (a) tag each projected row with the ledger offset that
+		// produced it (UNIQUE so re-applying the same offset is a
+		// no-op), and (b) persist a single-row checkpoint that
+		// Crier advances after each successful projection.
+		Version: 7,
+		Stmts: []string{
+			`ALTER TABLE op_events ADD COLUMN ledger_offset INTEGER`,
+			`CREATE UNIQUE INDEX idx_op_events_ledger_offset ON op_events(ledger_offset) WHERE ledger_offset IS NOT NULL`,
+			`CREATE TABLE crier_state (
+				id          INTEGER PRIMARY KEY CHECK (id = 1),
+				checkpoint  INTEGER NOT NULL,
+				updated_at  TEXT NOT NULL
+			)`,
+			`INSERT INTO crier_state (id, checkpoint, updated_at) VALUES (1, -1, datetime('now'))`,
+		},
+	})
 	sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
 	return migs
 }

--- a/storage/librarian/crier_apply.go
+++ b/storage/librarian/crier_apply.go
@@ -1,0 +1,131 @@
+package librarian
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// CrierCheckpoint is the durable cursor Crier (ADR 0022) advances as
+// it projects Ledger events into the Vault. -1 means "no events
+// applied yet"; the next event to project is offset = checkpoint + 1.
+type CrierCheckpoint struct {
+	Offset    int64
+	UpdatedAt time.Time
+}
+
+// GetCrierCheckpoint returns the current checkpoint. Reads the
+// single row in crier_state (created by migration 6).
+func (l *Librarian) GetCrierCheckpoint() (CrierCheckpoint, error) {
+	var c CrierCheckpoint
+	var updatedAt string
+	var found bool
+	err := l.v.Query(
+		`SELECT checkpoint, updated_at FROM crier_state WHERE id = 1`,
+		nil,
+		func(rs *sql.Rows) error {
+			if !rs.Next() {
+				return nil
+			}
+			found = true
+			return rs.Scan(&c.Offset, &updatedAt)
+		},
+	)
+	if err != nil {
+		return CrierCheckpoint{}, fmt.Errorf("GetCrierCheckpoint: %w", err)
+	}
+	if !found {
+		return CrierCheckpoint{}, ErrNoCheckpoint
+	}
+	if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {
+		c.UpdatedAt = t
+	} else if t2, err := time.Parse("2006-01-02 15:04:05", updatedAt); err == nil {
+		c.UpdatedAt = t2.UTC()
+	}
+	return c, nil
+}
+
+// ApplyLedgerEvent is Crier's idempotent projection primitive. In a
+// single transaction it:
+//
+//  1. Reads crier_state.checkpoint.
+//  2. If offset > checkpoint, projects the event by inserting one
+//     row into op_events with ledger_offset = offset.
+//  3. Updates crier_state.checkpoint to offset (and the timestamp).
+//
+// If offset <= checkpoint the call is a no-op (idempotent: re-applying
+// the same offset cannot double-write). The UNIQUE index on
+// op_events(ledger_offset) is a belt-and-braces guarantee.
+//
+// Returns (applied bool, err): applied=true when a new row was
+// inserted; applied=false when the call was a no-op.
+func (l *Librarian) ApplyLedgerEvent(
+	offset int64,
+	eventType string,
+	sessionID string,
+	createdAt time.Time,
+	payload map[string]any,
+) (bool, error) {
+	if eventType == "" {
+		return false, fmt.Errorf("ApplyLedgerEvent: event_type: %w", ErrEmptyArg)
+	}
+	if sessionID == "" {
+		return false, fmt.Errorf("ApplyLedgerEvent: session_id: %w", ErrEmptyArg)
+	}
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	var payloadJSON sql.NullString
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return false, fmt.Errorf("ApplyLedgerEvent marshal: %w", err)
+		}
+		payloadJSON = sql.NullString{String: string(b), Valid: true}
+	}
+
+	var applied bool
+	err := l.v.Tx(func(tx *sql.Tx) error {
+		var checkpoint int64
+		if err := tx.QueryRow(`SELECT checkpoint FROM crier_state WHERE id = 1`).Scan(&checkpoint); err != nil {
+			return fmt.Errorf("read checkpoint: %w", err)
+		}
+		if offset <= checkpoint {
+			// Already applied — no-op. Checkpoint stays.
+			return nil
+		}
+		// Insert op_events row with ledger_offset; the UNIQUE index
+		// catches any racing double-insert and the OR IGNORE turns it
+		// into a no-op (still idempotent if the unique constraint
+		// fires under contention).
+		res, err := tx.Exec(
+			`INSERT OR IGNORE INTO op_events (event_type, session_id, created_at, payload, ledger_offset)
+			 VALUES (?, ?, ?, ?, ?)`,
+			eventType, sessionID, formatTime(createdAt),
+			payloadJSON, offset,
+		)
+		if err != nil {
+			return fmt.Errorf("insert op_event: %w", err)
+		}
+		rows, _ := res.RowsAffected()
+		applied = rows > 0
+		if _, err := tx.Exec(
+			`UPDATE crier_state SET checkpoint = ?, updated_at = datetime('now') WHERE id = 1`,
+			offset,
+		); err != nil {
+			return fmt.Errorf("update checkpoint: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return applied, nil
+}
+
+// ErrNoCheckpoint is returned by GetCrierCheckpoint when the
+// crier_state row is missing — indicates an aborted migration or
+// schema corruption.
+var ErrNoCheckpoint = errors.New("crier_state row missing")


### PR DESCRIPTION
Implements [ADR 0022](https://github.com/momhq/mom/blob/main/adr/0022-crier-projector-via-librarian.md). Crier is the sole projector from Ledger → Vault, routed through Librarian.

## Migration v7
- `op_events.ledger_offset INTEGER` (NULL for legacy bus-path rows; non-NULL for Crier-projected rows).
- `UNIQUE INDEX` on `op_events(ledger_offset)` where non-NULL.
- `crier_state` table (1-row checkpoint).

## Librarian
`ApplyLedgerEvent(offset, type, session, created_at, payload)` is the idempotent primitive. One transaction:
1. Read checkpoint.
2. If `offset > checkpoint`: `INSERT OR IGNORE INTO op_events ... ledger_offset = offset`.
3. `UPDATE crier_state SET checkpoint = offset`.

Re-applying the same offset is a no-op. The UNIQUE index catches racing double-inserts.

## Crier package
`events/crier/crier.go` exposes `Replay()` that drains Ledger from checkpoint+1 to head. Returns `Stats{Applied, Skipped, LastOffset}`.

## archtest
Forbids Crier from importing `storage/vault` directly; forbids ingress/bus/workers/services imports.

## Tests (6 cases)
- Applies new events.
- Idempotent on rerun.
- Resumes after checkpoint.
- Empty ledger OK.
- Correctly projects via QueryOpEvents.
- Full reprojection from offset 0 against fresh vault reproduces same state.

## Not in this PR
- Crier daemon-loop wire-up (still a manual Replay call).
- Full replay-test harness covering every registered schema: #368.
- Storage-boundary archtests (services/finder forbid Ledger): #369.

Closes #367