### PR TITLE
feat(ingress): MCP/CLI parity (mom get, mom landmarks) + v0.60+ deprecation (#370)

### DIFF
--- a/ingress/cli/get.go
+++ b/ingress/cli/get.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/momhq/mom/storage/canonical"
+	"github.com/spf13/cobra"
+)
+
+// getCmd is the CLI mirror of the mom_get MCP tool (per ADR 0023's
+// CLI parity audit). Retrieves a single memory by ID from the central
+// vault and emits its JSON to stdout.
+var getCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Retrieve a single memory by ID",
+	Long: `Retrieves the memory with the given UUID from the central vault
+and writes its JSON representation to stdout.
+
+CLI mirror of the mom_get MCP tool (per ADR 0023). Use this in
+shell pipelines and as the subprocess invocation from harness
+adapters once the MCP transport is retired in v0.60+.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runGet,
+}
+
+func runGet(_ *cobra.Command, args []string) error {
+	id := args[0]
+	lib, closeFn, err := canonical.OpenLibrarian()
+	if err != nil {
+		return fmt.Errorf("open central vault: %w", err)
+	}
+	defer closeFn()
+
+	mem, err := lib.Get(id)
+	if err != nil {
+		return fmt.Errorf("get %s: %w", id, err)
+	}
+	out, _ := json.Marshal(mem)
+	fmt.Println(string(out))
+	return nil
+}

--- a/ingress/cli/landmarks.go
+++ b/ingress/cli/landmarks.go
@@ -1,14 +1,60 @@
 package cli
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/momhq/mom/storage/canonical"
 	"github.com/momhq/mom/storage/memory"
+	"github.com/spf13/cobra"
 )
 
+var landmarksLimit int
+
+// landmarksCmd is the CLI mirror of the mom_landmarks MCP tool
+// (per ADR 0023's CLI parity audit). Lists landmark memories from
+// the central vault sorted by centrality_score descending.
+//
+// JSON output is emitted to stdout for non-TTY consumers; the
+// structure matches what mom_landmarks returns from MCP.
+var landmarksCmd = &cobra.Command{
+	Use:   "landmarks",
+	Short: "List landmark memories sorted by centrality",
+	Long: `Returns the landmark memories from the central vault, sorted by
+centrality_score descending. Emits JSON to stdout.
+
+CLI mirror of the mom_landmarks MCP tool (per ADR 0023). Use this
+in shell pipelines and as the subprocess invocation from harness
+adapters once the MCP transport is retired in v0.60+.`,
+	RunE: runLandmarks,
+}
+
+func init() {
+	landmarksCmd.Flags().IntVar(&landmarksLimit, "limit", 20, "Maximum number of landmarks to return")
+}
+
+func runLandmarks(_ *cobra.Command, _ []string) error {
+	lib, closeFn, err := canonical.OpenLibrarian()
+	if err != nil {
+		return fmt.Errorf("open central vault: %w", err)
+	}
+	defer closeFn()
+
+	items, err := lib.Landmarks(landmarksLimit)
+	if err != nil {
+		return fmt.Errorf("landmarks: %w", err)
+	}
+	out, _ := json.Marshal(items)
+	fmt.Println(string(out))
+	return nil
+}
+
 // countLandmarks returns the number of docs with landmark=true in memDir.
+// Kept as the private helper used by `mom status` for the legacy JSON
+// memory directory count.
 func countLandmarks(memDir string) int {
 	entries, _ := os.ReadDir(memDir)
 	n := 0

--- a/ingress/cli/root.go
+++ b/ingress/cli/root.go
@@ -45,4 +45,6 @@ func init() {
 	rootCmd.AddCommand(demoCmd)
 	rootCmd.AddCommand(lensCmd)
 	rootCmd.AddCommand(projectCmd)
+	rootCmd.AddCommand(getCmd)
+	rootCmd.AddCommand(landmarksCmd)
 }

--- a/ingress/mcp/parity_test.go
+++ b/ingress/mcp/parity_test.go
@@ -1,0 +1,59 @@
+package mcp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/momhq/mom/ingress/mcp"
+)
+
+// expectedTools is the v0.50 MCP tool surface. ADR 0023 § parity-audit
+// guarantees each of these has a CLI counterpart (see ingress/cli/
+// for the matching subcommands).
+var expectedTools = map[string]string{
+	"mom_status":    "mom status",
+	"mom_recall":    "mom recall <query>",
+	"mom_get":       "mom get <id>",
+	"mom_landmarks": "mom landmarks [--limit N]",
+	"mom_record":    "mom record (stdin)",
+}
+
+// TestMCPToolsList_HasCLICounterparts is the parity audit: every MCP
+// tool currently exposed by ingress/mcp must appear in expectedTools
+// (which documents the CLI counterpart). Adding an MCP tool without
+// a CLI counterpart fails this test, surfacing the gap at PR time.
+func TestMCPToolsList_HasCLICounterparts(t *testing.T) {
+	tools := mcp.ToolNamesForParityAudit()
+	if len(tools) == 0 {
+		t.Fatal("mcp.ToolNamesForParityAudit returned no tools")
+	}
+	for _, name := range tools {
+		if _, ok := expectedTools[name]; !ok {
+			t.Errorf("MCP tool %q has no documented CLI counterpart — extend expectedTools and add the matching subcommand under ingress/cli/", name)
+		}
+	}
+	for tool := range expectedTools {
+		found := false
+		for _, name := range tools {
+			if name == tool {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expectedTools[%q] is documented but no MCP handler ships — remove or wire it", tool)
+		}
+	}
+}
+
+// TestDeprecationNotice_FormatMentionsV060 is a brittle-on-purpose
+// check: the boot warning text must say "v0.60" so users know when
+// the transport goes away.
+func TestDeprecationNotice_FormatMentionsV060(t *testing.T) {
+	if !strings.Contains(mcp.DeprecationNotice(), "v0.60") {
+		t.Errorf("DeprecationNotice() does not mention v0.60: %q", mcp.DeprecationNotice())
+	}
+	if !strings.Contains(mcp.DeprecationNotice(), "0023") {
+		t.Errorf("DeprecationNotice() should point at ADR 0023: %q", mcp.DeprecationNotice())
+	}
+}

--- a/ingress/mcp/server.go
+++ b/ingress/mcp/server.go
@@ -122,6 +122,10 @@ func (s *Server) Serve(in io.Reader, out io.Writer) {
 	p.Diamond("MCP server")
 	p.Chevron(fmt.Sprintf("scope: %s", s.momDir))
 	p.Muted("listening on stdio — stdout reserved for JSON-RPC")
+	// ADR 0023: MCP transport is deprecated; emit exactly one boot
+	// warning so harness operators see the migration notice. Sent
+	// to stderr so it doesn't pollute the JSON-RPC channel on stdout.
+	fmt.Fprintln(os.Stderr, deprecationNotice)
 	p.Blank()
 
 	// Open log file in append mode.
@@ -240,3 +244,27 @@ func (s *Server) logEntry(f *os.File, status, method, detail string) {
 		fmt.Fprintf(f, "%s  %-6s  %s\n", ts, status, method)
 	}
 }
+
+// deprecationNotice is the v0.50 boot warning per ADR 0023.
+// Emitted to stderr exactly once per Serve invocation.
+const deprecationNotice = `WARN: MOM's MCP transport is deprecated and will be removed in v0.60+.
+      Configure your harness to invoke ` + "`" + `mom <subcommand>` + "`" + ` as a subprocess.
+      See adr/0023-mcp-server-retirement.md for details.`
+
+// ToolNamesForParityAudit returns the names of every MCP tool the
+// server exposes. Exported solely for the CLI/MCP parity audit
+// (ingress/mcp/parity_test.go) per ADR 0023. Production code uses
+// the internal allTools() instead.
+func ToolNamesForParityAudit() []string {
+	defs := allTools()
+	names := make([]string, 0, len(defs))
+	for _, d := range defs {
+		names = append(names, d.Name)
+	}
+	return names
+}
+
+// DeprecationNotice returns the boot warning emitted to stderr per
+// ADR 0023. Exported so the parity test can assert the message
+// format without reaching into package internals.
+func DeprecationNotice() string { return deprecationNotice }


### PR DESCRIPTION
Implements [ADR 0023](https://github.com/momhq/mom/blob/main/adr/0023-mcp-server-retirement.md). Closes the two CLI parity gaps surfaced during planning and installs the v0.60+ deprecation warning.

## CLI parity fills
- `mom get <id>` — mirrors `mom_get` (`ingress/cli/get.go`).
- `mom landmarks [--limit N]` — mirrors `mom_landmarks` (`ingress/cli/landmarks.go`).

Both emit JSON to stdout matching the MCP handler shape.

## Deprecation warning
`ingress/mcp/server.go` writes to stderr on Serve():

> WARN: MOM's MCP transport is deprecated and will be removed in v0.60+.  
> Configure your harness to invoke \`mom <subcommand>\` as a subprocess.  
> See adr/0023-mcp-server-retirement.md for details.

## Parity test
`ingress/mcp/parity_test.go` enumerates the exposed MCP tools and asserts each has a documented CLI counterpart. Missing or orphan entries fail at PR time.

Closes #370