### PR TITLE
test(archtest): allow CHANGELOG.md at repo root (hotfix)

### DIFF
--- a/shared/archtest/layout_test.go
+++ b/shared/archtest/layout_test.go
@@ -34,6 +34,7 @@ var allowedTopLevelFiles = map[string]bool{
 	".mcp.json.bkp":      true,
 	".mom-project.yaml":  true,
 	"CODE_OF_CONDUCT.md": true,
+	"CHANGELOG.md":      true,
 	"CONTRIBUTING.md":    true,
 	"LICENSE":            true,
 	"Makefile":           true,


### PR DESCRIPTION
Layout test from #356 didn't anticipate CHANGELOG.md (landed in #383). Allowlist fix. This is a post-rollup hotfix with no paired issue.